### PR TITLE
fix(deps): update @torka/claude-workflows to v0.6.1 for skill discovery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.5.2",
         "@torka/claude-qol": "^0.1.2",
-        "@torka/claude-workflows": "^0.6.0",
+        "@torka/claude-workflows": "^0.6.1",
         "@types/node": "^25.0.7",
         "@types/pg": "^8.11.10",
         "@types/react": "^19.0.0",
@@ -14952,9 +14952,9 @@
       }
     },
     "node_modules/@torka/claude-workflows": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@torka/claude-workflows/-/claude-workflows-0.6.0.tgz",
-      "integrity": "sha512-0RRT9uSqQHcsT65NaGA6UxlSi5vNwMXkfehW+wOvoisqYH1YJuLd4pOR/edi7HVMv1QkBFuxtLQ/pnCyZc+lfg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@torka/claude-workflows/-/claude-workflows-0.6.1.tgz",
+      "integrity": "sha512-3C97cal359f5sgBYm4leAdhO/Rw+AcVlzge1ytt0Oh7AILC8csJ2S5XQWWS3jKGEAz15esOnCQCy3K/drBvMew==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.5.2",
     "@torka/claude-qol": "^0.1.2",
-    "@torka/claude-workflows": "^0.6.0",
+    "@torka/claude-workflows": "^0.6.1",
     "@types/node": "^25.0.7",
     "@types/pg": "^8.11.10",
     "@types/react": "^19.0.0",


### PR DESCRIPTION
## Summary
- Updates @torka/claude-workflows from v0.6.0 to v0.6.1
- Fixes designer-founder skill discovery by renaming `workflow.md` to `SKILL.md` in the npm package

## Problem
The `designer-founder` skill wasn't recognized by Claude Code because it used `workflow.md` as entry point instead of `SKILL.md`.

## Test plan
- [ ] Run `/designer-founder` and verify it's now recognized as a skill