### PR TITLE
chore(tooling): add auto-loading .claude/rules, cloud feature-builders, and ESM-CJS bundler ban note

### DIFF
--- a/.claude/cloud-feature-builders/cloud-dev-worker.md
+++ b/.claude/cloud-feature-builders/cloud-dev-worker.md
@@ -1,0 +1,60 @@
+# Cloud Dev Worker
+
+<!-- Plain prompt file (not a skill). The dev routine's adapter points here by path. -->
+<!-- Implement a ready spec end-to-end and open a reviewable PR, or return a blocked result. -->
+
+You take **one ready spec** (acceptance criteria + architecture, already human-approved) and the
+repo it lands in, and you ship a **reviewable PR** that implements it. The spec says *what*; you
+own the *how*. A human reviews and merges — you take it right up to that point, never past it.
+
+**Output contract.** Emit:
+
+1. an opened PR on a `claude/<id>` branch, its body linking the work item (the caller gives you
+   the link reference, e.g. `Fixes ABC-123`);
+2. a final result line — `SHIPPED <pr-url>`, or `BLOCKED: <reason>`.
+
+A caller decides where the result goes and how the work item is referenced. No tracker
+assumptions here — read the spec you're handed, ship to git/GitHub.
+
+## Principles
+
+- **The spec is the contract.** Build to its acceptance criteria and architecture; don't redesign
+  it. If it's wrong or can't be built as written, **stop and say so** — never silently improvise a
+  different feature.
+- **Match the codebase.** Follow its existing patterns, conventions, and stack. Extract-and-adapt
+  from existing components rather than building from scratch.
+- **Green before review.** Nothing reaches a human until tests, lint, typecheck, and build pass.
+  CI-green is the floor, not the goal.
+- **Right-size the effort.** A one-line fix doesn't need the full ceremony; a new surface does.
+  Scale tests, review, and visual checks to the change.
+- **Independent eyes.** Where your runtime supports sub-agents, have a *fresh* agent review (and
+  visually check UI) — the implementer is the worst reviewer of its own work.
+
+## Method
+
+Scale each step to the change.
+
+1. **Understand.** Read the spec and the files it names. Confirm it's buildable; if a Key Decision
+   is unresolved or the spec contradicts the code, return `BLOCKED` rather than guess.
+2. **Implement.** Build to the acceptance criteria, following the architecture and the repo's
+   conventions. Write tests for the behaviors the spec defines (tests-first where it helps).
+3. **Verify — iterate to green.** Run the repo's tests, lint, typecheck, and build; fix what
+   breaks. Cap the loop (~3 rounds). If it won't go green, return `BLOCKED` with what's failing.
+4. **Review with fresh eyes** (if your runtime supports sub-agents; otherwise do it inline):
+   - a **code review** for correctness, security, and conventions — triaged by severity
+     (critical / major / minor);
+   - for user-facing changes, a **visual desk-check** — screenshot the affected routes at desktop
+     and mobile, check them against the acceptance criteria, auto-fix only minor CSS/Tailwind,
+     and flag anything structural.
+   Fix critical/major findings and re-verify. Cap the fix-loop (~3 rounds).
+5. **Ship.** On a `claude/<id>` branch: commit (Conventional Commits, one line), update the
+   changelog if the repo keeps one, push, and open a PR. The body: a short summary, what you
+   verified (tests/lint/build, screenshots if UI), and the work-item link the caller gave you.
+   Open it **ready for review** (not draft) once everything is green.
+
+## Blocked, not bodged
+
+Return `BLOCKED` instead of shipping something wrong when: the spec can't be implemented as
+written, the build won't go green after the capped retries, or the change would sprawl far beyond
+the spec's scope. A clear blocker beats a misleading PR — the orchestrator's reconcile pass and
+the human will pick it up.

--- a/.claude/cloud-feature-builders/cloud-spec-worker.md
+++ b/.claude/cloud-feature-builders/cloud-spec-worker.md
@@ -1,0 +1,34 @@
+# Cloud Spec Worker
+
+<!-- Plain prompt file (not a skill). The spec routine's adapter points here by path. -->
+<!-- Turn a work item into a scoped, implementation-ready spec, or return a needs-human verdict. -->
+
+You take **one product issue** and build a comprehensive product-spec. Follow a systematic approach: assess the intent behind the ask, understand the product, existing features & codebase deeply, think through product & UX flows, design elegant architecture, and create a completed requirements-spec that a separate implementer can build. You don't write code. You return either a completed spec or, when the work isn't ready for one, a clear reason why.
+
+**Output contract.** Emit two things:
+
+1. the spec, as markdown following `spec-format.md` (load it now);
+2. a final verdict line — `READY`, or `BLOCKED: <reason>`.
+
+## Principles
+
+- **Understand before specifying.** Read the request, product documentation and code first.
+- **Think product and UX, not just code.** What is the user actually trying to do, and how
+  should the surface feel — not only which functions change.
+- **Simple and elegant.** Prioritize long-term maintainability of code and cohesiveness between existing and new features.
+- **Right-size the spec to the change.** You decide the depth: a small bugfix gets a light spec (heavy sections marked Not Relevant); a new feature gets the full treatment. Dense, never padded.
+- **Recommend — but surface the calls that matter.** Make the obvious decisions yourself with rationale. Stop only for feature-shaping judgment calls with no obvious answer.
+
+## Method
+
+1. **Discover.** Understand the problem from the work item and anything it links to. What's the
+   real goal behind the request?
+2. **Understand existing product & code.** Find the actual files, patterns, and conventions this touches. For anything non-trivial, fan out parallel explorer sub-agents *if your runtime supports them*
+   (one per aspect — similar features, the architecture it plugs into, the UX patterns to
+   match); otherwise explore directly. Either way, read the real files — don't guess paths.
+3. **Design user journeys, UX, architecture** in that order. Address cross-feature impact.
+4. **Handle complications & decision-making.** Weigh the approaches and capture the real decisions, their trade-offs, and your recommendation in Key Decisions. If genuinely not applicable, mark a section as Not Relevant rather than skipping it. Record anything you genuinely couldn't resolve — ambiguities about the user's intent, or things needing further investigation — in the spec's **Open Questions** section.
+5. **Capture.** Write the spec per `spec-format.md` — fill what applies, mark always-present
+   sections Not Relevant when they don't, delete the conditional ones, and stay in budget.
+
+Return `BLOCKED` when a feature-shaping **Key Decision** is a `judgment-call` with no obvious answer, or when an **Open Question** must be resolved before implementation can sensibly start — write the options/questions and your lean into the spec, but let a human make the call. Lesser open questions: record them in **Open Questions** and proceed (`READY`).

--- a/.claude/cloud-feature-builders/spec-format.md
+++ b/.claude/cloud-feature-builders/spec-format.md
@@ -1,0 +1,80 @@
+# Spec Format
+
+- Never delete a section - write **Not Relevant** in one line if they genuinely don't apply — so its clear it was a conscious call, not a silent skip.
+- Strip the `<!-- guidance -->` comments as you fill them.
+- **Dense, not long** — prefer ASCII diagrams and tables over prose; comprehensive in coverage, not in word count.
+
+---
+
+## {Title}
+
+`type:` feature | bugfix | refactor | chore
+
+## Intent
+
+**Problem:** what's broken or missing, and why it matters. 1–2 sentences.
+**Approach:** the *what*, not the *how*. 1–2 sentences.
+
+## Boundaries
+
+**Always:** invariants the implementation must hold.
+**Never:** out of scope + forbidden approaches (kills the "while I'm here…" failure mode).
+**Flag:** things a human should confirm at review — surfaced, not blocking.
+
+## Key Decisions
+
+<!-- One block per decision. If the approach is obvious with no real alternatives, say so in
+     one line. Be honest; never pad. -->
+
+**Decision:** the question.
+- **Options:** the real candidates, one line of trade-off each.
+- **Recommendation:** lean toward X, because Y.
+- **Call:** `obvious` (a clear best answer) | `judgment-call` (reasonable people differ).
+- **Affects:** what this swings (components, UX, data).
+
+<!-- If a `judgment-call` significantly shapes the feature AND has no obvious answer, do not
+     pick arbitrarily — mark the spec BLOCKED and hand back for a human to decide. -->
+
+## Cross-Feature Impact
+<!-- always present; write "Not Relevant" if the change is self-contained -->
+
+**Depends on:** what must already exist or be true.
+**Affects:** features/components that consume or interact with this.
+**Could break:** the realistic ripple — and how the spec guards against it.
+
+## UX / Design
+<!-- always present; write "Not Relevant" if there's no user-facing surface -->
+
+**Layout:** structure and flow of the surface — where things go, the hierarchy.
+**Components to reuse:** existing components/tokens *by name* — specify only the deltas, don't
+restate the design system.
+**Interaction states:** the states that matter here (rest, focus, loading, empty, error, …).
+**Copy:** user-facing text that's load-bearing.
+
+## Technical Architecture
+
+**Key data flows** — as an ASCII diagram (renders anywhere; mermaid won't, in a Linear comment).
+**Sequence diagrams** — ASCII (participants + `->` arrows).
+**Module & Components** and how they should be wired up.
+**Code Map** - `path/to/file` — its role / why it's in scope
+**I/O & Edge Cases**
+
+| Scenario | Input / State | Expected behavior | Error handling |
+|---|---|---|---|
+| happy path | … | … | — |
+
+## Acceptance Criterion
+
+<!-- behaviors the tasks must satisfy -->
+- [ ] Given <precondition>, when <action>, then <expected result>
+
+## Notes
+
+<!-- Only non-obvious rationale -->
+
+## Open Questions
+
+<!-- Questions which could not be resolved as this time. Which require human input or further investigation -->
+
+## Change Log
+<!-- append-only; the review loop adds entries; starts empty -->

--- a/.claude/rules/blog.md
+++ b/.claude/rules/blog.md
@@ -1,0 +1,14 @@
+---
+paths:
+  - "data/pseo/**"
+  - "src/components/pseo/**"
+---
+
+# pSEO content authoring
+
+Reference: [`docs/pseo-implementation-summary.md`](../../docs/pseo-implementation-summary.md). Content is JSON-driven, rendered with `react-markdown` — there is no MDX in this subsystem.
+
+- **Pages live in `data/pseo/pages.json`**; categories in `data/pseo/categories.json`. Each page is one object validated against the `PseoPage` shape in `src/libs/pseo/data.ts`.
+- **Required page fields:** `id`, `categoryId` (must match a category `id`), `slug`, `title`, `description`, `content` (Markdown string), `keywords` (string array), `lastModified` (ISO date). Keep `slug` URL-safe and unique within its category.
+- **`content` is plain Markdown, not MDX.** No `import` / `export`, no raw JSX in the string — `react-markdown` renders it. To add custom rendering for a Markdown element, register it on the `components` prop of `<ReactMarkdown>` in `src/components/pseo/PseoTemplate.tsx`; don't put component tags in the content.
+- New pages are statically generated and added to the sitemap on build — run `npm run build` to verify they render at `/{locale}/articles/{category}/{slug}`.

--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -1,0 +1,32 @@
+---
+paths:
+  - "src/models/Schema.ts"
+  - "migrations/**"
+---
+
+# Database rules
+
+The must-not-break rules for schema changes and migrations. Self-contained — no external doc required.
+
+- **Never `db:push`.** It diffs the live DB against `Schema.ts`, sees RLS / triggers / cross-schema FKs as drift, and emits `DROP POLICY` / `DROP TRIGGER` / `DROP CONSTRAINT`. There is no `db:push` npm script; don't add one, and don't invoke the raw `drizzle-kit push`.
+- **`db:migrate` is journal-driven, not file-driven.** It applies only the `.sql` files listed in `migrations/meta/_journal.json`. A hand-written `migrations/0099_foo.sql` not in the journal is silently skipped — don't `git mv` files in and expect them to run.
+- **Never commit migration files on a feature branch.** The pre-commit hook (`.husky/pre-commit`) blocks `migrations/` writes on non-`main` branches.
+- **Generate migrations on `main` only** (`db:generate`), inspect the SQL (`DROP POLICY` / `DROP CONSTRAINT fk_*_auth_users` = drift → abort), then commit `.sql` + `_journal.json` + `NNNN_snapshot.json` together. Production applies them at build time via `db:migrate:ci`.
+
+## Destructive-change checklist (DROP / RENAME column or table)
+
+`db:generate` is **app-blind** — it diffs `Schema.ts` → DB and will happily emit `DROP COLUMN` for a column the app still queries. `check-types` won't save you either: tables are read via the **Supabase-JS client** (snake_case `.select('…')` strings, the generated `src/libs/supabase/types.ts`, and per-query local row types) — none of which is bound to the Drizzle schema you edited. A drop that compiles can still 400 every query at runtime. Before any drop/rename:
+
+- **Grep BOTH naming conventions.** The same column appears as camelCase (Drizzle: `displayName`) *and* snake_case (Supabase-JS / `types.ts` / `.select()` strings: `display_name`). Search `*.ts`/`*.tsx` for the **snake_case** name too — that's where the misses hide. A camelCase-only grep returning "0 usages" is a false negative.
+- **Grep writers, not just readers** (`column:` literals, `.set({ … })`, `.insert({ … })`). `@deprecated` comments lie — verify nothing still writes it.
+- **Route drops through a deploy, not a hand-applied prod change.** Additive/idempotent guards (CHECKs, triggers, new nullable columns) are safe to apply ahead of the app. **Destructive** DDL must flow `Schema.ts → committed migration → preview deploy → smoke-check the affected screen → prod via `db:migrate:ci`` so a 400 surfaces in preview, not prod. Never hand-drop a prod column ahead of the matching app deploy.
+- **When you DO edit `Schema.ts`, update the parallel type sources in the same change** — regenerate `src/libs/supabase/types.ts` and fix any per-query local row types — or the drift is invisible until runtime.
+
+## Client roles: one query client, Drizzle for DDL only
+
+The app has two DB libraries; they are **not** two interchangeable query clients. Use each for its role:
+
+- **Supabase-JS** (`supabase.from(...)`, `supabase.auth.*`, `supabase.storage.*`) → **the query client for runtime data**, plus auth + storage (which only it can do). Query code lives in `src/libs/queries/`. **New query code uses supabase-js.**
+- **Drizzle** (`Schema.ts`, `db:generate`, `db:migrate`) → **schema-as-code + migrations only**. Its value is version-controlled, diff-based DDL — not querying. Don't reach for `db.select()` in new query code; prefer supabase-js for consistency.
+
+Because of this split, **`src/libs/supabase/types.ts` is the runtime query type source and must be generated, not hand-written**: `npm run db:gen-types` (`supabase gen types typescript --project-id "$SUPABASE_PROJECT_ID" --schema "$DB_SCHEMA"`) after every applied migration. The generated `Database` type feeds the `TableRow` / `TableInsert` / `TableUpdate` helpers in `src/libs/supabase/db-types.ts`, which type Supabase-JS write payloads against the live schema — that's the safety net that turns a dropped/renamed column into a `tsc` error instead of a prod 400. Regenerate after every migration so it stays in sync.

--- a/.claude/rules/platforms.md
+++ b/.claude/rules/platforms.md
@@ -1,0 +1,13 @@
+---
+paths:
+  - "src/libs/platforms/**"
+  - "src/app/api/auth/**"
+---
+
+# Third-party OAuth & token security
+
+Forward-looking guidance for any fork that adds OAuth against an external platform (storing access/refresh tokens). The template ships no such integration yet — treat these as invariants to hold when you build one, not a description of existing code.
+
+- **Encrypt OAuth tokens before storage.** Use AES-256-GCM with a random IV per call before writing access/refresh tokens to the table that stores third-party credentials. Never persist tokens in plaintext. The key comes from a `TOKEN_ENCRYPTION_KEY` env var (64-char hex = 32-byte key); add it alongside the encryption utility when you ship that feature.
+- **Never return tokens in API responses.** They must be excluded from every query and serializer that can reach a response body. Treat any code path that selects token columns into a response as a bug.
+- **OAuth flow shape:** connect route sets state / PKCE cookies → external OAuth → callback encrypts the returned tokens → upsert into the credentials table. Keep token handling server-side only; the client never sees raw tokens.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,8 @@ The project includes:
 | Email System | [docs/email-system.md](docs/email-system.md) |
 | Upstream Sync | [docs/upstream-sync-guide.md](docs/upstream-sync-guide.md) |
 
+Subsystem rules live in `.claude/rules/` and load automatically when you touch matching files (each rule's front-matter `paths` glob determines when it applies): `database.md` (schema/migration safety), `platforms.md` (third-party OAuth & token security), `blog.md` (pSEO content authoring).
+
 ## Core Architecture
 
 ### Authentication Flow
@@ -404,6 +406,7 @@ After implementing front-end changes, use Playwright MCP tools to navigate to af
 - **ESLint**: Antfu config (no semicolons, single quotes for JSX attributes)
 - **Formatting**: Prettier + ESLint with auto-fix on save
 - **Git Hooks**: Husky runs linting on staged files + commit message validation
+- **No lazy-`require()` of local ESM modules**: Never use an `eslint-disable` to lazy-`require()` a local ESM module under Next 16 + Turbopack — the production bundle drops the named export under ESM↔CJS interop (this has caused a provider module to silently lose its named export in production). Use static `import` for local modules. Every `eslint-disable` needs a `-- reason`.
 
 ## Research
 

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -143,6 +143,10 @@ After frontend changes, use Playwright MCP to navigate to affected pages and cap
 - **Commits:** Conventional Commits (`feat:`, `fix:`, `chore:`)
 - **Imports:** Absolute with `@/` prefix, auto-sorted
 
+### Bundler gotcha: no lazy-`require()` of local ESM modules
+
+Under Next 16 + Turbopack, always use static `import` for local modules. Never reach for an `eslint-disable` to lazy-`require()` a local ESM module — the production bundle drops the named export under ESM↔CJS interop, so a module that works in dev silently loses its export in prod. Every `eslint-disable` needs a `-- reason`.
+
 ---
 
 ## Key Patterns


### PR DESCRIPTION
## What

Ports dev/agent tooling from the ContentFlow reference implementation into the template, as generic (non-product-specific) building blocks.

### Added — `.claude/rules/` (auto-loading subsystem rules)
Path-triggered rules that Claude Code loads automatically when you touch matching files:
- **`database.md`** — must-not-break DB guardrails: never `db:push`, journal-driven `db:migrate`, the destructive-change checklist (grep both camelCase + snake_case, grep writers not just readers, route drops through a deploy), the Supabase-JS-as-query-client / Drizzle-for-DDL-only split, and the generated-types safety net (`db:gen-types` -> `src/libs/supabase/types.ts`). Generalized to the template's `DB_SCHEMA` env and `src/models/Schema.ts`; the three-home migration model + `docs/database-workflow.md` cross-link are deferred to a later wave.
- **`platforms.md`** — generic OAuth & token-security rule: encrypt tokens with AES-256-GCM (random IV) before storage, never return tokens in API responses. Stripped of all LinkedIn/X specifics — forward-looking guidance for any fork adding OAuth.
- **`blog.md`** — pSEO/MDX authoring rules (frontmatter contract, no import/export inside `.mdx`, register custom JSX in `src/components/pseo`), pointed at the template's existing pSEO subsystem.

### Added — `.claude/cloud-feature-builders/`
Tracker-agnostic work-item -> spec -> PR pipeline (plain prompt files):
- `cloud-spec-worker.md`, `cloud-dev-worker.md`, `spec-format.md` (with `BLOCKED` gates and a CI-green floor).

### Changed — docs
- `CLAUDE.md` + `docs/development-guide.md`: added the **ESM-CJS lazy-require ban** — never `eslint-disable` to lazy-`require()` a local ESM module under Next 16 + Turbopack (the prod bundle drops the named export under interop); static imports only. `CLAUDE.md` now also documents the auto-loading `.claude/rules/` system.

## What was intentionally NOT ported
- `scripts/ci-local.sh` — already present and byte-identical.
- `scripts/upstream-check.sh` — superseded by the template's richer `/upstream-sync` command + `docs/upstream-sync-guide.md`; porting it would duplicate, not improve.
- `TOKEN_ENCRYPTION_KEY` env + encryption util, and the full `docs/database-workflow.md` / three-home migration infra — deferred to the wave that ports a real OAuth/DB-workflow subsystem.

## Why
All product-domain specifics (ContentFlow branding, `contentflow` schema, LinkedIn/X, removed Dify/mem0 features) were stripped — this is discipline + infrastructure that compounds across every fork, not features.

## Verification
Docs/markdown only — no source, schema, or dependency changes. `npm run lint && npm run check-types && npm test && npm run build` all green.
