### PR TITLE
fix(api): harden webhook-secret compare + prevent db:gen-types data loss

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "db:generate": "drizzle-kit generate",
     "db:migrate": "dotenv -c production -- drizzle-kit migrate",
     "db:migrate:ci": "drizzle-kit migrate",
-    "db:gen-types": "supabase gen types typescript --project-id \"$SUPABASE_PROJECT_ID\" --schema \"$DB_SCHEMA\" > src/libs/supabase/types.ts",
+    "db:gen-types": "supabase gen types typescript --project-id \"$SUPABASE_PROJECT_ID\" --schema \"$DB_SCHEMA\" > src/libs/supabase/types.ts.tmp && mv src/libs/supabase/types.ts.tmp src/libs/supabase/types.ts",
     "db:studio": "dotenv -c production -- drizzle-kit studio",
     "email:dev": "email dev --dir src/libs/email/templates --port 3001",
 

--- a/src/libs/api/middleware/withWebhookSecret.ts
+++ b/src/libs/api/middleware/withWebhookSecret.ts
@@ -1,7 +1,6 @@
 /** @module withWebhookSecret HOF -- wraps API route handlers with webhook secret authentication. */
 
-import { Buffer } from 'node:buffer';
-import { timingSafeEqual } from 'node:crypto';
+import { createHash, timingSafeEqual } from 'node:crypto';
 
 import type { NextRequest } from 'next/server';
 
@@ -40,11 +39,12 @@ export function withWebhookSecret<P = Record<string, string>>(handler: WebhookHa
       return unauthorizedError('Webhook secret required');
     }
 
-    // Timing-safe comparison to prevent timing attacks
-    const expected = Buffer.from(secret, 'utf8');
-    const received = Buffer.from(headerSecret, 'utf8');
+    // Hash both to a fixed 32-byte digest before comparing, so the equal-length
+    // requirement of timingSafeEqual can't leak the secret's length via timing.
+    const expected = createHash('sha256').update(secret).digest();
+    const received = createHash('sha256').update(headerSecret).digest();
 
-    if (expected.length !== received.length || !timingSafeEqual(expected, received)) {
+    if (!timingSafeEqual(expected, received)) {
       logAuthError('Invalid webhook secret', {
         endpoint: request.nextUrl?.pathname ?? 'unknown',
         method: request.method ?? 'unknown',


### PR DESCRIPTION
Addresses two **verified** synchronous code-review findings on already-merged ported code:

- **`withWebhookSecret` timing oracle** (security) — the `expected.length !== received.length` short-circuit leaked the secret length via timing. Now hashes both sides to a fixed 32-byte digest before `timingSafeEqual`.
- **`db:gen-types` truncation** (data-loss bug) — `> types.ts` emptied the file even when the supabase CLI failed. Now writes to `types.ts.tmp` and `mv`s on success.

Both are small fixes (severity×effort gate). The lower-severity 'supabase CLI not in devDependencies' finding was left as-is — adding the heavy CLI dep isn't warranted for a low finding (template assumes a global/npx CLI).