### PR TITLE
feat: add upstream sync mechanism for downstream projects

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ The project includes:
 | Development | [docs/development-guide.md](docs/development-guide.md) |
 | Admin Setup | [docs/admin-setup.md](docs/admin-setup.md) |
 | Email System | [docs/email-system.md](docs/email-system.md) |
+| Upstream Sync | [docs/upstream-sync-guide.md](docs/upstream-sync-guide.md) |
 
 ## Core Architecture
 
@@ -225,6 +226,7 @@ Standard: `npm run dev`, `npm run build`, `npm test`, `npm run lint`, `npm run c
 - `npm run test:e2e` - Playwright E2E tests
 - `npm run dev:next` - Start Next.js only (no Sentry Spotlight)
 - `npm run email:dev` - Start React Email preview server (port 3001)
+- `npm run upstream:check` - Check for upstream template updates
 
 ## Key Development Patterns
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,19 @@ src/
 | SEO infrastructure | OG image & SEO defaults | |
 | Error handling | Email templates | |
 
+### Syncing Upstream Updates
+
+When new features or fixes are released in the template, pull them into your project:
+
+```bash
+npm run upstream:check          # Check for available updates
+git merge v3.2.0                # Merge a tagged release
+npm install                     # Update dependencies
+npm run lint && npm run check-types && npm test && npm run build   # Verify
+```
+
+See [Upstream Sync Guide](docs/upstream-sync-guide.md) for detailed instructions and conflict resolution strategies.
+
 ### Should You Build a POC Separately?
 
 **Recommendation: Build directly on the template.**
@@ -390,6 +403,9 @@ Comprehensive documentation is available in the `docs/` directory:
 - **[Removing Dify Chat](docs/customization/removing-dify-chat.md)** - Remove Dify implementation while keeping Vercel AI SDK
 - **[Removing Vercel AI SDK Chat](docs/customization/removing-vercel-chat.md)** - Remove Vercel implementation while keeping Dify
 - **[Removing All Chat Features](docs/customization/removing-all-chat.md)** - Completely remove all chat functionality
+
+### Maintenance
+- **[Upstream Sync Guide](docs/upstream-sync-guide.md)** - Pull new features and fixes from the template
 
 ## License
 

--- a/docs/upstream-sync-guide.md
+++ b/docs/upstream-sync-guide.md
@@ -1,0 +1,153 @@
+# Upstream Sync Guide
+
+How to pull new features and fixes from the VT SaaS Template into your project.
+
+## Overview
+
+GitHub's "Use this template" creates an independent repo with no link back to the original. This guide sets up that link so you can pull upstream updates when new releases are available.
+
+The template uses [semantic versioning](https://semver.org/) with auto-generated releases. Each release is a git tag (e.g., `v3.2.0`) with a changelog entry.
+
+## Quick Start
+
+```bash
+# 1. Check for updates (sets up remote on first run)
+npm run upstream:check
+
+# 2. Merge a specific release
+git merge v3.2.0
+
+# 3. Verify everything works
+npm install
+npm run lint && npm run check-types && npm test && npm run build
+```
+
+## Detailed Workflow
+
+### First-Time Setup
+
+Run the check script — it automatically adds the upstream remote:
+
+```bash
+npm run upstream:check
+```
+
+This does three things:
+1. Adds `upstream` remote pointing to `https://github.com/thevarun/vt-saas-template.git`
+2. Fetches all upstream tags
+3. Shows available releases and what's changed since your last sync
+
+### Checking for Updates
+
+Run `npm run upstream:check` anytime. It shows:
+- Recent release tags
+- Number of new commits since your last sync
+- One-line summary of recent changes
+
+### Performing a Sync
+
+1. **Review what changed** — check the [CHANGELOG](https://github.com/thevarun/vt-saas-template/blob/main/docs/CHANGELOG.md) for the release you want to merge
+
+2. **Merge the release tag** (not `upstream/main`):
+   ```bash
+   npm run upstream:check -- --merge v3.2.0
+   ```
+   Or manually:
+   ```bash
+   git merge v3.2.0
+   ```
+
+3. **Resolve any conflicts** — see the file classification table below
+
+4. **Update dependencies and verify:**
+   ```bash
+   npm install
+   npm run lint && npm run check-types && npm test && npm run build
+   ```
+
+5. **Commit** (if you merged manually):
+   ```bash
+   git commit -m "chore: sync upstream v3.2.0"
+   ```
+
+## File Classification
+
+Use this table to decide how to resolve merge conflicts:
+
+| Category | Files | Resolution Strategy |
+|----------|-------|---------------------|
+| **Core — Accept Upstream** | `src/proxy.ts`, `src/libs/supabase/*`, `src/libs/api/*`, `src/libs/DB.ts`, `src/models/Schema.ts`, `next.config.mjs`, `drizzle.config.ts` | Accept upstream changes. You rarely modify these. |
+| **Core — Review Carefully** | `src/app/[locale]/layout.tsx`, `package.json`, `tsconfig.json`, `.github/workflows/*` | Merge manually. Keep both your additions and upstream updates. |
+| **Branding — Keep Yours** | `src/styles/global.css`, `public/*` (logo, favicon, og-image), `src/utils/AppConfig.ts`, `src/libs/seo/constants.ts` | Keep your version. Cherry-pick upstream changes if needed. |
+| **Content — Keep Yours** | `src/templates/Navbar.tsx`, `src/templates/Footer.tsx`, `src/locales/*`, `README.md` | Keep your version. These are fully customized for your product. |
+| **Your Product Code** | `src/app/[locale]/(auth)/dashboard/*`, `src/features/*`, your custom routes | No conflict expected — upstream won't have these files. |
+| **Infrastructure** | `package-lock.json` | See "Common Conflicts" below. |
+
+## Common Conflicts
+
+### package-lock.json
+
+This will conflict on almost every sync. The easiest approach:
+
+```bash
+git checkout --theirs package-lock.json
+npm install
+git add package-lock.json
+```
+
+### package.json
+
+If upstream added new dependencies, accept both sides: keep your additions and take theirs. Then run `npm install` to regenerate the lock file.
+
+### Database Schema (src/models/Schema.ts)
+
+If upstream added new tables and you also modified the schema:
+
+1. Accept both sets of changes (your tables + upstream's new tables)
+2. Run `npm run db:generate` to create a clean migration
+3. Test with `npm run dev`
+
+### .env.example
+
+Accept upstream changes to get new environment variable documentation, then re-add any custom variables your project needs.
+
+## Best Practices
+
+- **Sync to tagged releases**, not `upstream/main` — tags are tested and stable
+- **Sync regularly** — smaller, frequent merges have fewer conflicts than large catch-up merges
+- **Read the changelog first** — understand what changed before merging
+- **Run the full CI check after every sync**: `npm run lint && npm run check-types && npm test && npm run build`
+- **Minimize edits to core files** — the less you modify template infrastructure, the fewer conflicts you'll encounter
+- **Use a dedicated branch** for the sync if you're nervous:
+  ```bash
+  git checkout -b sync/v3.2.0
+  git merge v3.2.0
+  # resolve conflicts, test, then merge to your main branch
+  ```
+
+## Troubleshooting
+
+### Too many conflicts
+
+If a large version jump causes overwhelming conflicts:
+- Skip intermediate versions — merge directly to the latest tag
+- Or cherry-pick specific commits instead of merging the whole tag:
+  ```bash
+  git log --oneline v3.1.0..v3.2.0  # see what changed
+  git cherry-pick <commit-hash>       # pick specific fixes
+  ```
+
+### npm install fails after merge
+
+```bash
+rm -rf node_modules package-lock.json
+npm install
+```
+
+### Script can't find upstream remote
+
+```bash
+git remote -v                    # check current remotes
+git remote remove upstream       # remove broken remote
+npm run upstream:check           # re-adds it automatically
+```

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "db:migrate": "dotenv -c production -- drizzle-kit migrate",
     "db:studio": "dotenv -c production -- drizzle-kit studio",
     "email:dev": "email dev --dir src/libs/email/templates --port 3001",
+    "upstream:check": "bash scripts/upstream-check.sh",
     "storybook": "storybook dev -p 6006",
     "storybook:build": "storybook build",
     "storybook:serve": "http-server storybook-static --port 6006 --silent",

--- a/scripts/upstream-check.sh
+++ b/scripts/upstream-check.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# upstream-check.sh - Check for upstream VT SaaS Template updates
+# Usage: ./scripts/upstream-check.sh [--merge vX.Y.Z]
+
+set -e
+
+UPSTREAM_URL="https://github.com/thevarun/vt-saas-template.git"
+UPSTREAM_REMOTE="upstream"
+MERGE_TAG=""
+
+# Parse args
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --merge)
+      MERGE_TAG="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1"
+      echo "Usage: ./scripts/upstream-check.sh [--merge vX.Y.Z]"
+      exit 1
+      ;;
+  esac
+done
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "🔄 Upstream Template Sync"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+# --- Step 1: Verify git repo ---
+if ! git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+  echo "❌ Not a git repository"
+  exit 1
+fi
+
+# --- Step 2: Setup upstream remote (idempotent) ---
+if ! git remote | grep -q "^${UPSTREAM_REMOTE}$"; then
+  echo "📡 Adding upstream remote..."
+  git remote add "$UPSTREAM_REMOTE" "$UPSTREAM_URL"
+  echo "   Added: $UPSTREAM_URL"
+else
+  echo "📡 Upstream remote exists: $(git remote get-url "$UPSTREAM_REMOTE")"
+fi
+echo ""
+
+# --- Step 3: Fetch upstream ---
+echo "📥 Fetching upstream tags and branches..."
+git fetch "$UPSTREAM_REMOTE" --tags --quiet
+echo "   Done"
+echo ""
+
+# --- Step 4: Show available releases ---
+echo "📦 Recent upstream releases:"
+git tag --sort=-version:refname | head -10 | while read -r tag; do
+  echo "   $tag"
+done
+echo ""
+
+# --- Step 5: Show what's new since last sync ---
+LAST_COMMON=$(git merge-base HEAD "${UPSTREAM_REMOTE}/main" 2>/dev/null || echo "")
+if [ -n "$LAST_COMMON" ]; then
+  NEW_COMMITS=$(git log --oneline "${LAST_COMMON}..${UPSTREAM_REMOTE}/main" 2>/dev/null | wc -l | tr -d ' ')
+  echo "📊 Commits since last sync: $NEW_COMMITS"
+  if [ "$NEW_COMMITS" -gt 0 ]; then
+    echo ""
+    echo "   Recent changes:"
+    git log --oneline "${LAST_COMMON}..${UPSTREAM_REMOTE}/main" 2>/dev/null | head -20 | while read -r line; do
+      echo "   $line"
+    done
+  else
+    echo "   You're up to date!"
+  fi
+else
+  echo "📊 No common history found with upstream (first sync)"
+fi
+echo ""
+
+# --- Step 6: Merge or print instructions ---
+if [ -n "$MERGE_TAG" ]; then
+  # Verify the tag exists
+  if ! git rev-parse "$MERGE_TAG" > /dev/null 2>&1; then
+    echo "❌ Tag $MERGE_TAG not found"
+    exit 1
+  fi
+
+  echo "🔀 Merging $MERGE_TAG..."
+  git merge "$MERGE_TAG" -m "chore: sync upstream $MERGE_TAG"
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "✅ Merged $MERGE_TAG"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo ""
+  echo "Next steps:"
+  echo "  npm install"
+  echo "  npm run lint && npm run check-types && npm test && npm run build"
+else
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "📋 To merge a specific release:"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo ""
+  echo "  npm run upstream:check -- --merge vX.Y.Z"
+  echo ""
+  echo "  Or manually:"
+  echo "  git merge vX.Y.Z"
+  echo "  npm install"
+  echo "  npm run lint && npm run check-types && npm test && npm run build"
+  echo ""
+  echo "See docs/upstream-sync-guide.md for conflict resolution strategies."
+fi


### PR DESCRIPTION
## Summary
- Added `scripts/upstream-check.sh` — helper script that sets up the upstream remote, fetches tags, shows available updates, and supports `--merge vX.Y.Z` for one-command syncing
- Added `docs/upstream-sync-guide.md` — comprehensive guide with file classification table, conflict resolution strategies, and best practices
- Added `npm run upstream:check` convenience script
- Updated README and CLAUDE.md with references

## Context
When someone uses "Use this template" on GitHub, there's no built-in link back to the original repo. This gives downstream projects a documented, low-friction way to pull new features and fixes from the template as they become available.

## Test plan
- [x] `bash scripts/upstream-check.sh` — adds remote, fetches tags, shows releases
- [x] Script is idempotent (second run detects existing remote)
- [x] `npm run upstream:check` works via package.json
- [x] Lint, typecheck, and all 1121 tests pass