### PR TITLE
feat(pseo): bypass module-level cache in dev so content edits surface without restart

### DIFF
--- a/src/libs/pseo/__tests__/data.test.ts
+++ b/src/libs/pseo/__tests__/data.test.ts
@@ -2,7 +2,7 @@
  * Tests for pSEO data loading utilities
  */
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   getAllPageParams,
@@ -15,6 +15,15 @@ import {
 } from '../data';
 
 describe('pSEO Data Utilities', () => {
+  afterEach(() => {
+    // The cache tests dynamically re-import the module with a stubbed
+    // NODE_ENV. Reset the env stub and the module registry afterwards so the
+    // prod cache state and env don't leak into the other tests, which use the
+    // statically-imported (test-env) functions.
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
   describe('loadCategories', () => {
     it('should load all categories', async () => {
       const categories = await loadCategories();
@@ -34,11 +43,34 @@ describe('pSEO Data Utilities', () => {
       expect(category).toHaveProperty('slug');
     });
 
-    it('should cache categories on subsequent calls', async () => {
-      const first = await loadCategories();
-      const second = await loadCategories();
+    it('should cache categories in production (same reference on repeat calls)', async () => {
+      // Re-import with a fresh module registry so the module-level cache
+      // starts empty under the stubbed production env.
+      vi.resetModules();
+      vi.stubEnv('NODE_ENV', 'production');
+      const mod = await import('../data');
 
-      expect(first).toBe(second); // Same reference = cached
+      const first = await mod.loadCategories();
+      const second = await mod.loadCategories();
+
+      // Second call is served from cache: identical reference, not re-read.
+      expect(first).toBe(second);
+    });
+
+    it('should bypass the cache outside production (fresh data each call)', async () => {
+      // In dev/test the cache is intentionally bypassed so edits to
+      // data/pseo/categories.json surface on the next request without a
+      // dev-server restart. Each call re-reads + re-parses the file, yielding
+      // an equal-but-distinct array instance.
+      vi.resetModules();
+      vi.stubEnv('NODE_ENV', 'development');
+      const mod = await import('../data');
+
+      const first = await mod.loadCategories();
+      const second = await mod.loadCategories();
+
+      expect(first).toEqual(second); // Equal content...
+      expect(first).not.toBe(second); // ...but freshly read each time (no cache)
     });
   });
 
@@ -65,11 +97,28 @@ describe('pSEO Data Utilities', () => {
       expect(page).toHaveProperty('lastModified');
     });
 
-    it('should cache pages on subsequent calls', async () => {
-      const first = await loadPages();
-      const second = await loadPages();
+    it('should cache pages in production (same reference on repeat calls)', async () => {
+      vi.resetModules();
+      vi.stubEnv('NODE_ENV', 'production');
+      const mod = await import('../data');
 
-      expect(first).toBe(second); // Same reference = cached
+      const first = await mod.loadPages();
+      const second = await mod.loadPages();
+
+      // Second call is served from cache: identical reference, not re-read.
+      expect(first).toBe(second);
+    });
+
+    it('should bypass the cache outside production (fresh data each call)', async () => {
+      vi.resetModules();
+      vi.stubEnv('NODE_ENV', 'development');
+      const mod = await import('../data');
+
+      const first = await mod.loadPages();
+      const second = await mod.loadPages();
+
+      expect(first).toEqual(second); // Equal content...
+      expect(first).not.toBe(second); // ...but freshly read each time (no cache)
     });
   });
 

--- a/src/libs/pseo/data.ts
+++ b/src/libs/pseo/data.ts
@@ -39,40 +39,54 @@ export type PseoPage = {
   lastModified: string;
 };
 
-// Cache for loaded data (populated at build time)
+// Cache for loaded data (populated on first load in production).
+// Disabled in dev so file changes under data/pseo/ surface without restart.
+const SHOULD_CACHE = process.env.NODE_ENV === 'production';
 let categoriesCache: PseoCategory[] | null = null;
 let pagesCache: PseoPage[] | null = null;
 
 /**
  * Load categories from JSON file
- * Data is cached after first load for performance
+ * Data is cached after first load in production; in dev, the cache is
+ * bypassed so edits to data/pseo/categories.json reflect on next request
+ * without a dev-server restart.
  */
 export async function loadCategories(): Promise<PseoCategory[]> {
-  if (categoriesCache) {
+  if (SHOULD_CACHE && categoriesCache) {
     return categoriesCache;
   }
 
   const dataPath = join(process.cwd(), 'data', 'pseo', 'categories.json');
   const content = await readFile(dataPath, 'utf-8');
-  categoriesCache = JSON.parse(content) as PseoCategory[];
+  const categories = JSON.parse(content) as PseoCategory[];
 
-  return categoriesCache;
+  if (SHOULD_CACHE) {
+    categoriesCache = categories;
+  }
+
+  return categories;
 }
 
 /**
  * Load all pages from JSON file
- * Data is cached after first load for performance
+ * Data is cached after first load in production; in dev, the cache is
+ * bypassed so edits to data/pseo/pages.json reflect on next request
+ * without a dev-server restart.
  */
 export async function loadPages(): Promise<PseoPage[]> {
-  if (pagesCache) {
+  if (SHOULD_CACHE && pagesCache) {
     return pagesCache;
   }
 
   const dataPath = join(process.cwd(), 'data', 'pseo', 'pages.json');
   const content = await readFile(dataPath, 'utf-8');
-  pagesCache = JSON.parse(content) as PseoPage[];
+  const pages = JSON.parse(content) as PseoPage[];
 
-  return pagesCache;
+  if (SHOULD_CACHE) {
+    pagesCache = pages;
+  }
+
+  return pages;
 }
 
 /**

--- a/src/libs/pseo/data.ts
+++ b/src/libs/pseo/data.ts
@@ -40,10 +40,22 @@ export type PseoPage = {
 };
 
 // Cache for loaded data (populated on first load in production).
-// Disabled in dev so file changes under data/pseo/ surface without restart.
-const SHOULD_CACHE = process.env.NODE_ENV === 'production';
+// Disabled outside production so file changes under data/pseo/ surface
+// without restart.
 let categoriesCache: PseoCategory[] | null = null;
 let pagesCache: PseoPage[] | null = null;
+
+/**
+ * Whether loaded data should be cached in module-level state.
+ *
+ * Evaluated per call (not as a module-load const) so the prod-gate stays
+ * trivially testable and the behavior is unchanged: cache in production,
+ * bypass everywhere else so dev edits to data/pseo/*.json surface on the
+ * next request without a dev-server restart.
+ */
+function shouldCache(): boolean {
+  return process.env.NODE_ENV === 'production';
+}
 
 /**
  * Load categories from JSON file
@@ -52,7 +64,7 @@ let pagesCache: PseoPage[] | null = null;
  * without a dev-server restart.
  */
 export async function loadCategories(): Promise<PseoCategory[]> {
-  if (SHOULD_CACHE && categoriesCache) {
+  if (shouldCache() && categoriesCache) {
     return categoriesCache;
   }
 
@@ -60,7 +72,7 @@ export async function loadCategories(): Promise<PseoCategory[]> {
   const content = await readFile(dataPath, 'utf-8');
   const categories = JSON.parse(content) as PseoCategory[];
 
-  if (SHOULD_CACHE) {
+  if (shouldCache()) {
     categoriesCache = categories;
   }
 
@@ -74,7 +86,7 @@ export async function loadCategories(): Promise<PseoCategory[]> {
  * without a dev-server restart.
  */
 export async function loadPages(): Promise<PseoPage[]> {
-  if (SHOULD_CACHE && pagesCache) {
+  if (shouldCache() && pagesCache) {
     return pagesCache;
   }
 
@@ -82,7 +94,7 @@ export async function loadPages(): Promise<PseoPage[]> {
   const content = await readFile(dataPath, 'utf-8');
   const pages = JSON.parse(content) as PseoPage[];
 
-  if (SHOULD_CACHE) {
+  if (shouldCache()) {
     pagesCache = pages;
   }
 


### PR DESCRIPTION
## Summary

The `categoriesCache` and `pagesCache` module-level caches in `src/libs/pseo/data.ts` persist for the lifetime of the dev-server process. This means edits to `data/pseo/categories.json` or `data/pseo/pages.json` don't reflect on the next request — you have to restart the dev server (or edit `data.ts` itself to trigger HMR) for changes to surface.

In production this is correct and important — every build is a fresh process, the cache fills once, and reads are free. The friction is dev-only.

## Change

Add a `SHOULD_CACHE = process.env.NODE_ENV === 'production'` guard around cache reads and writes in `loadCategories()` and `loadPages()`.

- Production behavior unchanged (cache populates on first load, served on subsequent reads).
- Dev behavior: cache bypassed, file is re-read on every request. ~1ms cost per request for a small JSON file; acceptable for the iteration speed it unlocks.

## Why now

Found while iterating on a project derived from this template — adding/removing categories in `categories.json` didn't reflect until I figured out I needed to restart the dev server. Easy gotcha to miss; cheap to fix permanently.

## Test plan

- [ ] `npm run check-types` — passes (already verified locally)
- [ ] Production build is functionally unchanged (cache populated, no re-reads)
- [ ] Dev iteration: edit `data/pseo/categories.json`, refresh the page — change appears without restarting `npm run dev`

## Backport context

This PR is one of a few small contributions back to the template from [ContentFlow](https://github.com/thevarun/ContentFlow) — a project derived from `vt-saas-template`. The cache bypass was added there first; merging upstream so future template-derived projects don't hit the same gotcha.