### PR TITLE
docs: surface /init-downstream and /upstream-sync in README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,8 +226,8 @@ Standard: `npm run dev`, `npm run build`, `npm test`, `npm run lint`, `npm run c
 - `npm run test:e2e` - Playwright E2E tests
 - `npm run dev:next` - Start Next.js only (no Sentry Spotlight)
 - `npm run email:dev` - Start React Email preview server (port 3001)
-- `/upstream-sync` - Interactive upstream sync (Claude Code command)
-- `/init-downstream` - Post-fork project initialization (Claude Code command)
+- `/init-downstream` - **Run first after forking.** Renames DB schema, configures merge strategies (`.gitattributes`), fixes `gh` CLI targeting, cleans template artifacts. See `docs/upstream-sync-guide.md` for manual equivalent.
+- `/upstream-sync` - **Pull upstream template updates.** Fetches releases, merges with conflict classification, auto-detects re-added deleted files. Requires `/init-downstream` to have run first.
 
 ## Key Development Patterns
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ VT SaaS Template is a modern web application template that provides a solid foun
    cd vt-saas-template
    ```
 
+   > **Forked or used "Use this template"?** After installing dependencies, run the `/init-downstream` Claude Code command to rename the DB schema, configure merge strategies, and clean up template artifacts. See [Building a Product on This Template](#building-a-product-on-this-template) for the full workflow.
+
 2. **Install dependencies**
    ```bash
    npm install
@@ -94,6 +96,10 @@ npm run lint:fix         # Fix auto-fixable issues
 npm run check-types      # TypeScript type checking
 npm run db:studio        # Open Drizzle Studio
 npm run db:generate      # Generate migration from schema
+
+# Claude Code commands (run inside Claude Code):
+/init-downstream          # Post-fork project initialization
+/upstream-sync            # Pull upstream template updates
 ```
 
 ## Customizing This Template
@@ -182,6 +188,25 @@ src/
 | SEO infrastructure | OG image & SEO defaults | |
 | Error handling | Email templates | |
 
+### First Steps After Forking
+
+Run the `/init-downstream` Claude Code command to set up your project as an independent downstream repo:
+
+```bash
+# Using Claude Code (recommended):
+/init-downstream
+```
+
+This interactive command handles:
+1. **Database schema rename** -- regenerates a clean migration under your project's schema name (replaces `vt_saas`)
+2. **Merge strategy config** -- sets up `.gitattributes` with `merge=ours` for files you customize, so upstream syncs don't overwrite your branding
+3. **gh CLI targeting** -- runs `gh repo set-default` so PRs and issues target your repo, not the template
+4. **Template artifact cleanup** -- removes template-only files (planning docs, archived workflows) listed in `.template-cleanup`
+
+If you're not using Claude Code, see the [manual equivalent](docs/upstream-sync-guide.md#manual-equivalent-without-claude-code) in the Upstream Sync Guide.
+
+> **Suggested workflow:** `/init-downstream` (5 min) → branding pass (20 min) → stub cleanup (30 min) → start building your first feature.
+
 ### Syncing Upstream Updates
 
 When new features or fixes are released in the template, pull them into your project:
@@ -198,6 +223,8 @@ npm run lint && npm run check-types && npm test && npm run build
 ```
 
 See [Upstream Sync Guide](docs/upstream-sync-guide.md) for detailed instructions and conflict resolution strategies.
+
+> **Prerequisite:** Run `/init-downstream` first if you haven't already -- it configures the merge strategies that make upstream syncs clean.
 
 ### Should You Build a POC Separately?
 
@@ -246,7 +273,7 @@ Set it in `.env.local`:
 DB_SCHEMA=vt_saas
 ```
 
-When forking this template, pick a unique schema name for your project (e.g. `my_app`) and run `npm run db:generate` to create a migration for the new schema.
+When forking this template, run `/init-downstream` (Claude Code) to rename the schema and regenerate migrations automatically. Without Claude Code: update `DB_SCHEMA` in `.env.example` and `.env.local`, delete existing migrations, and run `npm run db:generate`.
 
 ### Making Schema Changes
 
@@ -410,6 +437,7 @@ Comprehensive documentation is available in the `docs/` directory:
 
 ### Maintenance
 - **[Upstream Sync Guide](docs/upstream-sync-guide.md)** - Pull new features and fixes from the template
+- **Claude Code commands** - `/init-downstream` (post-fork setup) and `/upstream-sync` (pull template updates) -- see [Building a Product](#building-a-product-on-this-template)
 
 ## License
 

--- a/docs/upstream-sync-guide.md
+++ b/docs/upstream-sync-guide.md
@@ -31,6 +31,8 @@ If you forked or templated this project, run the `/init-downstream` Claude Code 
 3. **gh CLI targeting** — runs `gh repo set-default` so PRs/issues target your repo, not the template
 4. **Template cleanup** — removes template-only artifacts (`.template-cleanup` manifest)
 
+See the [First Steps After Forking](../README.md#first-steps-after-forking) section in the README for a quick overview.
+
 ### Two Protection Mechanisms
 
 **For files you keep but customize** (e.g., `README.md`, `AppConfig.ts`):


### PR DESCRIPTION
## Summary
- Add `/init-downstream` visibility across README.md — installation callout, "First Steps After Forking" section, Available Scripts, DB schema docs, and documentation index
- Expand CLAUDE.md command descriptions so AI agents understand sequencing (`/init-downstream` first, then `/upstream-sync`)
- Add cross-reference from upstream-sync-guide.md back to new README section

## Test plan
- [ ] Read through README as a first-time fork user — `/init-downstream` should be discoverable from Installation, Building a Product, DB Management, and doc index
- [ ] Verify internal anchor links work (`#building-a-product-on-this-template`, `#first-steps-after-forking`, `#manual-equivalent-without-claude-code`)
- [ ] Confirm CLAUDE.md command descriptions match actual command behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)