### PR TITLE
refactor(blog): rename /articles route to /blog

### DIFF
--- a/src/app/[locale]/(unauth)/blog/[category]/[slug]/page.tsx
+++ b/src/app/[locale]/(unauth)/blog/[category]/[slug]/page.tsx
@@ -37,7 +37,7 @@ export async function generateMetadata(props: PseoPageProps): Promise<Metadata> 
   }
 
   const baseUrl = getBaseUrl();
-  const pageUrl = `${baseUrl}/${locale}/articles/${categorySlug}/${slug}`;
+  const pageUrl = `${baseUrl}/${locale}/blog/${categorySlug}/${slug}`;
 
   return {
     title: page.title,

--- a/src/app/[locale]/(unauth)/blog/[category]/page.tsx
+++ b/src/app/[locale]/(unauth)/blog/[category]/page.tsx
@@ -31,10 +31,10 @@ export async function generateMetadata(props: CategoryPageProps): Promise<Metada
   const baseUrl = getBaseUrl();
 
   return {
-    title: `${category.name} Articles`,
+    title: category.name,
     description: category.description,
     alternates: {
-      canonical: `${baseUrl}/${locale}/articles/${categorySlug}`,
+      canonical: `${baseUrl}/${locale}/blog/${categorySlug}`,
     },
   };
 }
@@ -58,8 +58,8 @@ export default async function CategoryPage(props: CategoryPageProps) {
               Home
             </Link>
             <span className="mx-2">/</span>
-            <Link href={`/${locale}/articles`} className="hover:text-foreground">
-              Articles
+            <Link href={`/${locale}/blog`} className="hover:text-foreground">
+              Blog
             </Link>
             <span className="mx-2">/</span>
             <span className="text-foreground">{category.name}</span>
@@ -72,7 +72,7 @@ export default async function CategoryPage(props: CategoryPageProps) {
           {pages.map(page => (
             <Link
               key={page.id}
-              href={`/${locale}/articles/${categorySlug}/${page.slug}`}
+              href={`/${locale}/blog/${categorySlug}/${page.slug}`}
               className="group block"
             >
               <article className="rounded-lg border border-border p-6 transition-all hover:border-foreground/20 hover:shadow-md">
@@ -92,7 +92,7 @@ export default async function CategoryPage(props: CategoryPageProps) {
 
         {pages.length === 0 && (
           <div className="py-16 text-center">
-            <p className="text-muted-foreground">No articles in this category yet.</p>
+            <p className="text-muted-foreground">No posts in this category yet.</p>
           </div>
         )}
       </div>

--- a/src/app/[locale]/(unauth)/blog/page.tsx
+++ b/src/app/[locale]/(unauth)/blog/page.tsx
@@ -4,24 +4,24 @@ import Link from 'next/link';
 import { getPagesByCategory, loadCategories } from '@/libs/pseo/data';
 import { getBaseUrl } from '@/utils/Helpers';
 
-type ArticlesPageProps = {
+type BlogPageProps = {
   params: Promise<{ locale: string }>;
 };
 
-export async function generateMetadata(props: ArticlesPageProps): Promise<Metadata> {
+export async function generateMetadata(props: BlogPageProps): Promise<Metadata> {
   const { locale } = await props.params;
   const baseUrl = getBaseUrl();
 
   return {
-    title: 'Articles',
-    description: 'Browse our collection of articles across various topics.',
+    title: 'Blog',
+    description: 'Browse our collection of posts across various topics.',
     alternates: {
-      canonical: `${baseUrl}/${locale}/articles`,
+      canonical: `${baseUrl}/${locale}/blog`,
     },
   };
 }
 
-export default async function ArticlesIndexPage(props: ArticlesPageProps) {
+export default async function BlogIndexPage(props: BlogPageProps) {
   const { locale } = await props.params;
   const categories = await loadCategories();
 
@@ -40,13 +40,13 @@ export default async function ArticlesIndexPage(props: ArticlesPageProps) {
             Home
           </Link>
           <span className="mx-2">/</span>
-          <span className="font-medium text-foreground">Articles</span>
+          <span className="font-medium text-foreground">Blog</span>
         </nav>
 
         <header className="mb-12">
-          <h1 className="mb-3 text-4xl font-bold text-foreground">Articles</h1>
+          <h1 className="mb-3 text-4xl font-bold text-foreground">Blog</h1>
           <p className="text-lg text-muted-foreground">
-            Browse our collection of articles across various topics.
+            Browse our collection of posts across various topics.
           </p>
         </header>
 
@@ -59,7 +59,7 @@ export default async function ArticlesIndexPage(props: ArticlesPageProps) {
                   <p className="mt-1 text-muted-foreground">{category.description}</p>
                 </div>
                 <Link
-                  href={`/${locale}/articles/${category.slug}`}
+                  href={`/${locale}/blog/${category.slug}`}
                   className="text-sm font-medium text-primary hover:underline"
                 >
                   View all &rarr;
@@ -69,7 +69,7 @@ export default async function ArticlesIndexPage(props: ArticlesPageProps) {
                 {pages.map(page => (
                   <Link
                     key={page.id}
-                    href={`/${locale}/articles/${category.slug}/${page.slug}`}
+                    href={`/${locale}/blog/${category.slug}/${page.slug}`}
                     className="group block"
                   >
                     <article className="rounded-lg border border-border p-6 transition-all hover:border-foreground/20 hover:shadow-md">

--- a/src/app/sitemap.test.ts
+++ b/src/app/sitemap.test.ts
@@ -51,7 +51,7 @@ describe('sitemap', () => {
     const entries = await sitemap();
 
     // Homepage entries should have priority 1.0
-    const homepageEntries = entries.filter(e => !e.url.includes('/articles'));
+    const homepageEntries = entries.filter(e => !e.url.includes('/blog'));
     homepageEntries.forEach((entry) => {
       expect(entry.priority).toBe(1.0);
     });
@@ -60,7 +60,7 @@ describe('sitemap', () => {
   it('sets correct changeFrequency for homepage', async () => {
     const entries = await sitemap();
 
-    const homepageEntries = entries.filter(e => !e.url.includes('/articles'));
+    const homepageEntries = entries.filter(e => !e.url.includes('/blog'));
     homepageEntries.forEach((entry) => {
       expect(entry.changeFrequency).toBe('daily');
     });

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -9,9 +9,9 @@ import { AllLocales, AppConfig } from '@/utils/AppConfig';
  *
  * PUBLIC ROUTES (included in sitemap):
  * - / (landing page)
- * - /articles (pSEO index)
- * - /articles/[category] (pSEO category pages)
- * - /articles/[category]/[slug] (pSEO article pages)
+ * - /blog (pSEO index)
+ * - /blog/[category] (pSEO category pages)
+ * - /blog/[category]/[slug] (pSEO article pages)
  * - Future: /about, /pricing, /blog/[slug], /docs/[...path]
  *
  * PRIVATE ROUTES (excluded from sitemap, disallowed in robots.txt):
@@ -94,7 +94,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const categoryParams = await getAllCategoryParams();
   for (const param of categoryParams) {
     entries.push(
-      ...generateLocalizedUrls(`/articles/${param.category}`, {
+      ...generateLocalizedUrls(`/blog/${param.category}`, {
         changeFrequency: 'weekly',
         priority: 0.7,
       }),
@@ -103,7 +103,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   // Articles index page
   entries.push(
-    ...generateLocalizedUrls('/articles', {
+    ...generateLocalizedUrls('/blog', {
       changeFrequency: 'weekly',
       priority: 0.8,
     }),
@@ -120,7 +120,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         const isDefaultLocale = locale === AppConfig.defaultLocale;
         const localePrefix = isDefaultLocale ? '' : `/${locale}`;
         entries.push({
-          url: `${siteUrl}${localePrefix}/articles/${param.category}/${param.slug}`,
+          url: `${siteUrl}${localePrefix}/blog/${param.category}/${param.slug}`,
           lastModified: new Date(page.lastModified),
           changeFrequency: 'weekly',
           priority: 0.7,

--- a/src/components/pseo/Breadcrumbs.tsx
+++ b/src/components/pseo/Breadcrumbs.tsx
@@ -19,14 +19,14 @@ type BreadcrumbsProps = {
   category: PseoCategory;
   pageTitle: string;
   locale: string;
-  articlesLabel?: string;
+  rootLabel?: string;
 };
 
-export function Breadcrumbs({ category, pageTitle, locale, articlesLabel = 'Articles' }: BreadcrumbsProps) {
+export function Breadcrumbs({ category, pageTitle, locale, rootLabel = 'Blog' }: BreadcrumbsProps) {
   const items = [
     { name: 'Home', href: `/${locale}` },
-    { name: articlesLabel, href: `/${locale}/articles` },
-    { name: category.name, href: `/${locale}/articles/${category.slug}` },
+    { name: rootLabel, href: `/${locale}/blog` },
+    { name: category.name, href: `/${locale}/blog/${category.slug}` },
     { name: pageTitle, href: null }, // Current page, not a link
   ];
 

--- a/src/components/pseo/PseoTemplate.tsx
+++ b/src/components/pseo/PseoTemplate.tsx
@@ -36,13 +36,13 @@ export function PseoTemplate({ page, category, relatedPages, locale }: PseoTempl
   // Construct the current page URL for sharing
   const pageUrl = typeof window !== 'undefined'
     ? window.location.href
-    : `/${locale}/articles/${category.slug}/${page.slug}`;
+    : `/${locale}/blog/${category.slug}/${page.slug}`;
 
   return (
     <div className="min-h-screen bg-background">
       <div className="container mx-auto max-w-5xl px-4 py-12">
         {/* Breadcrumb navigation */}
-        <Breadcrumbs category={category} pageTitle={page.title} locale={locale} articlesLabel="Articles" />
+        <Breadcrumbs category={category} pageTitle={page.title} locale={locale} rootLabel="Blog" />
 
         {/* Article header */}
         <header className="mb-8">

--- a/src/components/pseo/RelatedPages.tsx
+++ b/src/components/pseo/RelatedPages.tsx
@@ -27,12 +27,12 @@ export function RelatedPages({ pages, categorySlug, locale }: RelatedPagesProps)
 
   return (
     <section className="mt-12 border-t border-border pt-8">
-      <h2 className="mb-6 text-2xl font-bold text-foreground">Related Articles</h2>
+      <h2 className="mb-6 text-2xl font-bold text-foreground">Related Posts</h2>
       <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
         {pages.map(page => (
           <Link
             key={page.id}
-            href={`/${locale}/articles/${categorySlug}/${page.slug}`}
+            href={`/${locale}/blog/${categorySlug}/${page.slug}`}
             className="group block"
           >
             <article className="rounded-lg border border-border p-6 transition-all hover:border-foreground/20 hover:shadow-md">

--- a/src/components/pseo/__tests__/Breadcrumbs.test.tsx
+++ b/src/components/pseo/__tests__/Breadcrumbs.test.tsx
@@ -39,12 +39,12 @@ describe('Breadcrumbs Component', () => {
     );
 
     expect(screen.getByText('Home')).toBeInTheDocument();
-    expect(screen.getByText('Articles')).toBeInTheDocument();
+    expect(screen.getByText('Blog')).toBeInTheDocument();
     expect(screen.getByText('Productivity')).toBeInTheDocument();
     expect(screen.getByText('Time Management')).toBeInTheDocument();
   });
 
-  it('should make home, articles, and category links clickable', () => {
+  it('should make home, blog, and category links clickable', () => {
     render(
       <Breadcrumbs
         category={mockCategory}
@@ -57,13 +57,13 @@ describe('Breadcrumbs Component', () => {
 
     expect(homeLink).toHaveAttribute('href', '/en');
 
-    const articlesLink = screen.getByRole('link', { name: 'Articles' });
+    const blogLink = screen.getByRole('link', { name: 'Blog' });
 
-    expect(articlesLink).toHaveAttribute('href', '/en/articles');
+    expect(blogLink).toHaveAttribute('href', '/en/blog');
 
     const categoryLink = screen.getByRole('link', { name: 'Productivity' });
 
-    expect(categoryLink).toHaveAttribute('href', '/en/articles/productivity');
+    expect(categoryLink).toHaveAttribute('href', '/en/blog/productivity');
   });
 
   it('should not make current page clickable', () => {

--- a/src/components/pseo/__tests__/RelatedPages.test.tsx
+++ b/src/components/pseo/__tests__/RelatedPages.test.tsx
@@ -42,7 +42,7 @@ describe('RelatedPages Component', () => {
       />,
     );
 
-    expect(screen.getByText('Related Articles')).toBeInTheDocument();
+    expect(screen.getByText('Related Posts')).toBeInTheDocument();
   });
 
   it('should render all related page cards', () => {
@@ -83,8 +83,8 @@ describe('RelatedPages Component', () => {
     const links = screen.getAllByRole('link');
 
     expect(links).toHaveLength(2);
-    expect(links[0]).toHaveAttribute('href', '/en/articles/productivity/time-management');
-    expect(links[1]).toHaveAttribute('href', '/en/articles/productivity/focus-techniques');
+    expect(links[0]).toHaveAttribute('href', '/en/blog/productivity/time-management');
+    expect(links[1]).toHaveAttribute('href', '/en/blog/productivity/focus-techniques');
   });
 
   it('should not render if no pages provided', () => {

--- a/src/templates/Footer.tsx
+++ b/src/templates/Footer.tsx
@@ -94,7 +94,7 @@ export const Footer = () => {
         </li>
 
         <li>
-          <Link href="/articles">{t('blog')}</Link>
+          <Link href="/blog">{t('blog')}</Link>
         </li>
 
         <li>

--- a/src/templates/Navbar.tsx
+++ b/src/templates/Navbar.tsx
@@ -60,7 +60,7 @@ export const Navbar = () => {
         </li>
 
         <li>
-          <Link href="/articles">{t('blog')}</Link>
+          <Link href="/blog">{t('blog')}</Link>
         </li>
 
         <li>


### PR DESCRIPTION
## Summary

Rename the pSEO route from `/articles` to `/blog`. "Blog" is more familiar to most users — it's the term most SaaS marketing sites use for indexed long-form content, and matches what visitors expect to see in the navbar (`Blog` reads more naturally than `Articles`).

## Change

- **Route folder:** `src/app/[locale]/(unauth)/articles/` → `src/app/[locale]/(unauth)/blog/`
- **Path strings:** all `/articles` → `/blog` references updated across sitemap, breadcrumb components, related-pages component, navbar/footer templates, and tests (12 files total)
- **Breadcrumb component:** `articlesLabel?: string = 'Articles'` prop renamed to `rootLabel?: string = 'Blog'`. Cleaner naming now that it's not tied to the word "Articles."
- **Display strings:** page title `"Articles"` → `"Blog"`, heading "Related Articles" → "Related Posts", empty state "No articles in this category" → "No posts in this category"
- **Test assertions** updated to match the new labels

## Breaking change

⚠️ **This is a breaking change for template-derived projects that already have content live at `/articles`.**

Migration for downstream projects:

```bash
# 1. Pull this change into your fork
git fetch upstream && git merge upstream/main

# 2. If you had any in-content links pointing at /articles (e.g. in MDX), rewrite them
find content -name "*.mdx" -exec sed -i '' 's|](/articles/|](/blog/|g' {} +

# 3. (Optional) Add a redirect in next.config to preserve any external links
# In next.config:
# async redirects() {
#   return [{ source: '/articles/:path*', destination: '/blog/:path*', permanent: true }];
# }
```

## Test plan

- [x] `npm run check-types` — passes (verified after `npm run clean` to clear stale `.next` validator types)
- [x] `npx vitest run src/components/pseo src/app/sitemap.test.ts` — 18 tests pass
- [ ] Navigate `/blog`, `/blog/[category]`, `/blog/[category]/[slug]` — all 200
- [ ] Sitemap at `/sitemap.xml` includes `/blog/*` URLs (no `/articles/*`)
- [ ] `/articles` returns 404
- [ ] Breadcrumb on article pages reads `Home / Blog / Category / Title`

## Backport context

This PR is one of several small contributions back from [ContentFlow](https://github.com/thevarun/ContentFlow). The rename was done there first; merging upstream so future template-derived projects default to the more familiar `/blog` route.