### PR TITLE
feat(ci): automated docs sync workflow

### DIFF
--- a/.github/docs-sync.config.json
+++ b/.github/docs-sync.config.json
@@ -1,0 +1,14 @@
+{
+  "allowlist": [
+    "docs/**/*.md",
+    "CLAUDE.md",
+    "AGENTS.md",
+    "README.md"
+  ],
+  "denylist": [
+    "docs/CHANGELOG.md",
+    "docs/changelog/**",
+    "CHANGELOG.md"
+  ],
+  "rangeDays": 7
+}

--- a/.github/prompts/docs-quick-update.md
+++ b/.github/prompts/docs-quick-update.md
@@ -1,0 +1,477 @@
+---
+description: 'Detect code changes and suggest targeted documentation updates'
+---
+
+# Docs Quick Update
+
+You are a documentation maintenance assistant. Analyze code changes and suggest targeted documentation updates for affected docs.
+
+## Overview
+
+This command intelligently detects code changes and proposes documentation updates:
+1. Detects change scope (uncommitted, branch diff, or recent commits)
+2. Analyzes what changed (features, APIs, config, refactors)
+3. Finds docs that reference changed code
+4. Detects dead references (deleted/renamed code still mentioned)
+5. Generates an update plan with user confirmation
+
+## CLI Arguments
+
+| Argument | Description |
+|----------|-------------|
+| (none) | Smart auto-detect: uncommitted → branch diff → recent commits |
+| `--uncommitted` | Only analyze staged/unstaged changes |
+| `--branch` | Compare current branch vs main |
+| `--yolo` | Skip confirmation, apply all updates directly |
+| `--ci` | Non-interactive CI mode — see "CI Mode" section below |
+
+## Target Documents (Auto-Detected)
+
+The command scans for these doc locations:
+- `./docs/` folder (if exists)
+- `CLAUDE.md`
+- `AGENTS.md`
+- `README.md`
+
+---
+
+## Workflow Phases
+
+<steps>
+
+### Phase 0: Pre-flight Checks
+
+1. **Verify git repository**
+   - Run `git rev-parse --is-inside-work-tree`
+   - If not a git repo: Stop with message "Not a git repository. This command requires git to detect changes."
+
+2. **Parse CLI arguments**
+   - Check if `$ARGUMENTS` contains `--branch`, `--uncommitted`, or `--yolo`
+   - Store flags for later use
+
+3. **Discover existing docs**
+   - Check for `./docs/` folder
+   - Check for `CLAUDE.md`, `AGENTS.md`, `README.md` at project root
+   - Build list of doc paths that exist
+   - If no docs found: Stop with message "No documentation files found. Expected: docs/, CLAUDE.md, AGENTS.md, or README.md"
+
+4. **Display pre-flight summary:**
+   ```
+   Docs Quick Update
+   =================
+   Flags: {--branch | --uncommitted | --yolo | auto-detect}
+   Docs found: {list of doc paths}
+   ```
+
+### Phase 1: Smart Change Detection
+
+Determine which changes to analyze based on flags or auto-detection:
+
+**If `--uncommitted` flag:**
+- Use: `git diff HEAD` (staged + unstaged)
+- Scope label: "Uncommitted changes"
+
+**If `--branch` flag:**
+- Detect main branch: `git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null || echo "main"`
+- Use: `git diff {main}...HEAD`
+- Scope label: "Branch diff vs {main}"
+
+**If no flag (auto-detect):**
+1. Check for uncommitted changes: `git status --porcelain`
+   - If changes exist → use uncommitted scope
+2. Check if on feature branch: `git branch --show-current`
+   - If not main/master → suggest branch diff, ask user to confirm
+3. Fallback: use last 5 commits on main
+   - Use: `git diff HEAD~5...HEAD`
+   - Scope label: "Recent commits (last 5)"
+
+**Display scope summary:**
+```
+Change Scope
+============
+Mode: {scope label}
+Command: {git diff command used}
+
+Proceed with this scope? [Y/n]
+```
+
+Unless `--yolo` flag is set, use `AskUserQuestion` to confirm or let user override:
+```
+header: "Scope"
+question: "Use this change scope for doc analysis?"
+options:
+  - label: "Yes, proceed"
+    description: "{scope label}"
+  - label: "Use uncommitted only"
+    description: "Staged and unstaged changes"
+  - label: "Use branch diff"
+    description: "All commits on current branch vs main"
+```
+
+### Phase 2: Analyze Changes
+
+1. **Run the git diff command** determined in Phase 1
+   - Capture full diff output
+
+2. **Parse diff output** and extract:
+   - Files added/modified/deleted
+   - Function/class names changed (look for `function`, `class`, `def`, `const`, `export`)
+   - File renames (look for `rename from`/`rename to` in diff)
+
+3. **Categorize changes:**
+
+   | Category | Detection Signals |
+   |----------|-------------------|
+   | New features | New files, new exports, new functions |
+   | API changes | Modified function signatures, changed exports |
+   | Config changes | Changes to `*.config.*`, `package.json`, env files |
+   | Refactors | Renamed files, moved code, internal changes |
+   | Deletions | Removed files, removed exports, removed functions |
+
+4. **Build change summary:**
+   ```
+   Change Analysis
+   ===============
+   Files changed: {count}
+
+   By category:
+   - New features: {list}
+   - API changes: {list}
+   - Config changes: {list}
+   - Refactors: {list}
+   - Deletions: {list}
+
+   Key identifiers affected:
+   - Functions: {list}
+   - Exports: {list}
+   - Files renamed: {old} → {new}
+   ```
+
+### Phase 3: Doc Discovery & Relevance
+
+1. **Read each discovered doc file**
+
+2. **For each doc, cross-reference with changes:**
+   - Search for mentions of changed file paths
+   - Search for mentions of changed function/class names
+   - Search for mentions of deleted/renamed identifiers
+
+3. **Detect dead references:**
+   - If doc mentions a deleted file → flag as dead reference
+   - If doc mentions a renamed file by old name → flag as dead reference
+   - If doc mentions a deleted function/export → flag as dead reference
+
+4. **Rank docs by update priority:**
+
+   | Priority | Criteria |
+   |----------|----------|
+   | HIGH | Contains dead references (deleted/renamed code) |
+   | MEDIUM | References files/functions that changed |
+   | LOW | General project docs that might need refresh |
+
+5. **Build relevance map:**
+   ```
+   Doc Relevance Analysis
+   ======================
+
+   [HIGH] README.md
+     - Dead reference: mentions deleted function `oldHelper()`
+     - Stale: references `src/utils.js` (renamed to `src/helpers.js`)
+
+   [MEDIUM] CLAUDE.md
+     - References modified: `install.js`
+     - May need update for new export `newFeature`
+
+   [LOW] docs/api.md
+     - General API docs, no direct references found
+   ```
+
+### Phase 4: Generate Update Plan
+
+For each doc needing updates, generate specific recommendations:
+
+1. **For dead references:**
+   - Identify exact line/section
+   - Recommend: remove reference, or update to new name
+
+2. **For stale content:**
+   - Identify section that references changed code
+   - Summarize what changed and suggest update
+
+3. **Format update plan:**
+   ```
+   Documentation Update Plan
+   =========================
+
+   README.md (2 updates needed)
+   ├── [1] Remove reference to deleted `oldHelper()` function
+   │       Section: "API Reference"
+   │       Action: Remove or replace with new equivalent
+   │
+   └── [2] Update file path `src/utils.js` → `src/helpers.js`
+           Section: "Project Structure"
+           Action: Find/replace old path with new
+
+   CLAUDE.md (1 update needed)
+   └── [1] Document new export `newFeature`
+           Section: "Development Commands" or new section
+           Action: Add brief description of new functionality
+
+   Total: 3 updates across 2 files
+   ```
+
+### Phase 5: User Confirmation
+
+**If `--yolo` flag:** Skip to Phase 6 (apply all updates)
+
+**Otherwise:** Use `AskUserQuestion` with `multiSelect: true`:
+
+```
+header: "Updates"
+question: "Which documentation updates should be applied?"
+multiSelect: true
+options:
+  - label: "All updates"
+    description: "Apply all {N} recommended updates"
+  - label: "README.md updates"
+    description: "{N} updates: {brief summary}"
+  - label: "CLAUDE.md updates"
+    description: "{N} updates: {brief summary}"
+  - label: "Skip all"
+    description: "Exit without making changes"
+```
+
+If user selects individual docs, confirm each update within that doc.
+
+### Phase 6: Apply Updates
+
+For each approved update:
+
+1. **Read the target doc file**
+
+2. **Make the specific edit:**
+   - For dead reference removal: Delete the line/paragraph
+   - For path updates: Find/replace old path with new
+   - For new content: Add to appropriate section
+
+3. **Preserve doc structure:**
+   - Maintain existing headings and formatting
+   - Only modify relevant sections
+   - Don't reorganize or reformat unrelated content
+
+4. **Track changes made:**
+   - Record each edit for summary
+
+### Phase 7: Completion Summary
+
+Display final summary:
+
+```
+================================
+DOCUMENTATION UPDATE COMPLETE
+================================
+
+Changes Applied:
+- README.md: 2 updates
+  ✓ Removed dead reference to `oldHelper()`
+  ✓ Updated path `src/utils.js` → `src/helpers.js`
+
+- CLAUDE.md: 1 update
+  ✓ Added documentation for `newFeature` export
+
+Suggested Commit Message:
+  docs: update documentation for recent code changes
+
+Files Changed:
+- README.md
+- CLAUDE.md
+
+To Revert:
+  git checkout README.md CLAUDE.md
+```
+
+</steps>
+
+---
+
+## Safety Rules
+
+**CRITICAL - These rules must NEVER be violated:**
+
+1. **NEVER edit docs without user confirmation** (unless `--yolo` or `--ci` flag is set)
+2. **Always show the update plan** before applying changes (even with `--yolo`, show summary after)
+3. **Preserve doc structure** - only update relevant sections, don't reorganize
+4. **Don't add unverifiable content** - only document what can be confirmed from code changes
+5. **Keep edits minimal** - fix specific issues, don't rewrite entire sections
+6. **Always provide revert instructions** - user should be able to undo easily
+
+---
+
+## CI Mode (`--ci`)
+
+For non-interactive execution from CI (e.g., GitHub Actions). When `--ci` is set, override the default workflow as follows.
+
+### Behavior overrides
+
+1. **Treat as `--yolo`** — skip every `AskUserQuestion` call. Apply all proposed updates directly. Skip Phase 5 (User Confirmation) entirely.
+2. **Do not commit or push** — leave changes in the working tree. The CI workflow handles git operations.
+3. **Empty diff is a clean exit** — if no doc updates are needed, exit normally without error. Do not print revert instructions.
+
+### Project configuration
+
+Load `.github/docs-sync.config.json` from the repo root. If missing, use defaults below.
+
+**Schema:**
+
+```json
+{
+  "allowlist": ["docs/**/*.md", "CLAUDE.md"],
+  "denylist": [],
+  "rangeDays": 7
+}
+```
+
+**Defaults** (when config is missing or a field is omitted):
+
+| Field | Default |
+|---|---|
+| `allowlist` | `["docs/**/*.md", "CLAUDE.md", "AGENTS.md", "README.md"]` |
+| `denylist` | `[]` |
+| `rangeDays` | `7` |
+
+### Override Phase 1 (Smart Change Detection)
+
+Do NOT auto-detect via `git status` / `git branch`. Instead:
+
+1. Compute the diff range:
+   ```bash
+   SINCE_SHA=$(git rev-list -n 1 --before="${rangeDays} days ago" HEAD || git rev-list --max-parents=0 HEAD)
+   RANGE="${SINCE_SHA}..HEAD"
+   ```
+2. Run `git diff $RANGE` and use that as the diff to analyze in Phase 2.
+3. If the diff is empty, exit cleanly.
+
+### Override Phase 6 (Apply Updates)
+
+- Only edit files matching `allowlist`.
+- Never edit files matching `denylist`.
+- After editing, do NOT run `git add`, `git commit`, or `git push`. The workflow handles it.
+
+### Output
+
+Replace the Phase 7 completion summary with a concise log:
+
+```
+[docs-sync] Range: <range>
+[docs-sync] Edited: <file> — <one-line reason>
+[docs-sync] Edited: <file> — <one-line reason>
+[docs-sync] Done. <N> file(s) modified.
+```
+
+If no files were edited:
+
+```
+[docs-sync] Range: <range>
+[docs-sync] No documentation updates needed.
+```
+
+---
+
+## Change Category Detection
+
+| Category | File Patterns | Code Patterns |
+|----------|---------------|---------------|
+| New features | New files in `src/`, `lib/` | `export`, new functions |
+| API changes | Modified exports, signatures | `function.*\(`, `export {` |
+| Config changes | `*.config.*`, `package.json` | JSON keys, env vars |
+| Refactors | File renames, moves | Import path changes |
+| Deletions | Removed files | Removed exports/functions |
+
+---
+
+## Error Handling
+
+| Scenario | Action |
+|----------|--------|
+| Not a git repo | Stop with clear error message |
+| No docs found | Stop with message listing expected locations |
+| No changes detected | Stop with message "No changes found in the specified scope" |
+| Empty diff | Report "No code changes to analyze" |
+| Doc file unreadable | Skip that file, warn user |
+| Git command fails | Report error with the specific command |
+
+---
+
+## Example Session
+
+```
+User: /docs-quick-update
+
+Claude: Docs Quick Update
+=================
+Flags: auto-detect
+Docs found: README.md, CLAUDE.md, docs/
+
+Change Scope
+============
+Mode: Uncommitted changes (auto-detected)
+Files with changes: 3
+
+[Analyzing changes...]
+
+Change Analysis
+===============
+Files changed: 3
+- Modified: src/install.js
+- Renamed: src/utils.js → src/helpers.js
+- Deleted: src/legacy.js
+
+Documentation Update Plan
+=========================
+
+README.md (2 updates needed)
+├── [1] Update file path `src/utils.js` → `src/helpers.js`
+└── [2] Remove reference to deleted `src/legacy.js`
+
+CLAUDE.md (1 update needed)
+└── [1] Update "Key Files" section with renamed file
+
+[Question] Which documentation updates should be applied?
+> All updates
+
+Applying updates...
+
+DOCUMENTATION UPDATE COMPLETE
+=============================
+Changes Applied:
+- README.md: 2 updates ✓
+- CLAUDE.md: 1 update ✓
+
+Suggested Commit Message:
+  docs: update documentation for recent code changes
+```
+
+---
+
+## Example with --yolo Flag
+
+```
+User: /docs-quick-update --yolo
+
+Claude: Docs Quick Update (YOLO mode)
+=====================================
+Skipping confirmations, applying all updates directly...
+
+[Auto-detected scope: uncommitted changes]
+[Found 2 updates across 2 docs]
+[Applying all updates...]
+
+DOCUMENTATION UPDATE COMPLETE
+=============================
+Changes Applied:
+- README.md: 1 update ✓
+- CLAUDE.md: 1 update ✓
+
+Suggested Commit Message:
+  docs: update documentation for recent code changes
+```

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -1,0 +1,174 @@
+name: Docs Sync
+
+# Automated documentation maintenance via /meta:docs-quick-update --ci.
+#
+# How it works:
+#   - Push to main touching watched code surfaces → workflow runs.
+#   - Cold periods (no relevant changes) cost zero GHA minutes (paths filter).
+#   - Concurrency-grouped + queued: rapid back-to-back merges process in order.
+#   - Single rolling PR on `docs-sync/auto` accumulates updates; one open PR max.
+#   - Project-specific behavior lives in `.github/docs-sync.config.json`
+#     (allowlist, denylist, diff window).
+#
+# Prerequisites:
+#   - Run `/install-github-app` in Claude Code first to set up the Claude
+#     Code GitHub App and configure `CLAUDE_CODE_OAUTH_TOKEN` repo secret.
+#
+# Per-project tuning:
+#   - Adjust the `paths:` filter below to match your project's documented
+#     code surfaces.
+#   - Adjust `.github/docs-sync.config.json` for allowlist/denylist/range.
+#
+# The vendored command at `.github/prompts/docs-quick-update.md` is a copy of
+# `meta:docs-quick-update` from the vt-spells private plugin marketplace.
+# Refresh by overwriting that file when the upstream command improves.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      # Adjust these for your project. Defaults below cover common surfaces
+      # in a vt-saas-template-derived app.
+      - 'src/models/**'
+      - 'src/libs/**'
+      - 'src/app/api/**'
+      - src/proxy.ts
+      - src/instrumentation.ts
+  workflow_dispatch: {}
+
+concurrency:
+  group: docs-sync
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+
+    steps:
+      - name: Checkout main with full history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Skip if commit is cosmetic (Conventional Commits filter)
+        id: filter
+        if: github.event_name == 'push'
+        run: |
+          set -euo pipefail
+          SUBJECT=$(git log -1 --format=%s)
+          echo "Commit subject: $SUBJECT"
+          # Skip prefixes that are unlikely to need doc updates.
+          # Matches both bare (chore:) and scoped (chore(deps):) forms.
+          if echo "$SUBJECT" | grep -qE '^(chore|test|style|ci|build|refactor|docs|perf)(\([^)]+\))?!?:'; then
+            echo "Cosmetic / non-feature commit — skipping docs sync."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check for existing rolling PR
+        if: steps.filter.outputs.skip != 'true'
+        id: existing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          PR_NUMBER=$(gh pr list --head docs-sync/auto --state open --json number --jq '.[0].number // empty')
+          if [ -n "$PR_NUMBER" ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Found existing rolling PR #$PR_NUMBER"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "No existing rolling PR"
+          fi
+
+      - name: Prepare rolling branch
+        if: steps.filter.outputs.skip != 'true'
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if [ "${{ steps.existing.outputs.exists }}" = "true" ]; then
+            git fetch origin docs-sync/auto
+            git checkout docs-sync/auto
+            if ! git rebase origin/main; then
+              git rebase --abort
+              echo "::error::Rebase of docs-sync/auto onto main failed. Resolve manually on the PR, then re-run."
+              exit 1
+            fi
+          else
+            git checkout -b docs-sync/auto
+          fi
+
+      - name: Load command prompt
+        if: steps.filter.outputs.skip != 'true'
+        run: |
+          {
+            echo 'DOCS_PROMPT<<PROMPT_EOF'
+            cat .github/prompts/docs-quick-update.md
+            echo ""
+            echo "---"
+            echo ""
+            echo "Execute the command above with the \`--ci\` flag."
+            echo 'PROMPT_EOF'
+          } >> "$GITHUB_ENV"
+
+      - name: Run Claude docs-quick-update --ci
+        if: steps.filter.outputs.skip != 'true'
+        # Pinned to v1.0.133. Dependabot will bump as new releases ship.
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: --model claude-sonnet-4-6
+          prompt: ${{ env.DOCS_PROMPT }}
+
+      - name: Commit and push doc updates
+        if: steps.filter.outputs.skip != 'true'
+        id: commit
+        run: |
+          set -euo pipefail
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "No documentation changes produced. Exiting clean."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git add -A
+          git commit -m "docs: sync with code changes through ${GITHUB_SHA:0:7}"
+          git push origin docs-sync/auto
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Open rolling PR if new
+        if: steps.commit.outputs.changed == 'true' && steps.existing.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create \
+            --base main \
+            --head docs-sync/auto \
+            --title "docs: automated documentation sync" \
+            --body "$(cat <<'EOF'
+          Auto-generated documentation updates from recent code changes on `main`.
+
+          **Source command:** `/meta:docs-quick-update --ci`
+          **Config:** `.github/docs-sync.config.json`
+          **Workflow:** `.github/workflows/docs-sync.yml`
+
+          ### How this PR evolves
+
+          This is a **rolling PR**. Future runs push additional commits to `docs-sync/auto` rather than opening new PRs. Merge when you're happy with the current state; the next relevant code change on `main` opens a fresh rolling PR.
+
+          ### If a suggestion is wrong
+
+          Just edit the file directly on the `docs-sync/auto` branch. The next workflow run will rebase onto `main` and add new commits on top of your edits.
+          EOF
+          )"

--- a/README.md
+++ b/README.md
@@ -96,6 +96,20 @@ npm run db:studio        # Open Drizzle Studio
 npm run db:generate      # Generate migration from schema
 ```
 
+### Optional: Claude-Powered Docs Sync
+
+An automated docs-maintenance workflow ships with this template (`.github/workflows/docs-sync.yml`). On pushes to `main` that touch watched code surfaces, Claude reviews recent changes and accumulates documentation updates into a single rolling PR on the `docs-sync/auto` branch. Cold periods cost zero GitHub Actions minutes — the path filter prevents the workflow from starting.
+
+**One-time setup per repo:**
+
+1. Run `/install-github-app` in Claude Code (terminal). This installs the Claude Code GitHub App and configures the `CLAUDE_CODE_OAUTH_TOKEN` repo secret.
+2. Adjust the `paths:` filter in `.github/workflows/docs-sync.yml` to match your project's documented code surfaces (default covers `src/libs`, `src/models`, `src/app/api`, etc.).
+3. Adjust `.github/docs-sync.config.json` — `allowlist` / `denylist` (which doc files Claude may edit) and `rangeDays` (diff window).
+
+**To disable:** delete `.github/workflows/docs-sync.yml`.
+
+The workflow vendors a copy of the upstream `meta:docs-quick-update` command at `.github/prompts/docs-quick-update.md` — refresh that file when the upstream command improves.
+
 ## Customizing This Template
 
 ### Quick Rebrand Checklist


### PR DESCRIPTION
## Summary

Adds an automated documentation maintenance workflow that runs Claude on pushes to `main` and accumulates doc updates into a single rolling PR.

### Files

- `.github/workflows/docs-sync.yml` — the workflow (template-generic; only `paths:` filter is project-specific)
- `.github/docs-sync.config.json` — allowlist / denylist / `rangeDays` (per-project tuning)
- `.github/prompts/docs-quick-update.md` — verbatim copy of the upstream `meta:docs-quick-update` command (vendored because `vt-spells` is private)
- `README.md` — adds an "Optional: Claude-Powered Docs Sync" subsection under Development with one-time setup steps

### Design (one-liners)

- **Trigger**: push to `main` with `paths:` filter → zero GHA cost in cold periods
- **Rolling PR** on `docs-sync/auto` → one open PR at a time, accumulates commits
- **7-day diff window** (configurable via `rangeDays`); current doc state is read fresh each run, so re-analysis of already-documented changes is harmless
- **Concurrency-grouped, queued** (not cancelled) → back-to-back merges process in order
- **Cosmetic-commit filter** → skips `chore:`/`test:`/`style:`/`ci:`/`build:`/`refactor:`/`docs:`/`perf:` commits cheaply
- **Bot self-trigger** blocked via `github.actor` check
- **Action pinned to SHA** (Dependabot auto-bumps via the existing `github-actions` ecosystem)
- **Model**: Sonnet 4.6 (Opus is overkill for diff-driven doc patching)

### Prerequisite

Each repo that adopts this needs `/install-github-app` run once in Claude Code (terminal) to install the Claude Code GitHub App and configure `CLAUDE_CODE_OAUTH_TOKEN`. README documents this.

### Origin

First built and validated in [ContentFlow #267](https://github.com/thevarun/ContentFlow/pull/267). The upstream command's `--ci` mode was added in [`vt-spells` meta@0.17.1](https://github.com/thevarun/vt-spells).

## Test plan

- [ ] Merge this PR
- [ ] Validate in a derived project (e.g., ContentFlow already running it)
- [ ] When propagating to existing forks: copy the three new files + README diff, adjust `paths:` filter for that project's documented code surfaces