### PR TITLE
chore(deps): upgrade zod from v3 to v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
         "sharp": "^0.34.5",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0",
-        "zod": "^3.23.8"
+        "zod": "^4.0.0"
       },
       "devDependencies": {
         "@antfu/eslint-config": "^7.2.0",
@@ -615,15 +615,6 @@
         }
       }
     },
-    "node_modules/@assistant-ui/react-ai-sdk/node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@assistant-ui/react-devtools": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@assistant-ui/react-devtools/-/react-devtools-0.2.3.tgz",
@@ -649,15 +640,6 @@
         }
       }
     },
-    "node_modules/@assistant-ui/react-devtools/node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@assistant-ui/react-markdown": {
       "version": "0.12.3",
       "resolved": "https://registry.npmjs.org/@assistant-ui/react-markdown/-/react-markdown-0.12.3.tgz",
@@ -678,15 +660,6 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@assistant-ui/react/node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@assistant-ui/store": {
@@ -30809,6 +30782,15 @@
         "sqlite3": "5.1.7"
       }
     },
+    "node_modules/mem0ai/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/memfs": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.5.3.tgz",
@@ -38945,6 +38927,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/shadcn/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/sharp": {
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
@@ -43831,9 +43823,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "sharp": "^0.34.5",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
-    "zod": "^3.23.8"
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^7.2.0",

--- a/src/app/api/admin/email/test/route.ts
+++ b/src/app/api/admin/email/test/route.ts
@@ -17,7 +17,7 @@ import { createClient } from '@/libs/supabase/server';
 const TestEmailSchema = z.object({
   template: z.enum(['welcome', 'password-reset', 'verify-email']),
   email: z.string().email(),
-  data: z.record(z.unknown()).optional(),
+  data: z.record(z.string(), z.unknown()).optional(),
 });
 
 export async function POST(request: NextRequest) {

--- a/src/app/api/admin/feedback/bulk/__tests__/route.test.ts
+++ b/src/app/api/admin/feedback/bulk/__tests__/route.test.ts
@@ -51,8 +51,8 @@ vi.mock('@/libs/api/errors/logger', () => ({
 
 const { POST } = await import('../route');
 
-const ADMIN_USER_ID = '11111111-1111-1111-1111-111111111111';
-const IDS = ['22222222-2222-2222-2222-222222222222', '33333333-3333-3333-3333-333333333333'];
+const ADMIN_USER_ID = '11111111-1111-4111-8111-111111111111';
+const IDS = ['22222222-2222-4222-8222-222222222222', '33333333-3333-4333-8333-333333333333'];
 
 function createMockRequest(body: unknown): NextRequest {
   return {

--- a/src/app/api/admin/feedback/bulk/route.ts
+++ b/src/app/api/admin/feedback/bulk/route.ts
@@ -37,7 +37,7 @@ export async function POST(request: NextRequest) {
     const body = await request.json();
     const parsed = bulkActionSchema.safeParse(body);
     if (!parsed.success) {
-      return validationError(parsed.error.errors[0]?.message || 'Invalid request');
+      return validationError(parsed.error.issues[0]?.message || 'Invalid request');
     }
 
     const { action, ids } = parsed.data;

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -17,7 +17,7 @@ import { feedback } from '@/models/Schema';
 // Zod validation schema for feedback submission
 const feedbackSchema = z.object({
   type: z.enum(['bug', 'feature', 'praise'], {
-    errorMap: () => ({ message: 'Type must be bug, feature, or praise' }),
+    error: 'Type must be bug, feature, or praise',
   }),
   message: z
     .string()

--- a/src/app/api/profile/check-username/route.ts
+++ b/src/app/api/profile/check-username/route.ts
@@ -37,7 +37,7 @@ export async function POST(request: Request) {
     if (!validation.success) {
       return NextResponse.json(
         {
-          error: validation.error.errors[0]?.message || 'Invalid username format',
+          error: validation.error.issues[0]?.message || 'Invalid username format',
           code: 'VALIDATION_ERROR',
         },
         { status: 400 },

--- a/src/app/api/profile/update-preferences/route.ts
+++ b/src/app/api/profile/update-preferences/route.ts
@@ -97,7 +97,7 @@ export async function PATCH(request: Request) {
         {
           error: 'Invalid request data',
           code: 'VALIDATION_ERROR',
-          details: error.errors,
+          details: error.issues,
         },
         { status: 400 },
       );

--- a/src/app/api/profile/update-username/route.ts
+++ b/src/app/api/profile/update-username/route.ts
@@ -37,7 +37,7 @@ export async function PATCH(request: Request) {
     if (!validation.success) {
       return NextResponse.json(
         {
-          error: validation.error.errors[0]?.message || 'Invalid username format',
+          error: validation.error.issues[0]?.message || 'Invalid username format',
           code: 'VALIDATION_ERROR',
         },
         { status: 400 },

--- a/src/libs/api/errors/responses.ts
+++ b/src/libs/api/errors/responses.ts
@@ -106,7 +106,7 @@ export function forbiddenError(
  * ```typescript
  * const result = schema.safeParse(body);
  * if (!result.success) {
- *   return validationError(result.error.errors);
+ *   return validationError(result.error.issues);
  * }
  * ```
  */


### PR DESCRIPTION
## Summary
- Upgrades Zod from v3 (^3.23.8) to v4 (^4.0.0) — major version bump
- Fixes all breaking API changes across 7 source files + 1 test file
- Supersedes Dependabot PR #96 (which only bumped the version without code fixes)

## Breaking Changes Addressed
- **`.errors` → `.issues`**: ZodError property renamed in v4 (4 files)
- **`errorMap` → `error`**: Simplified error customization API for `z.enum()` (1 file)
- **`z.record()` signature**: Now requires both key and value schemas (1 file)
- **Stricter UUID validation**: v4 enforces RFC 4122 compliance; updated test UUIDs (1 test file)
- **JSDoc**: Updated example in `responses.ts` to reflect `.issues` (1 file)

## Verified Compatible
- `@t3-oss/env-nextjs` — uses Standard Schema, works with Zod v4
- `@hookform/resolvers` (zodResolver) — auto-detects v3/v4
- `ai` (Vercel AI SDK) — no Zod schemas passed to SDK in this codebase
- `drizzle-orm` — compatible with Zod v4

## Test plan
- [x] `npm run check-types` — passes
- [x] `npm run lint` — passes (0 errors)
- [x] `npm test` — 91/91 suites, 966/966 tests pass
- [x] `npm run build` — passes
- [x] Pre-commit hooks (lint-staged + tsc) — passes

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)