### PR TITLE
fix(ci): trigger codex followup on commented reviews

### DIFF
--- a/.github/workflows/codex-followup.yml
+++ b/.github/workflows/codex-followup.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   spawn_fixer:
     if: >-
-      github.event.review.state == 'changes_requested' &&
+      (github.event.review.state == 'changes_requested' || github.event.review.state == 'commented') &&
       github.event.review.user.login == 'chatgpt-codex-connector[bot]'
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- Expand Codex follow-up workflow trigger to include `commented` reviews
- Codex sometimes leaves feedback as `COMMENTED` instead of `changes_requested`

## Changes
- Updated condition in `.github/workflows/codex-followup.yml` to trigger on both `changes_requested` OR `commented` review states

## Test plan
- [ ] Merge and have Codex leave a `COMMENTED` review on a PR
- [ ] Verify the workflow triggers correctly