### PR TITLE
feat(skills): bundle marketing-site-polish skill for template-derived projects

### DIFF
--- a/.claude/skills/marketing-site-polish/SKILL.md
+++ b/.claude/skills/marketing-site-polish/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: marketing-site-polish
+description: Marketing & launch expert agency mode for polishing the unauthenticated surface of a vt-saas-template-derived SaaS before launch. Audits navbar/footer/legal pages/SEO/auth flow, brainstorms a prioritized plan, executes in logical commits, and guides pre-launch infrastructure setup (email forwarding, branch protection + semantic-release, legal review, product screenshots). Use when the user says "polish the landing page for launch", "prep the unauth pages", "make this site launch-ready", or similar.
+disable-model-invocation: true
+---
+
+# Marketing Site Polish — Orchestrator
+
+**Goal:** Take a vt-saas-template-derived project's unauthenticated surface from "functionally works" to "launch-ready" — trust-building legal pages, polished navbar/footer, working SEO, sensible auth-flow redirects, and a pre-launch external-systems checklist — without overpolishing low-value items.
+
+---
+
+## PARTNER STANCE
+
+You're embodying an agency that has shipped many B2B SaaS launches across solo founders, seed startups, and small teams. Bring the taste that comes with that exposure — pattern recognition for what reads trustworthy versus amateur, instinct for which polish items matter at this stage, awareness of how users actually find and evaluate the product.
+
+- **Calibrated by taste, not rules.** Recommend nav copy, footer ordering, hero subheads from gut + a comparable site you've seen do it well. Don't fall back on "best practice" — everyone has seen those and they age fast. Cite the example.
+- **Distribution-aware by default.** Every visible surface is also a distribution surface: the landing page is the LinkedIn share card, the indexed Google page, the screenshot in a blog roundup. Treat copy and visuals as channel-aware artifacts, not in-isolation design choices.
+- **Skeptical of own playbook.** Steelman the runner-up before recommending. Push back when the user's request reproduces a pattern that's bad for their specific case — a testimonials section with zero named users is a credibility footgun, not a credibility signal.
+- **Comfortable saying "not yet."** Knows NOT polishing something is often the right call. Empty FAQ section is worse than no FAQ section. A dropdown with two items is worse than two flat links. An About page that says "TBD" is worse than no About link in the nav.
+- **Discipline-aware.** Recognizes when a "frontend polish" task is actually a legal task (Privacy/Terms), an ops task (email forwarding), or a content-strategy task (blog cadence). Routes to the right place; doesn't pretend to be all of them.
+- **Brand voice has a smell test.** Can tell when copy reads like AI slop, when it reads like a SaaS founder doing what every other SaaS founder did, and when it reads like a confident product with a point of view. Aims for the third.
+
+---
+
+## CONSTRAINTS
+
+- **Audit before proposing.** Read the actual current state (per the audit map below) before any recommendation. The template evolves and project forks diverge — don't recommend changes to code that no longer exists.
+- **Plan before executing.** For any work spanning >2 files or >1 concern, write a prioritized plan (P0/P1/P2) and get user approval before committing. Trivial single-line changes don't need a plan.
+- **One logical concern per commit.** Each commit body answers "what changed and why" in one sentence. Verify in browser (or via test) after each commit before moving on.
+- **Surface the runner-up, recommend one.** When choosing between viable options (nav label, footer ordering, dialog vs. page), name the alternative + why you passed. Don't present bare menus.
+- **GitHub issues for deferred items.** Anything not P0 gets a numbered issue with a clear scope. No "TODO" comments hidden in code.
+
+---
+
+## AUDIT MAP
+
+> **Drift caveat:** vt-saas-template evolves. Before relying on file paths cited here, verify the file exists in the current project. When paths drift, prefer reading the project's actual structure (`git ls-files` or directory listings) over the skill's assumptions.
+
+First-pass read of the marketing/unauth surface. Touch only these files — don't exhaustively grep:
+
+| Area | File(s) |
+|---|---|
+| Route hierarchy | `src/app/[locale]/(unauth)/layout.tsx`, `src/app/[locale]/(unauth)/page.tsx` (or `src/app/[locale]/page.tsx` if landing not yet relocated) |
+| Marketing chrome | `src/templates/Navbar.tsx` + `Footer.tsx` (template default), or `src/components/landing/*` if the project has forked its marketing components |
+| Landing composition | `src/app/[locale]/page.tsx` (template default) or `src/app/[locale]/(unauth)/page.tsx` (if landing was relocated into the unauth group for shared layout) — what sections render in what order |
+| Auth flow surface | `src/app/[locale]/(unauth)/(center)/sign-in/`, `sign-up/` for the template's page-based auth; `src/components/landing/auth-dialog.tsx` if the project adopted the overlay-dialog pattern |
+| Auth redirect helpers | `src/libs/auth/landing-auth-url.ts` (absence is expected on a fresh template; presence means the project has adopted the landing-dialog redirect pattern) |
+| Middleware | `src/proxy.ts` — what redirects unauth users to landing |
+| SEO scaffolding | `src/app/sitemap.ts`, `src/app/robots.ts`, `src/libs/seo/opengraph.ts`, `src/libs/seo/constants.ts` |
+| pSEO content loader | `src/libs/pseo/data.ts` |
+| Locale strings | `src/locales/<default>.json` — `meta_title`, `meta_description` for landing |
+| Existing pages | List `src/app/[locale]/(unauth)/` subdirs — flag presence/absence of `about`, `privacy`, `terms`, `changelog`, `blog` |
+| Existing content | List the project's content source — `content/blog/` (folder + MDX), `data/pseo/*.json` (template default), or a CMS integration |
+| Release config | `package.json` `release.plugins`, `.github/workflows/release.yml` |
+| i18n setup | `src/libs/i18nNavigation.ts`, `src/utils/AppConfig.ts` (localePrefix, locales) |
+
+Output a structured audit summary back to the user before proposing changes. Cite `file:line` for anything you'll suggest modifying.
+
+---
+
+## REFERENCE FILES
+
+Two reference files live alongside this SKILL.md. Pull them in when the relevant trigger appears — don't load preemptively.
+
+- **`references/playbook-notes.md`** — standardized decisions (em-dash separator, max-w-3xl article body, footer column order, etc.) and concrete gotchas (pSEO dev-cache, Porkbun + Resend coexistence, AuthDialogProvider scope, locale-aware Link, etc.). Consult when proposing changes or when a relevant code area gets touched.
+- **`references/pre-launch.md`** — external-system checklist (email forwarding, branch protection + Semantic Release App, legal review, screenshots, DMARC, OG image generation, Search Console). Consult during the pre-launch phase.
+
+---
+
+## PHASE SUGGESTIONS (light scaffolding, not rigid steps)
+
+These exist to anchor the work — not to enforce a workflow. Skip or reorder when context warrants.
+
+**1. Audit.** Read the files in the AUDIT MAP. Produce a written state summary in 5-10 lines covering: current navbar/footer structure, missing pages (about/privacy/terms/etc.), SEO baseline, auth-redirect pattern, blog setup. Cite `file:line` for anything proposed for change.
+
+**2. Brainstorm + plan.** Discuss priorities with the user. Default frame: P0 (trust-killer fixes — dead legal links, broken auth dialog, missing pages users will look for); P1 (polish that compounds — refined nav/footer, locale-aware links, blog chrome); P2 (defer until volume justifies — per-article OG, JSON-LD, audience landings). Write a plan to `~/.claude/plans/` (use plan mode) and get approval before committing.
+
+**3. Execute in logical commits.** One concern per commit. Browser-verify after each commit (`preview_*` tools). Run unit + E2E tests at logical checkpoints — not after every commit, but before big architectural changes (provider hoists, route renames) and before opening the PR.
+
+**4. PR + CI.** Open a PR with a structured body: summary, what changed, test plan checklist, pre-launch action items, backlog issues filed. Monitor checks; address Codex/review feedback as it arrives. Locale-preservation and broken-MDX-link issues are recurring — pre-empt them.
+
+**5. Pre-launch infrastructure.** Walk through `references/pre-launch.md` with the user. These are external-system steps (email DNS, GitHub branch protection, legal review, screenshots) that aren't in the codebase but block launch.
+
+---
+
+## OUT OF SCOPE
+
+This skill does NOT cover:
+
+- Authenticated product UX (post-sign-in flows, dashboards, settings pages)
+- Auth form polish itself (the sign-in/sign-up pages — only their visibility and routing in the marketing surface)
+- Marketing content authoring (the skill helps wire blog infrastructure; doesn't write articles or position copy)
+- Performance / Core Web Vitals optimization (separate skill)
+- Dark mode / theming
+- Analytics dashboards / instrumentation
+- Deploy-readiness (Vercel / Supabase / Stripe setup) — that's its own skill (`production-deploy` if installed)

--- a/.claude/skills/marketing-site-polish/references/playbook-notes.md
+++ b/.claude/skills/marketing-site-polish/references/playbook-notes.md
@@ -1,0 +1,138 @@
+# Playbook Notes
+
+Two halves: **standardized decisions** (don't re-litigate per project) and **concrete gotchas** (Claude won't infer these without painful re-discovery).
+
+Pulled in by `SKILL.md` when a relevant code area gets touched or a relevant question gets raised. Don't load preemptively.
+
+---
+
+## Standardized decisions
+
+These are choices already made across previous launches. Recommend them by default; only deviate when the user has a specific reason.
+
+### Brand & typography
+
+- **Em-dash as brand-name separator** (`—`, U+2014). Modern convention for "Brand — tagline" usage. Apple, Stripe, etc. do this. En-dash (`–`) is for numeric ranges; hyphen (`-`) reads dated. Apply in:
+  - `<title>` separators (`Page Title — BrandName`)
+  - `og:title` auto-suffix in `src/libs/seo/opengraph.ts`
+  - Any locale `meta_title` strings using a separator
+- **Title separator on apex landing:** use the em-dash directly in the locale `meta_title`. Don't rely on per-page suffix logic for the landing.
+
+### Layout widths
+
+- **`max-w-3xl`** for article body and any long-form prose page (About, Privacy, Terms). Reading-optimized line length.
+- **`max-w-5xl`** for grid pages (blog index, category landing, dashboards). Lets cards breathe without becoming uncomfortably wide.
+- **`max-w-2xl`** for hero lead paragraphs. Tight enough to read in one eye-sweep below a `text-5xl` headline.
+
+### Navigation
+
+- **Resources dropdown** via shadcn NavigationMenu when secondary nav surfaces reach ≥3 items (Blog + About + Changelog). Below that, keep flat nav links. Dropdown with 2 items reads as over-engineering.
+- **Dropdown content pattern:** icon (lucide) + bold label + 1-line description per item. Keeps the dropdown scannable without forcing the user to click each to discover what's there.
+- **Dropdown trigger styling:** override shadcn's default chunky button look. Use the same `text-sm font-medium text-muted-foreground hover:text-foreground` as flat nav links + add chevron. Without override, the trigger reads as a "button" in a row of "links" — inconsistent.
+- **Right-grouped layout:** logo on far left; nav links + auth buttons grouped together on the right. Apple/Stripe/Linear convention. Avoids the cluttered "nav links in center, buttons on right" feel.
+- **CTA primary copy:** "Start Free Trial" beats "Sign Up for Free" — shorter, more direct, implies value received not just an action.
+- **Login button:** subtle outline pill (shadcn `variant="outline"` + `rounded-full px-5`). Visible enough to find, low enough weight to not compete with primary CTA.
+
+### Footer
+
+- **4 columns, in this order:** Product · Company · Legal · Compare. Legal next to copyright (closing trust signal). Compare last (named competitor links — SEO anchor text for tool-comparison queries).
+- **Named competitor links** ("{YourProduct} vs {Competitor}") beat generic ones ("Comparisons"). Better SEO anchor text; faster path for users with specific tool questions.
+- **No floating social icon cluster.** Roll social into the Company column under a "Social" subheading. Avoids the dead-space feel of a separate icon strip.
+- **Drop the FAQ from footer** if it's already in the navbar. Don't repeat. The footer's job is "things not in the nav."
+
+### Auth & routing
+
+- **Landing-page redirect for unauth users**, not `/sign-in`. When a user hits a protected route while unauthenticated, redirect to landing with `?auth=signin&redirect=<original-path>` query params. The landing's `AuthDialogAutoOpener` reads these and opens the dialog. Benefits: cold visitors see product context first; the auth dialog is consistent across all entry points.
+- **`/sign-in` and `/sign-up` pages still exist** as direct URLs (for password managers, email links, OAuth fallback). But every internal redirect uses the landing-dialog pattern.
+- **Logout flow does NOT auto-open dialog.** After logout, redirect to bare `/` with no `?auth=` param. The user just chose to leave — pushing them back into sign-in is hostile.
+- **`AuthDialogProvider` lives in `(unauth)/layout.tsx`, landing page lives inside `(unauth)/`.** These are paired — the layout doesn't wrap the landing unless the landing is in the same route group. Don't hoist the provider without relocating `page.tsx`.
+
+### i18n
+
+- **`localePrefix: 'as-needed'`** — default locale stays unprefixed (`/`, `/about`). Other locales get `/<locale>` prefix (`/hi`, `/hi/about`). Don't add `/en` prefix in redirect URLs that target the default locale.
+- **Use `Link` from `@/libs/i18nNavigation`** (which wraps `next-intl/navigation`) for any internal link in shared components — navbar, footer, etc. Plain `next/link` loses the active locale when generating href.
+
+### Content & SEO
+
+- **`/blog` not `/articles`** for the SEO content route. "Blog" reads more familiar to most users.
+- **Reading-optimized article hero matches About page hero.** Same `text-4xl sm:text-5xl tracking-tight` headline, same `text-lg text-muted-foreground` lead. Consistent typography across long-form content surfaces.
+- **Article cards on index/category:** `rounded-xl bg-card`, group-hover lift (`group-hover:-translate-y-0.5 group-hover:shadow-lg`), arrow that nudges right on hover. Consistent across Blog index, Category page, and Related Posts at the bottom of articles.
+- **Breadcrumbs on article pages, "← All posts" back-link on category pages.** Both improve nav clarity without cluttering the chrome.
+
+---
+
+## Concrete gotchas
+
+Things that bit us before and will bite again. Surface to the user when the relevant area gets touched.
+
+### pSEO dev-cache persists across requests
+
+`src/libs/pseo/data.ts` keeps module-level `categoriesCache` and `pagesCache` variables. In production this is fine (each build is a fresh process). In dev with Turbopack HMR, these caches persist for the lifetime of the dev server process — adding/removing/renaming files under `content/blog/` won't reflect until the dev server restarts OR the `data.ts` file itself is edited.
+
+**Mitigation:** add a `NODE_ENV !== 'production'` guard around cache reads and writes. ~5-line change. Or just restart the dev server when content changes don't reflect.
+
+**Surface this to the user when:** they're adding/removing blog categories or report "I deleted the example article but it's still showing."
+
+### Porkbun's "Create Email Forward" auto-tool deletes 3rd-party subdomain MX records
+
+Porkbun's auto-DNS-fix flow scans the whole domain for MX records and flags anything not pointing at Porkbun as "3rd party unsupported" — **including subdomain MX used by Resend / Amazon SES for bounce handling**. Clicking OK on the warning popup will silently destroy your outbound email setup.
+
+**Right pattern:**
+1. Manually add Porkbun's MX values on the apex only: `fwd1.porkbun.com` priority 10, `fwd2.porkbun.com` priority 20.
+2. Manually update apex SPF to include `_spf.porkbun.com` alongside existing apex senders. Do NOT include `amazonses.com` on apex SPF (it belongs only on the subdomain).
+3. Then create the forwarding alias rule — popup may still appear; accept the risk and verify immediately after.
+4. If subdomain records did get nuked, recover via Resend dashboard → Domains → "Verify DNS" — regenerates exact records to re-add.
+
+**Surface this to the user when:** they're setting up email forwarding for the first time on a domain that already has Resend (or any other ESP) configured.
+
+### Apex SPF and subdomain SPF have distinct purposes
+
+SPF is checked against the envelope sender's domain, not the From: header. Resend's envelope sender is `<something>@send.mail.yourdomain.com` (the configured sending subdomain), so `amazonses.com` belongs on the SUBDOMAIN SPF, not apex.
+
+Mixing them (`include:amazonses.com` on apex) authorizes any AWS SES customer to send `From: anything@yourdomain.com` that passes SPF. DMARC still saves you (DKIM alignment required), but it's poor hygiene.
+
+**RFC 7208 rule:** only ONE SPF record per hostname. Multiple SPFs on the same hostname = many receiving servers treat the domain as having no valid SPF.
+
+### `AuthDialogProvider` won't reach the landing page unless landing is inside `(unauth)/`
+
+If you hoist `AuthDialogProvider` from the landing page to `(unauth)/layout.tsx` without also moving the landing page into the `(unauth)/` route group, the landing **silently** loses access to the provider. Buttons no-op (because `useAuthDialog()` returns the default no-op context). The `AuthDialogAutoOpener` calls `openSignUp()`/`openSignIn()` against the default context, and the dialog never opens.
+
+Worse: this isn't caught by visual review (page renders fine, buttons look fine). Only E2E tests that wait for the dialog to appear will catch it.
+
+**Pair the changes:** when moving the provider to the layout, also move `src/app/[locale]/page.tsx` → `src/app/[locale]/(unauth)/page.tsx`. Route groups don't affect URLs (`/` still routes there), but they DO affect which layout wraps the page.
+
+### Hash anchors in shared nav need `/`-prefix and locale awareness
+
+Two problems:
+
+1. **Bare hash anchors** (`href="#pricing"`) only scroll if you're on the same page as the anchor. From `/blog`, clicking `#pricing` does nothing. Fix: use `/#pricing` so Next.js navigates to `/` first.
+2. **Plain `next/link` strips locale.** From `/hi/blog`, clicking `<Link href="/#pricing">` navigates to `/#pricing` (English) — drops the user out of their locale. Fix: use `Link` from `@/libs/i18nNavigation` (re-export of `next-intl`'s locale-aware Link) instead of `next/link`.
+
+### Semantic-release with branch protection requires app token or bypass
+
+The default `GITHUB_TOKEN` in the release workflow cannot bypass branch protection rules — by design. When semantic-release tries to push the `chore(release): vX.Y.Z` commit (containing the updated `docs/CHANGELOG.md`), the push gets rejected.
+
+**Two fixes:**
+- Install the Semantic Release GitHub App, grant it bypass on protected branches, use its app token in the workflow (cleanest).
+- OR generate a PAT from a bot account with bypass permission, store as repo secret, use that token.
+
+**Wire this BEFORE enabling branch protection**, not after — otherwise the next release blocks immediately.
+
+### Route renames need MDX content sed too
+
+When renaming a route (e.g., `/articles` → `/blog`), the page templates and components get updated by editor edits, but **in-content links inside MDX files don't**. Codex review reliably flags broken `[link](/articles/foo)` references inside content files.
+
+**Fix during the rename:** `find content/blog -name "*.mdx" -exec sed -i '' 's|](/articles/|](/blog/|g' {} +`
+
+### Formatter race in PostToolUse hooks
+
+When a project has a `PostToolUse:Edit` hook that runs `eslint --fix` automatically:
+
+1. Edit #1 adds a new import (`import { Newspaper } from 'lucide-react'`)
+2. **Hook runs** between Edit #1 and Edit #2
+3. Hook sees `Newspaper` is imported but not yet used → removes it as "unused"
+4. Edit #2 adds the JSX that uses `Newspaper` → ReferenceError at runtime
+
+**Mitigation:** always batch import + usage in a single Edit or Write call when introducing a new import. Avoid the two-step "add import, then use it" pattern.
+
+**Environmental fix** (if user wants): remove the PostToolUse formatter hook entirely; rely on pre-commit lint-staged to catch unused imports at commit time. (This is project-config territory, not skill territory.)

--- a/.claude/skills/marketing-site-polish/references/playbook-notes.md
+++ b/.claude/skills/marketing-site-polish/references/playbook-notes.md
@@ -122,7 +122,7 @@ The default `GITHUB_TOKEN` in the release workflow cannot bypass branch protecti
 
 When renaming a route (e.g., `/articles` → `/blog`), the page templates and components get updated by editor edits, but **in-content links inside MDX files don't**. Codex review reliably flags broken `[link](/articles/foo)` references inside content files.
 
-**Fix during the rename:** `find content/blog -name "*.mdx" -exec sed -i '' 's|](/articles/|](/blog/|g' {} +`
+**Fix during the rename:** `find content/blog -name "*.mdx" -exec perl -i -pe 's{\]\(/articles/}{](/blog/}g' {} +` (use `perl -i` instead of `sed -i ''` — the BSD `sed -i ''` form fails on GNU sed in Linux CI/dev containers, silently leaving stale `](/articles/...)` links; `perl -i` is portable across macOS and Linux).
 
 ### Formatter race in PostToolUse hooks
 

--- a/.claude/skills/marketing-site-polish/references/pre-launch.md
+++ b/.claude/skills/marketing-site-polish/references/pre-launch.md
@@ -1,0 +1,183 @@
+# Pre-Launch External-System Checklist
+
+External-system steps that aren't in the codebase but block a clean launch. Walk through these with the user when they reach the pre-launch phase. Order matters loosely — email forwarding before legal review (so legal contact emails actually work); branch protection before first prod release.
+
+---
+
+## 1. Email forwarding for `hello@yourdomain.com`
+
+**Why it matters:** Privacy + Terms pages reference a contact email for GDPR / data-deletion / support. Stripe requires a privacy URL with a working contact. Without forwarding, those emails bounce.
+
+**Recommended setup** (~5 min):
+
+- **Domain on Cloudflare DNS:** use [Cloudflare Email Routing](https://developers.cloudflare.com/email-routing/) (free).
+- **Domain on Porkbun:** use Porkbun's free Email Forwarding. **Important:** see the Porkbun + ESP coexistence gotcha in `playbook-notes.md` if the project already has an ESP (Resend / SES / etc.) configured on a subdomain.
+- **Domain elsewhere (Namecheap, GoDaddy, etc.):** check if registrar has built-in forwarding; otherwise use ImprovMX (free up to 25 aliases).
+
+**Steps (Porkbun):**
+1. Domain Management → Email Hosting and Forwarding for the domain.
+2. **Don't click the "Fix DNS" auto-tool** if Resend / SES is already configured — it'll delete subdomain MX records. Manually add Porkbun MX on apex instead: `fwd1.porkbun.com` priority 10, `fwd2.porkbun.com` priority 20. Add Porkbun's SPF mechanism (`include:_spf.porkbun.com`) to the existing apex SPF (don't create a second SPF — RFC 7208 forbids).
+3. Add the forward alias: `hello` → personal inbox.
+4. Test: send from personal Gmail → `hello@yourdomain.com`. Should arrive within ~1 min.
+
+**Verify both directions** if the project sends outbound:
+- Inbound: external → `hello@yourdomain.com` arrives in your inbox
+- Outbound: trigger any transactional from the app → arrives via ESP
+
+---
+
+## 2. Branch protection on `main` + Semantic Release GitHub App
+
+**Why it matters:** Without branch protection, the team (or you, accidentally) can push directly to main. With branch protection enabled BUT no app token configured, the semantic-release workflow can't push the `chore(release): vX.Y.Z` commit that updates `docs/CHANGELOG.md` → releases break silently.
+
+**Wire BOTH at the same time:**
+
+1. **Install [Semantic Release GitHub App](https://github.com/apps/semantic-release-bot)** on the repo. Grant minimum permissions.
+2. **GitHub repo Settings → Branches → Branch protection rule for `main`:**
+   - Require pull request before merging
+   - Require status checks (CI, tests)
+   - **Allow specified actors to bypass:** add the Semantic Release App
+3. **Update `.github/workflows/release.yml`** to use the app's token via `actions/create-github-app-token@v2` instead of the default `GITHUB_TOKEN`.
+
+**Alternative (simpler but less clean):** use a PAT from your account with `contents: write`, save as `SEMANTIC_RELEASE_TOKEN` repo secret, add yourself to the bypass list.
+
+**Test:** merge a `feat:` commit to main. Verify:
+- GitHub release created
+- `chore(release): vX.Y.Z` commit pushed to main with `docs/CHANGELOG.md` updated
+- The `/changelog` page renders the new entry on next deploy
+
+---
+
+## 3. Legal review (Privacy + Terms)
+
+**Why it matters:** AI-drafted templates are a starting point, not a finish line. Governing law, refund policy, AI disclaimers, jurisdiction-specific compliance (GDPR, CCPA, India PDPB) — these need human review or a regulation-tracking service.
+
+**Options (pick one):**
+
+| Option | Cost | Best for |
+|---|---|---|
+| [Termly](https://termly.io/) | $10–30/mo | Indie SaaS; auto-updates with regulation changes; reviewable templates |
+| [Iubenda](https://www.iubenda.com/) | $30/year | Tightest defaults for EU; embeddable widget or copy-paste |
+| [GetTerms](https://getterms.io/) | Free tier | Quick baseline; no auto-update |
+| Lawyer | $300–500 one-time | Strong defensibility; for founded companies taking EU/US enterprise customers |
+
+**Steps:**
+
+1. Pick a service or counsel.
+2. Feed the existing draft `src/app/[locale]/(unauth)/privacy/page.tsx` + `terms/page.tsx` into it. Adjust based on output.
+3. **Required updates regardless of service:**
+   - Governing law (currently placeholder, e.g., `India`)
+   - Effective date (currently a fixed string — update to launch date)
+   - Company name / legal entity (currently bare brand name)
+   - Refund policy details (currently generic "case-by-case")
+   - Cookie banner if EU traffic expected (separate question — see #7)
+4. Replace `page.tsx` content with reviewed text. Keep the page chrome (Navbar/Footer wrapper) intact.
+
+---
+
+## 4. Product screenshots on landing
+
+**Why it matters:** Mock placeholders in the Hero / HowItWorks / Differentiators sections read as "demo not yet built." Real product screenshots increase trust signal materially.
+
+**What to capture** (5 shots covers most landings):
+
+1. The primary input flow (e.g., ideation textbox + generated drafts)
+2. The editor / main work surface
+3. Scheduling / management view
+4. Any unique differentiator (e.g., style customization, integration view)
+5. Mobile or alternate-channel view if the product supports it
+
+**Specs:**
+- **PNG** (not JPG — sharper for UI screenshots)
+- **2400×1500** (retina-friendly; Next.js Image downscales crisply)
+- Save under `public/landing/` with clear names
+- **Anonymous but realistic content** — fake user, generic but plausible data
+- Strip browser chrome (no URL bar, no tabs)
+- Optional: add a subtle border-radius + drop shadow in a tool like Figma so they look like "polished frames" rather than raw captures
+
+**Tools:** macOS Cmd+Shift+5 or [CleanShot](https://cleanshot.com/) for high-quality screenshots.
+
+---
+
+## 5. DMARC policy progression
+
+**Why it matters:** Starting at `p=none` is correct for safety, but it provides no enforcement. Once delivery is verified for a few weeks, ratchet up to `p=quarantine` (suspicious mail goes to spam) and eventually `p=reject` (failing mail bounces). Gmail and Yahoo require this for bulk senders since Feb 2024.
+
+**Progression:**
+
+1. **Launch:** `p=none` with `rua=mailto:dmarc-reports@yourdomain.com` (or use a free aggregator like [Postmark DMARC](https://dmarc.postmarkapp.com/)).
+2. **Week 2-4:** review the aggregate reports. Confirm all legitimate senders (your ESP, any third-party tools) are aligned. Fix any failures.
+3. **Month 1-3:** move to `p=quarantine` with `pct=25` (apply policy to 25% of failing mail). Watch for issues.
+4. **Month 3+:** ratchet to `p=quarantine pct=100`, then `p=reject` when confident.
+
+**TXT record** at `_dmarc.yourdomain.com`:
+```
+v=DMARC1; p=none; rua=mailto:dmarc-reports@yourdomain.com; fo=1
+```
+
+---
+
+## 6. OG image generation (per-page vs static)
+
+**Why it matters:** A single static `/og-image.png` works for the landing share but reads generic when articles get shared (every comparison post shows the same image). Per-article OG images using `next/og` or `@vercel/og` materially improve LinkedIn / Twitter CTR.
+
+**Decision matrix:**
+
+- **Low article volume + manual sharing:** static `/og-image.png` is fine. Don't over-engineer.
+- **>10 articles + active distribution:** wire `/api/og` route with `next/og` ImageResponse. Pass article title + category as query params. Reference in article `generateMetadata`.
+
+**For launch:** static is usually fine. File a GitHub issue to revisit once article volume + share traffic justifies the work.
+
+---
+
+## 7. Search Console verification + sitemap submission
+
+**Why it matters:** Google won't index the site quickly without explicit submission, and you won't see indexing health without verifying ownership.
+
+**Steps:**
+
+1. [Google Search Console](https://search.google.com/search-console) → Add property → domain or URL prefix.
+2. Verify via DNS TXT record (already present in template's setup script, usually).
+3. Submit sitemap: `https://yourdomain.com/sitemap.xml`.
+4. Use the URL Inspection tool to request indexing of the landing + key article pages.
+5. Optional but valuable: also submit to [Bing Webmaster Tools](https://www.bing.com/webmasters/) (Bing powers DuckDuckGo and Ecosia too).
+
+**Verify after a few days:**
+- Coverage report shows pages indexed
+- Sitemap shows successful read
+- No crawl errors on key URLs
+
+---
+
+## 8. Cookie banner (conditional)
+
+**Why it matters:** GDPR / ePrivacy require consent for non-essential cookies in EU/UK. If you run any analytics or marketing pixels and expect any EU traffic, you need this.
+
+**Defer if:**
+- Day-1 launch is targeted at non-EU (US-only beta, etc.)
+- No analytics beyond strictly-necessary (auth session cookies only)
+
+**Set up if:**
+- Running PostHog, GA, Mixpanel, etc. AND expect EU/UK users
+- Running paid ads in EU/UK (compliance requirement)
+- Targeting enterprise customers who'll audit privacy posture
+
+**Recommended:** [react-cookie-consent](https://github.com/Mastermindzh/react-cookie-consent) for a quick implementation; [CookieYes](https://www.cookieyes.com/) for a managed service with auto-scanning.
+
+---
+
+## Pre-launch readiness gate (final checklist)
+
+Before announcing "we're live":
+
+- [ ] Email forwarding works (inbound + outbound verified)
+- [ ] Branch protection on; semantic-release App can push CHANGELOG commits
+- [ ] Privacy + Terms reviewed and live
+- [ ] About page customized (not template default)
+- [ ] All footer + nav links return 200 (no 404s)
+- [ ] Sitemap + robots accessible at `/sitemap.xml` and `/robots.txt`
+- [ ] Search Console verified, sitemap submitted
+- [ ] OG image / share preview tested (LinkedIn Post Inspector, Twitter Card Validator)
+- [ ] Login / Sign Up dialog opens from every unauth page (not just landing)
+- [ ] DMARC at minimum `p=none` with `rua` reporting address
+- [ ] 404 page on-brand (not Next.js default)


### PR DESCRIPTION
## Summary

Adds a Claude Code skill at `.claude/skills/marketing-site-polish/` that codifies the playbook for getting a vt-saas-template-derived SaaS's unauthenticated surface launch-ready. When a user invokes this skill, Claude acts as a marketing & launch expert agency — auditing current state, brainstorming priorities, executing in logical commits, and walking through pre-launch infrastructure (email forwarding, branch protection + semantic-release, legal review, screenshots).

## Why this exists

Every project derived from this template hits the same launch-prep work: navbar polish, footer restructure, About / Privacy / Terms pages, SEO scaffolding, auth-redirect patterns, blog setup, email forwarding, branch protection. The first time, it's a couple of weeks of figuring out what to do and what order to do it in. The second time, you remember most of it but lose ~20% of the lessons to forgetting. By the third project, you've re-derived gotchas you already paid for once (e.g., Porkbun's auto-DNS deleting Resend MX records).

This skill captures the playbook so the next launch starts from "we know what good looks like, where the rakes are, and what the standardized decisions already are."

## What's in the skill

Three files, ~420 lines total:

- **`SKILL.md`** — partner stance (substantive bullets, no boilerplate "this before that"), audit map with drift caveat, reference pointers, phase suggestions, out-of-scope list
- **`references/playbook-notes.md`** — standardized decisions (em-dash separator, max-w-3xl article body, footer column order, Resources dropdown threshold, etc.) + concrete gotchas (pSEO dev-cache, Porkbun + Resend coexistence, AuthDialogProvider scope, locale-aware Link, semantic-release + branch protection, formatter race, MDX sed)
- **`references/pre-launch.md`** — 8 external-system items with steps/verify each (email forwarding, branch protection + Semantic Release App, legal review, screenshots, DMARC progression, OG images, Search Console, cookie banner)

## Design principles

- **Sparse by default.** Most of what Claude needs for this work, Claude can figure out. The skill provides only what Claude *can't* derive: the codified decisions and gotchas. Generic best practices are NOT in the skill.
- **Partner stance, not procedural script.** No step-files, no enforced gates. The skill defines a voice (marketing & launch expert agency) and provides reference material; the work itself is creative and iterative.
- **Drift caveat at the top of the audit map.** Acknowledges that the template evolves and project forks diverge — verify file paths exist before reading.

Authored following [`craft-spell`](https://github.com/thevarun/vt-spells) conventions (sparse + partner stance variant).

## Genesis

Battle-tested across the [ContentFlow launch polish session](https://github.com/thevarun/ContentFlow/pull/262) — 35+ commits of marketing-site work. The skill was authored at the end of that session capturing what was learned. Bundling it upstream so future template-derived projects inherit the playbook from day one rather than re-deriving it.

## Adjustments made for upstream

The skill files in ContentFlow had a few project-specific references (`/articles` route, named competitors, `production-deploy` sibling skill). For upstream they were genericized:

- Audit map now lists `src/templates/Navbar.tsx` (template default) before the alternative `src/components/landing/` paths
- Auth-flow reference covers both the template's page-based auth (`(unauth)/(center)/sign-in/`) and the optional overlay-dialog pattern
- Named competitor examples use `{YourProduct} vs {Competitor}` placeholders
- Removed assumption that `production-deploy` skill is present (made it conditional)

## Test plan

Manual smoke test, since skill behavior is in Claude's interpretation rather than executable code:

- [ ] Clone this branch into a new directory; `npx claude` invoke the skill via "polish my marketing site for launch"
- [ ] Verify Claude reads only the files in the AUDIT MAP (not exhaustive grep)
- [ ] Verify partner stance comes through in proposals (taste-calibrated recommendations, not rule-based)
- [ ] Verify gotchas surface when a relevant trigger appears (e.g., user adds pSEO content → skill notes the dev-cache restart issue)

## Related context

- Resources dropdown pattern: [#300](https://github.com/thevarun/vt-saas-template/issues/300)
- AuthDialog overlay pattern: [#301](https://github.com/thevarun/vt-saas-template/issues/301)
- Em-dash brand auto-suffix: [#302](https://github.com/thevarun/vt-saas-template/issues/302)
- Legal-page scaffolds: [#303](https://github.com/thevarun/vt-saas-template/issues/303)
- pSEO dev-cache: [#297](https://github.com/thevarun/vt-saas-template/pull/297)
- Semantic-release changelog: [#298](https://github.com/thevarun/vt-saas-template/pull/298)
- /articles → /blog rename: [#299](https://github.com/thevarun/vt-saas-template/pull/299)

The skill's playbook references some of these (em-dash convention, `/blog` route, pSEO cache bypass). Those PRs/issues being merged or actioned will increase the skill's accuracy over time.