### PR TITLE
ci: add Claude Code review + @claude workflows and document template-contribution flow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,67 @@
+name: Claude Code Review
+
+# The code-review plugin ends its session on a TodoWrite tool call, which
+# orphans the captured `result` (empty string) so the action posts nothing in
+# default mode (upstream bug, still open: anthropics/claude-code-action#1087).
+# Workaround: the `--comment` flag below makes the plugin post findings as
+# inline PR comments DURING the session via `gh`, so it no longer depends on
+# the orphaned final result.
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+    # Optional: Only run on specific file changes
+    # paths:
+    #   - "src/**/*.ts"
+    #   - "src/**/*.tsx"
+    #   - "src/**/*.js"
+    #   - "src/**/*.jsx"
+  workflow_dispatch:
+
+jobs:
+  claude-review:
+    # Only run for real PR events — a manual `workflow_dispatch` would leave
+    # `github.event.pull_request.number` unset and the prompt would interpolate
+    # an empty PR target, reviewing nothing.
+    if: github.event_name == 'pull_request'
+    # Optional: Filter by PR author
+    # if: |
+    #   github.event.pull_request.user.login == 'external-contributor' ||
+    #   github.event.pull_request.user.login == 'new-developer' ||
+    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+
+    runs-on: ubuntu-latest
+    # `pull-requests: write` + `issues: write` so the plugin's inline `gh`
+    # comments can actually be posted (PR review comments ride the issues API
+    # under the hood). No `contents: write` — this job never pushes.
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Required for Claude to read CI results on PRs (correlate failing
+          # checks with the code under review).
+          additional_permissions: |
+            actions: read
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: code-review@claude-code-plugins
+          # `--comment` posts findings as inline PR comments during the session
+          # (works around the TodoWrite-orphan bug — see header). If a test PR
+          # produces a clean run but posts nothing, the plugin's `gh` calls are
+          # likely being denied by the default sandbox allowlist — uncomment:
+          # claude_args: --allowedTools "Bash(gh:*)"
+          prompt: '/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,70 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    # Two gates, both must pass per event:
+    #   1. An `@claude` mention in the triggering body/title.
+    #   2. The *triggering actor* is a trusted collaborator
+    #      (OWNER/MEMBER/COLLABORATOR). The association is read from the field
+    #      that belongs to the actor for that event (the commenter for
+    #      *_comment, the reviewer for pull_request_review, the opener for
+    #      issues) — NOT a sibling field, so a trusted user's issue can't be
+    #      hijacked by an untrusted `@claude` comment.
+    # claude-code-action already enforces "write access required" by default,
+    # but this repo is PUBLIC, so we gate by author_association as defense in
+    # depth — it stops a drive-by `@claude` from a random account before the
+    # job (with its write token) ever starts. Keep this if you later enable
+    # `allowed_non_write_users`, which would otherwise relax the action's check.
+    if: |
+      (github.event_name == 'issue_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' &&
+        contains(github.event.review.body, '@claude') &&
+        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' &&
+        (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr *)'

--- a/docs/upstream-sync-guide.md
+++ b/docs/upstream-sync-guide.md
@@ -211,3 +211,27 @@ git remote remove upstream       # remove broken remote
 git remote add upstream https://github.com/thevarun/vt-saas-template.git
 git fetch upstream --tags
 ```
+
+---
+
+## Contributing changes back to the template
+
+The template is the **source of truth for shared code** — anything generic enough to help the *next* product belongs here, not just in one fork. Keeping a single lineage (rather than divergent copies across forks) is the whole point of the template.
+
+### Principle: template-first
+
+- **Build it in the template first** when you already know a change is generic — tooling, CI, build config, infra, auth, DB workflow, shared UI/primitives, error/API conventions. It lands once and every fork inherits it on the next sync. Per-fork edits multiply the work N times.
+- **Contribute it back** when something built inside a product turns out to be reusable. Don't leave two copies drifting.
+
+### Flow for contributing back (product → template)
+
+1. Branch the **template** repo (not the product).
+2. Copy the file(s) over and **strip product specifics** — branding, copy, product-domain endpoints, hardcoded routes — until it's generic.
+3. Open a PR on the template, review, merge, and let semantic-release **tag** it.
+4. Pull it back into the product via `/upstream-sync` (or `git fetch upstream --tags` + merge the new tag). Resolve the one conflict where your local copy meets the now-generic version, then delete the product-local copy.
+
+### Anti-patterns
+
+- ❌ Editing shared code in the product and cherry-picking commits up to the template — it works (shared history), but it inverts ownership and you'll fight drift forever.
+- ❌ Maintaining a product-local fork of code that also lives in the template — pick one home (the template) and sync.
+- ✅ **Exception:** product-specific, urgent (security/outage), or experimental/unproven changes may land in the product first; promote to the template once stable.


### PR DESCRIPTION
## What

Adds the GitHub Claude Code integration to the template and documents the product→template contribution loop:

- **`.github/workflows/claude-code-review.yml`** — automated PR review via the `code-review` plugin. Runs on PR open/sync/ready/reopen (plus manual `workflow_dispatch`, guarded so a manual run can't interpolate an empty PR number). Uses the `--comment` flag so findings post as inline PR comments during the session, working around the upstream TodoWrite-orphan bug ([claude-code-action#1087](https://github.com/anthropics/claude-code-action/issues/1087)) where default mode posts nothing. Permissions include `pull-requests: write` + `issues: write` so inline comments can actually be posted.
- **`.github/workflows/claude.yml`** — `@claude` mention handler for issues, PRs, and reviews. `contents: write` + `pull-requests: write` so it can push fixes and edit PR descriptions; `actions: read` so it can read CI results on PRs.
- **`docs/upstream-sync-guide.md`** — appends a generic "Contributing changes back to the template" section (template-first principle, product→template flow, anti-patterns).

## Why

These are net-new on `main` (a bare "Add Claude" wizard scaffold exists only on an unmerged, PR-less branch — this lands the refined, bug-worked-around versions instead). Landing the review bot first means every subsequent template-contribution PR gets auto-reviewed. The docs section closes the loop by documenting how reusable code flows from a fork back into the template.

## Notes

- No new dependencies.
- Both workflows reuse the existing **`CLAUDE_CODE_OAUTH_TOKEN`** repo secret (already referenced by `docs-sync.yml`). The YAML merges and parses without it; the bot only runs once the secret is configured.
- `actions/checkout@v6` pinned to match every other template workflow.
- Fully generic — no product-specific branding, schema, routes, or platform references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)