### PR TITLE
fix: prevent open redirect and replace localhost URL in email

### DIFF
--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -61,13 +61,15 @@ export async function GET(request: NextRequest) {
       }
 
       // Successfully exchanged code for session
-      return NextResponse.redirect(new URL(next, request.url));
+      const safePath = next.startsWith('/') ? next : '/';
+      return NextResponse.redirect(new URL(safePath, request.url));
     }
   }
 
   // Return the user to an error page with instructions
   // Extract locale from the 'next' parameter or default to 'en'
-  const localeMatch = next.match(/^\/([^/]+)\//);
+  const safeNext = next.startsWith('/') ? next : '/';
+  const localeMatch = safeNext.match(/^\/([^/]+)\//);
   const locale = localeMatch?.[1] ?? 'en';
   return NextResponse.redirect(new URL(`/${locale}/auth-code-error`, request.url));
 }

--- a/src/app/api/auth/verify-complete/route.ts
+++ b/src/app/api/auth/verify-complete/route.ts
@@ -64,11 +64,13 @@ export async function GET(request: NextRequest) {
       ).catch(err => console.error('Failed to send welcome email:', err));
     }
 
-    return NextResponse.redirect(new URL(next, request.url));
+    const safePath = next.startsWith('/') ? next : '/';
+    return NextResponse.redirect(new URL(safePath, request.url));
   }
 
   // Extract locale from next path or default to 'en'
-  const localeMatch = next.match(/^\/([^/]+)\//);
+  const safeNext = next.startsWith('/') ? next : '/';
+  const localeMatch = safeNext.match(/^\/([^/]+)\//);
   const locale = localeMatch?.[1] ?? 'en';
   return NextResponse.redirect(new URL(`/${locale}/auth-code-error`, request.url));
 }

--- a/src/libs/email/sendWelcomeEmail.tsx
+++ b/src/libs/email/sendWelcomeEmail.tsx
@@ -1,3 +1,5 @@
+import { getBaseUrl } from '@/utils/Helpers';
+
 import { sendEmail } from './sendEmail';
 import { WelcomeEmail } from './templates/WelcomeEmail';
 import type { EmailSendResult } from './types';
@@ -28,7 +30,7 @@ export async function sendWelcomeEmail(
   name?: string,
 ): Promise<EmailSendResult> {
   const appName = process.env.EMAIL_FROM_NAME || 'VT SaaS Template';
-  const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+  const appUrl = getBaseUrl();
 
   return sendEmail(
     email,


### PR DESCRIPTION
## Summary
- Sanitize `next` parameter in auth callback and verify-complete routes to prevent open redirect attacks (ensures path starts with `/`)
- Replace hardcoded `localhost:3000` fallback in `sendWelcomeEmail` with `getBaseUrl()` helper

## Context
Addresses review comments from PR #69.

## Test plan
- [ ] Verify auth callback redirects correctly with valid relative paths
- [ ] Verify malicious absolute URLs in `next` param get sanitized to `/`
- [ ] Verify welcome email uses correct base URL in all environments