### PR TITLE
feat(data): data-layer conventions — query keys, server-safe fetch, wrapper hooks + Zustand stores

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "@supabase/supabase-js": "2.105.4",
         "@t3-oss/env-nextjs": "^0.13.11",
         "@tailwindcss/typography": "^0.5.19",
+        "@tanstack/react-query": "^5.101.0",
         "@tanstack/react-table": "^8.20.5",
         "@types/react-dom": "^19.2.3",
         "@vercel/otel": "^2.1.2",
@@ -21699,6 +21700,32 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.101.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.0.tgz",
+      "integrity": "sha512-cQetA74EB+seWySv1TTKr828TnP0u39m6LykwDXIo84SNortpDkp30TMEjkqtYCNP9c40uT/iwl6MLiufEt0Ow==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.101.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.0.tgz",
+      "integrity": "sha512-rLlJXSpkqfizLWgkR5+eLeIk0MvTx/meEIR7LRjxic+qxiQP8zVjq7BqQkiCMNLQBlLfuOLqqr6KO5GtrDlmSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.101.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tanstack/react-table": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@supabase/supabase-js": "2.105.4",
     "@t3-oss/env-nextjs": "^0.13.11",
     "@tailwindcss/typography": "^0.5.19",
+    "@tanstack/react-query": "^5.101.0",
     "@tanstack/react-table": "^8.20.5",
     "@types/react-dom": "^19.2.3",
     "@vercel/otel": "^2.1.2",

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -6,6 +6,7 @@ import { getMessages } from 'next-intl/server';
 import { Toaster as SonnerToaster } from 'sonner';
 
 import { PostHogProvider } from '@/components/analytics/PostHogProvider';
+import { QueryProvider } from '@/components/providers/query-provider';
 import { ThemeProvider } from '@/components/theme';
 import { Toaster } from '@/components/ui/toaster';
 import { getSiteUrl } from '@/libs/seo/config';
@@ -104,14 +105,16 @@ export default async function RootLayout(props: {
         </a>
         <ThemeProvider>
           <PostHogProvider>
-            <NextIntlClientProvider
-              locale={locale}
-              messages={messages}
-            >
-              <main id="main-content">{props.children}</main>
-              <Toaster />
-              <SonnerToaster position="bottom-right" />
-            </NextIntlClientProvider>
+            <QueryProvider>
+              <NextIntlClientProvider
+                locale={locale}
+                messages={messages}
+              >
+                <main id="main-content">{props.children}</main>
+                <Toaster />
+                <SonnerToaster position="bottom-right" />
+              </NextIntlClientProvider>
+            </QueryProvider>
           </PostHogProvider>
         </ThemeProvider>
       </body>

--- a/src/components/providers/query-provider.test.tsx
+++ b/src/components/providers/query-provider.test.tsx
@@ -1,0 +1,27 @@
+import { useQuery } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { QueryProvider } from './query-provider';
+
+function Consumer() {
+  const { data } = useQuery({
+    queryKey: ['probe'],
+    queryFn: () => Promise.resolve('ok'),
+  });
+  return <span>{data ?? 'loading'}</span>;
+}
+
+describe('QueryProvider', () => {
+  it('provides a QueryClient so child useQuery does not throw', async () => {
+    render(
+      <QueryProvider>
+        <Consumer />
+      </QueryProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('ok')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/providers/query-provider.tsx
+++ b/src/components/providers/query-provider.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useState } from 'react';
+
+/**
+ * TanStack Query provider.
+ *
+ * Mounted once in the root `[locale]/layout.tsx` so every `useQuery` /
+ * `useMutation` / `useQueryClient` in the app has a client in the tree —
+ * without it those hooks throw "No QueryClient set".
+ *
+ * The `QueryClient` is created lazily via `useState(() => …)` so it is
+ * instantiated exactly once per provider mount (not on every render) and is not
+ * shared across requests on the server.
+ */
+export function QueryProvider({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            // Avoid refetch storms on tab focus; favour explicit invalidation
+            // (see the wrapper-hook pattern in src/libs/hooks/).
+            staleTime: 60 * 1000,
+            refetchOnWindowFocus: false,
+          },
+        },
+      }),
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+    </QueryClientProvider>
+  );
+}

--- a/src/libs/actions/items.ts
+++ b/src/libs/actions/items.ts
@@ -1,0 +1,29 @@
+'use server';
+
+import type { ActionResult } from '@/libs/actions/types';
+
+/**
+ * STUB server actions for the generic `item` entity — the integration seam.
+ *
+ * This file exists so the data-layer exemplars (`use-item-mutations.ts`) compile
+ * and run end-to-end against a real `ActionResult` contract. A fork DELETES this
+ * file and points the wrapper hook at its real actions (which read/write a real
+ * table). The stubs intentionally do nothing but return success.
+ *
+ * Server Actions must return `ActionResult<T>` per the architecture rules — the
+ * stubs honour that so the calling convention is demonstrated correctly.
+ */
+
+export type CreateItemInput = { name: string; description?: string | null };
+
+export async function createItem(
+  _input: CreateItemInput,
+): Promise<ActionResult<{ id: string }>> {
+  return { data: { id: 'stub' }, error: null };
+}
+
+export async function deleteItem(
+  _id: string,
+): Promise<ActionResult<{ id: string }>> {
+  return { data: { id: 'stub' }, error: null };
+}

--- a/src/libs/hooks/use-item-mutations.test.tsx
+++ b/src/libs/hooks/use-item-mutations.test.tsx
@@ -1,0 +1,68 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { queryKeys } from '@/libs/queries/keys';
+
+// Control the wrapped action's result per test by mocking the seam module the
+// hook imports from.
+const createItem = vi.fn();
+const deleteItem = vi.fn();
+
+vi.mock('@/libs/actions/items', () => ({ createItem, deleteItem }));
+
+const { useItemMutations } = await import('./use-item-mutations');
+
+function makeWrapper(client: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+}
+
+describe('useItemMutations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('invalidates the items list on a successful action', async () => {
+    createItem.mockResolvedValueOnce({ data: { id: '1' }, error: null });
+
+    const client = new QueryClient();
+    const invalidateSpy = vi.spyOn(client, 'invalidateQueries');
+
+    const { result } = renderHook(() => useItemMutations(), {
+      wrapper: makeWrapper(client),
+    });
+
+    let actionResult: Awaited<ReturnType<typeof result.current.createItem>>;
+    await act(async () => {
+      actionResult = await result.current.createItem({ name: 'Widget' });
+    });
+
+    expect(actionResult!.error).toBeNull();
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.items.all });
+  });
+
+  it('does NOT invalidate when the action returns an error', async () => {
+    createItem.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'nope', code: 'VALIDATION_ERROR' },
+    });
+
+    const client = new QueryClient();
+    const invalidateSpy = vi.spyOn(client, 'invalidateQueries');
+
+    const { result } = renderHook(() => useItemMutations(), {
+      wrapper: makeWrapper(client),
+    });
+
+    let actionResult: Awaited<ReturnType<typeof result.current.createItem>>;
+    await act(async () => {
+      actionResult = await result.current.createItem({ name: 'Widget' });
+    });
+
+    expect(actionResult!.error).not.toBeNull();
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/libs/hooks/use-item-mutations.ts
+++ b/src/libs/hooks/use-item-mutations.ts
@@ -1,0 +1,49 @@
+'use client';
+
+import { useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+
+import type { CreateItemInput } from '@/libs/actions/items';
+import { createItem as createItemAction, deleteItem as deleteItemAction } from '@/libs/actions/items';
+import { queryKeys } from '@/libs/queries/keys';
+
+/**
+ * Wrapper-hook pattern: wrap a server action and own cache invalidation so
+ * call-sites can't forget to refresh.
+ *
+ * The wrapper returns the raw `ActionResult` so callers keep their own control
+ * flow (branch on `result.error`, surface a toast, etc.). Invalidation is
+ * INTRINSIC — it fires only on success (`if (!result.error) invalidate()`), so
+ * a call-site can never leave the list view stale by omitting a callback. That
+ * is the whole point of routing mutations through here instead of calling the
+ * action directly.
+ *
+ * The wrapped actions are STUBS in `@/libs/actions/items` (the integration
+ * seam). A fork repoints that import at its real actions; the
+ * wrap→check→invalidate body stays identical.
+ */
+export function useItemMutations() {
+  const queryClient = useQueryClient();
+
+  const invalidate = useCallback(() => {
+    void queryClient.invalidateQueries({ queryKey: queryKeys.items.all });
+  }, [queryClient]);
+
+  const createItem = useCallback(async (input: CreateItemInput) => {
+    const result = await createItemAction(input);
+    if (!result.error) {
+      invalidate();
+    }
+    return result;
+  }, [invalidate]);
+
+  const deleteItem = useCallback(async (id: string) => {
+    const result = await deleteItemAction(id);
+    if (!result.error) {
+      invalidate();
+    }
+    return result;
+  }, [invalidate]);
+
+  return { createItem, deleteItem };
+}

--- a/src/libs/hooks/use-item.ts
+++ b/src/libs/hooks/use-item.ts
@@ -1,0 +1,43 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import type { ItemRow } from '@/libs/queries/item';
+import { fetchItem, fetchItems, itemQueryKey } from '@/libs/queries/item';
+import { queryKeys } from '@/libs/queries/keys';
+import { createClient } from '@/libs/supabase/client';
+
+export type { ItemRow } from '@/libs/queries/item';
+
+/**
+ * TanStack read hooks for the generic `item` entity.
+ *
+ * Data hooks live under `src/libs/hooks/` (alongside the `src/libs/queries/`
+ * fetch functions they wrap), distinct from `src/hooks/` which holds generic
+ * React UI hooks. Each hook reuses the SAME query key and row shape as its
+ * fetch function so an RSC prefetch and the client read agree by construction.
+ *
+ * A fork copies these → `useThing` / `useThings`, repointing at `item.ts`'s
+ * sibling for the new entity.
+ */
+
+export function useItem(id: string) {
+  const supabase = createClient();
+
+  return useQuery<ItemRow | null>({
+    queryKey: itemQueryKey(id),
+    queryFn: () => fetchItem(supabase, id),
+  });
+}
+
+export function useItems<TData = ItemRow[]>(options?: {
+  select?: (rows: ItemRow[]) => TData;
+}) {
+  const supabase = createClient();
+
+  return useQuery<ItemRow[], Error, TData>({
+    queryKey: queryKeys.items.all,
+    queryFn: () => fetchItems(supabase),
+    select: options?.select,
+  });
+}

--- a/src/libs/hooks/use-user-preferences.ts
+++ b/src/libs/hooks/use-user-preferences.ts
@@ -1,0 +1,86 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+export type UserPreferences = {
+  emailNotifications: boolean;
+  language: string;
+  username: string | null;
+};
+
+type UpdatePayload = Partial<Omit<UserPreferences, 'username'>>;
+
+const QUERY_KEY = ['user-preferences'] as const;
+
+// Integration seam: this route does NOT exist in the template yet. A fork
+// implements `GET`/`PATCH /api/profile/preferences` reading & writing the
+// `user_preferences` table (the server half's columns). Kept as a constant so
+// the client hook reads as native and the seam is obvious.
+const ENDPOINT = '/api/profile/preferences';
+
+const DEFAULTS: UserPreferences = {
+  emailNotifications: true,
+  language: 'en',
+  username: null,
+};
+
+async function fetchPreferences(): Promise<UserPreferences> {
+  const response = await fetch(ENDPOINT, {
+    method: 'GET',
+    headers: { Accept: 'application/json' },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to load preferences (${response.status})`);
+  }
+
+  const json = (await response.json()) as Partial<UserPreferences>;
+  return {
+    emailNotifications: json.emailNotifications ?? DEFAULTS.emailNotifications,
+    language: json.language ?? DEFAULTS.language,
+    username: json.username ?? DEFAULTS.username,
+  };
+}
+
+async function patchPreferences(
+  payload: UpdatePayload,
+): Promise<UserPreferences> {
+  const response = await fetch(ENDPOINT, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const message = await response.text().catch(() => response.statusText);
+    throw new Error(message || `Failed to save preferences (${response.status})`);
+  }
+
+  const json = (await response.json()) as Partial<UserPreferences>;
+  return {
+    emailNotifications: json.emailNotifications ?? DEFAULTS.emailNotifications,
+    language: json.language ?? DEFAULTS.language,
+    username: json.username ?? DEFAULTS.username,
+  };
+}
+
+export function useUserPreferences() {
+  return useQuery<UserPreferences>({
+    queryKey: QUERY_KEY,
+    staleTime: 60 * 1000,
+    queryFn: fetchPreferences,
+  });
+}
+
+export function useUpdateUserPreferences() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: patchPreferences,
+    onSuccess: (data) => {
+      // Optimistically write the canonical result into cache so consumers see
+      // the saved value without a refetch round-trip.
+      queryClient.setQueryData<UserPreferences>(QUERY_KEY, data);
+    },
+  });
+}

--- a/src/libs/preferences/email-preferences.test.ts
+++ b/src/libs/preferences/email-preferences.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const maybeSingle = vi.fn();
+
+vi.mock('@/libs/supabase/admin', () => ({
+  createAdminClient: () => ({
+    from: () => ({
+      select: () => ({
+        eq: () => ({ maybeSingle }),
+      }),
+    }),
+  }),
+}));
+
+const { getUserEmailPreferences } = await import('./email-preferences');
+
+describe('getUserEmailPreferences', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the on default when the query errors', async () => {
+    maybeSingle.mockResolvedValueOnce({ data: null, error: { message: 'boom' } });
+
+    const prefs = await getUserEmailPreferences('user-1');
+
+    expect(prefs).toEqual({ emailNotifications: true });
+  });
+
+  it('returns the on default when no row exists', async () => {
+    maybeSingle.mockResolvedValueOnce({ data: null, error: null });
+
+    const prefs = await getUserEmailPreferences('user-1');
+
+    expect(prefs).toEqual({ emailNotifications: true });
+  });
+
+  it('maps a present row', async () => {
+    maybeSingle.mockResolvedValueOnce({ data: { email_notifications: false }, error: null });
+
+    const prefs = await getUserEmailPreferences('user-1');
+
+    expect(prefs).toEqual({ emailNotifications: false });
+  });
+
+  it('falls back to the default when the column is null', async () => {
+    maybeSingle.mockResolvedValueOnce({ data: { email_notifications: null }, error: null });
+
+    const prefs = await getUserEmailPreferences('user-1');
+
+    expect(prefs).toEqual({ emailNotifications: true });
+  });
+
+  it('passes a query error to the logger when provided', async () => {
+    maybeSingle.mockResolvedValueOnce({ data: null, error: { message: 'boom' } });
+    const logger = { warn: vi.fn() };
+
+    await getUserEmailPreferences('user-1', logger);
+
+    expect(logger.warn).toHaveBeenCalled();
+  });
+});

--- a/src/libs/preferences/email-preferences.ts
+++ b/src/libs/preferences/email-preferences.ts
@@ -1,0 +1,75 @@
+import { createAdminClient } from '@/libs/supabase/admin';
+
+export type EmailPreferences = {
+  emailNotifications: boolean;
+};
+
+const DEFAULTS: EmailPreferences = {
+  emailNotifications: true,
+};
+
+type PreferencesLogger = {
+  warn: (msg: string, data?: Record<string, unknown>) => void;
+};
+
+// Local row type + cast: the generated `src/libs/supabase/types.ts` is a
+// placeholder stub with no real tables, so the admin client is not schema-typed
+// and `.select(...)` rows surface as `never`. Declaring the shape here keeps this
+// reader compiling against the stub (same approach as `src/libs/queries/item.ts`).
+// A fork that generates real types can drop this and read the typed row directly.
+type UserPreferencesRow = {
+  email_notifications: boolean | null;
+};
+
+/**
+ * Fetch a user's email notification preference.
+ *
+ * Called from server-side notification senders (e.g. an Inngest worker). Uses
+ * the admin Supabase client to bypass RLS — these reads happen outside a user
+ * request context, so there is no session cookie to authorize against.
+ *
+ * If no row exists for the user (new user who has never visited settings), or
+ * the fetch errors, returns the "on" default. Erring on the side of sending is
+ * intentional — silently suppressing notifications because of a transient infra
+ * issue would be worse than an extra email.
+ *
+ * This is the server half of the preferences split; the client read/write hook
+ * lives in `src/libs/hooks/use-user-preferences.ts` (intentionally decoupled —
+ * server senders never import the client hook).
+ */
+export async function getUserEmailPreferences(
+  userId: string,
+  logger?: PreferencesLogger,
+): Promise<EmailPreferences> {
+  try {
+    const supabase = createAdminClient();
+    const { data, error } = await supabase
+      .from('user_preferences')
+      .select('email_notifications')
+      .eq('user_id', userId)
+      .maybeSingle();
+
+    if (error) {
+      logger?.warn('[email-preferences] Query error; using defaults', {
+        userId,
+        error: error.message,
+      });
+      return DEFAULTS;
+    }
+
+    if (!data) {
+      return DEFAULTS;
+    }
+
+    const row = data as UserPreferencesRow;
+    return {
+      emailNotifications: row.email_notifications ?? DEFAULTS.emailNotifications,
+    };
+  } catch (err) {
+    logger?.warn('[email-preferences] Unexpected error; using defaults', {
+      userId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return DEFAULTS;
+  }
+}

--- a/src/libs/queries/item.test.ts
+++ b/src/libs/queries/item.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ItemFetchClient } from './item';
+import { fetchItem, fetchItems, itemQueryKey } from './item';
+
+// Builds a supabase-js-shaped client whose `.single()` resolves to the given
+// `{ data, error }`. Only the chain `fetchItem` actually calls is mocked.
+function mockClient(result: { data: unknown; error: unknown }) {
+  const single = vi.fn().mockResolvedValue(result);
+  const eq = vi.fn().mockReturnValue({ single });
+  const select = vi.fn().mockReturnValue({ eq });
+  const from = vi.fn().mockReturnValue({ select });
+  return { client: { from } as unknown as ItemFetchClient, from, select, eq, single };
+}
+
+// Builds a client whose `.order()` resolves the list result `fetchItems` reads.
+function mockListClient(result: { data: unknown; error: unknown }) {
+  const order = vi.fn().mockResolvedValue(result);
+  const select = vi.fn().mockReturnValue({ order });
+  const from = vi.fn().mockReturnValue({ select });
+  return { client: { from } as unknown as ItemFetchClient, from, select, order };
+}
+
+describe('fetchItem', () => {
+  it('returns null when no row is found (PGRST116)', async () => {
+    const { client } = mockClient({ data: null, error: { code: 'PGRST116' } });
+
+    await expect(fetchItem(client, 'missing')).resolves.toBeNull();
+  });
+
+  it('maps a row when present', async () => {
+    const row = { id: '1', name: 'Widget', description: null, created_at: '2026-01-01' };
+    const { client, from, eq } = mockClient({ data: row, error: null });
+
+    const result = await fetchItem(client, '1');
+
+    expect(result).toEqual(row);
+    expect(from).toHaveBeenCalledWith('items');
+    expect(eq).toHaveBeenCalledWith('id', '1');
+  });
+
+  it('throws on a non-not-found error', async () => {
+    const { client } = mockClient({ data: null, error: { code: '500', message: 'boom' } });
+
+    await expect(fetchItem(client, '1')).rejects.toMatchObject({ code: '500' });
+  });
+});
+
+describe('fetchItems', () => {
+  it('returns the rows ordered by the query', async () => {
+    const rows = [{ id: '1', name: 'Widget', description: null, created_at: '2026-01-01' }];
+    const { client, from, order } = mockListClient({ data: rows, error: null });
+
+    const result = await fetchItems(client);
+
+    expect(result).toEqual(rows);
+    expect(from).toHaveBeenCalledWith('items');
+    expect(order).toHaveBeenCalledWith('created_at', { ascending: false });
+  });
+
+  it('returns an empty array when data is null', async () => {
+    const { client } = mockListClient({ data: null, error: null });
+
+    await expect(fetchItems(client)).resolves.toEqual([]);
+  });
+
+  it('throws on error', async () => {
+    const { client } = mockListClient({ data: null, error: { code: '500', message: 'boom' } });
+
+    await expect(fetchItems(client)).rejects.toMatchObject({ code: '500' });
+  });
+});
+
+describe('itemQueryKey', () => {
+  it('delegates to the centralized key factory', () => {
+    expect(itemQueryKey('1')).toEqual(['item', '1']);
+  });
+});

--- a/src/libs/queries/item.ts
+++ b/src/libs/queries/item.ts
@@ -1,0 +1,75 @@
+import { queryKeys } from '@/libs/queries/keys';
+import type { createClient as createBrowserClient } from '@/libs/supabase/client';
+import type { createClient as createServerClient } from '@/libs/supabase/server';
+
+/**
+ * Server-safe fetch-function pattern (generic `item` exemplar).
+ *
+ * The fetch functions (`fetchItem`, `fetchItems`) and the client hooks
+ * (`src/libs/hooks/use-item.ts`) share the SAME keys (`itemQueryKey`,
+ * `queryKeys.items.all`) and the SAME row shape (`ItemRow`). Because this module
+ * has no `'use client'` directive, an RSC can import either fetch function to
+ * prefetch on the server and hand the client the identical key/shape it will
+ * read — killing SSR hydration mismatches.
+ *
+ * `item` is a placeholder entity. A fork points `.from('items')` at a real
+ * table and copies this file per entity.
+ */
+
+// Local row type + cast (NOT `TableRow<'items'>`): the generated
+// `src/libs/supabase/types.ts` is a placeholder stub with no real tables, so the
+// supabase clients are not schema-typed. Declaring the row shape here keeps this
+// example compiling against the stub. Once a fork generates real types it can
+// switch to `TableRow<'items'>`.
+export type ItemRow = {
+  id: string;
+  name: string;
+  description: string | null;
+  created_at: string;
+};
+
+export const itemQueryKey = (id: string) => queryKeys.items.detail(id);
+
+export type ItemFetchClient
+  = | ReturnType<typeof createBrowserClient>
+    | ReturnType<typeof createServerClient>;
+
+// Shared projection so the single- and list-fetch functions (and any RSC
+// prefetch) read the identical column set.
+const ITEM_COLUMNS = 'id, name, description, created_at';
+
+export async function fetchItem(
+  supabase: ItemFetchClient,
+  id: string,
+): Promise<ItemRow | null> {
+  const { data, error } = await supabase
+    .from('items')
+    .select(ITEM_COLUMNS)
+    .eq('id', id)
+    .single();
+
+  if (error) {
+    // PGRST116 = "no rows" from `.single()` → treat as not-found, not an error.
+    if (error.code === 'PGRST116') {
+      return null;
+    }
+    throw error;
+  }
+
+  return data as ItemRow | null;
+}
+
+export async function fetchItems(
+  supabase: ItemFetchClient,
+): Promise<ItemRow[]> {
+  const { data, error } = await supabase
+    .from('items')
+    .select(ITEM_COLUMNS)
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? []) as ItemRow[];
+}

--- a/src/libs/queries/keys.test.ts
+++ b/src/libs/queries/keys.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { queryKeys } from './keys';
+
+describe('queryKeys', () => {
+  it('exposes a stable list key', () => {
+    expect(queryKeys.items.all).toEqual(['items']);
+  });
+
+  it('builds a parameterized detail key', () => {
+    expect(queryKeys.items.detail('abc')).toEqual(['item', 'abc']);
+  });
+});

--- a/src/libs/queries/keys.ts
+++ b/src/libs/queries/keys.ts
@@ -1,0 +1,26 @@
+/**
+ * Single source of truth for TanStack Query keys.
+ *
+ * Why this exists: hand-typed key literals (`['items']`, `['item', id]`, …)
+ * duplicated across hooks and every component that invalidates them. A typo
+ * silently produced stale data instead of an error. Importing from here makes
+ * keys typo-proof (a wrong key is a `tsc` error), greppable, and the whole
+ * namespace reviewable in one file.
+ *
+ * Keep this module server-safe (NO `'use client'`) so RSC prefetch on a page
+ * can import the same keys it later hydrates the client with — see the
+ * server-safe fetch-function pattern in `src/libs/queries/item.ts`.
+ *
+ * `items` is a generic placeholder entity. A fork copies the namespace and
+ * renames `items` → its own entity (`posts`, `projects`, …); list-style keys
+ * stay `as const` arrays, parameterized keys stay functions so a bare prefix
+ * (`queryKeys.items.all`) invalidates every variant.
+ */
+export const queryKeys = {
+  items: {
+    /** List view. See `useItems`. */
+    all: ['items'] as const,
+    /** Single record. See `useItem`. */
+    detail: (id: string) => ['item', id] as const,
+  },
+} as const;

--- a/src/stores/editor-store.test.tsx
+++ b/src/stores/editor-store.test.tsx
@@ -1,0 +1,85 @@
+import { act, render, renderHook, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { EditorStoreProvider, useEditorStore } from './editor-store';
+
+function wrapperWith(initialContent?: string) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <EditorStoreProvider initialContent={initialContent}>
+        {children}
+      </EditorStoreProvider>
+    );
+  };
+}
+
+describe('editor-store', () => {
+  it('seeds state from initialContent', () => {
+    const { result } = renderHook(() => useEditorStore(s => s.content), {
+      wrapper: wrapperWith('hello'),
+    });
+
+    expect(result.current).toBe('hello');
+  });
+
+  it('isolates state between two provider instances', () => {
+    // Two independently-mounted providers must each own a separate store, so
+    // writing to one never leaks into the other (the cross-entity-leak bug class
+    // this factory exists to prevent).
+    const { result: resultA } = renderHook(() => useEditorStore(), { wrapper: wrapperWith('A') });
+    const { result: resultB } = renderHook(() => useEditorStore(), { wrapper: wrapperWith('B') });
+
+    act(() => {
+      resultA.current.setContent('A-edited');
+    });
+
+    expect(resultA.current.content).toBe('A-edited');
+    expect(resultB.current.content).toBe('B');
+  });
+
+  it('throws when used outside a provider', () => {
+    function Consumer() {
+      useEditorStore();
+      return null;
+    }
+
+    // React logs the thrown render error to console; silence it so the
+    // fail-on-console setup does not flag this intentional throw.
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => render(<Consumer />)).toThrow(
+      'useEditorStore must be used within an EditorStoreProvider',
+    );
+
+    spy.mockRestore();
+  });
+
+  it('updates the dirty flag', () => {
+    function Consumer() {
+      const isDirty = useEditorStore(s => s.isDirty);
+      const setDirty = useEditorStore(s => s.setDirty);
+      return (
+        <button type="button" onClick={() => setDirty(true)}>
+          {isDirty ? 'dirty' : 'clean'}
+        </button>
+      );
+    }
+
+    render(
+      <EditorStoreProvider>
+        <Consumer />
+      </EditorStoreProvider>,
+    );
+
+    const button = screen.getByRole('button');
+
+    expect(button).toHaveTextContent('clean');
+
+    act(() => {
+      button.click();
+    });
+
+    expect(button).toHaveTextContent('dirty');
+  });
+});

--- a/src/stores/editor-store.tsx
+++ b/src/stores/editor-store.tsx
@@ -1,0 +1,108 @@
+/* eslint-disable react-refresh/only-export-components -- store factory + context idiom intentionally colocates the provider component with its hooks in one module */
+'use client';
+
+import type { ReactNode } from 'react';
+import { createContext, use, useState } from 'react';
+import type { StoreApi } from 'zustand';
+import { createStore, useStore } from 'zustand';
+
+/**
+ * Per-entity scoped store — Zustand factory + React context idiom.
+ *
+ * Each mounted editor gets its OWN store instance (via {@link EditorStoreProvider},
+ * keyed on the entity id), so client-side navigation between entities can't leak
+ * one entity's transient state (draft content, dirty flag, …) into the next. A
+ * fresh store per entity eliminates that whole bug class by construction rather
+ * than resetting fields one-by-one on every route change.
+ *
+ * Contrast with the module-level singletons (`editor-ui-store.ts`,
+ * `entity-dialog-store.ts`): those are deliberately ONE store for the whole app
+ * — use them for state that should survive navigation. Use THIS factory for
+ * state that should be torn down per entity.
+ *
+ * A fork renames `entity` → its domain (`post`, `document`, `project`) and adds
+ * the slices it needs; the factory/context machinery stays as-is.
+ */
+
+type EditorStore = {
+  content: string;
+  setContent: (content: string) => void;
+  isDirty: boolean;
+  setDirty: (dirty: boolean) => void;
+};
+
+type EditorStoreInit = {
+  initialContent?: string;
+};
+
+const createEditorStore = (init?: EditorStoreInit) =>
+  createStore<EditorStore>()(set => ({
+    content: init?.initialContent ?? '',
+    setContent: content => set({ content }),
+    isDirty: false,
+    setDirty: isDirty => set({ isDirty }),
+  }));
+
+type EditorStoreApi = StoreApi<EditorStore>;
+
+const EditorStoreContext = createContext<EditorStoreApi | null>(null);
+
+/**
+ * Creates one store per mount and provides it to the subtree. Place at the
+ * editor route boundary with `key={entityId}` so navigating A → B remounts the
+ * provider and hands the next entity a clean store.
+ *
+ * `useState(() => createEditorStore(...))` runs the factory exactly once for the
+ * lifetime of this provider instance (not on every render). `initialContent` is
+ * read only at creation; the provider remounts per `key`, so a new entity always
+ * gets a fresh store seeded with its own content.
+ */
+export function EditorStoreProvider({
+  children,
+  initialContent,
+}: {
+  children: ReactNode;
+  initialContent?: string;
+}) {
+  const [store] = useState(() => createEditorStore({ initialContent }));
+  return (
+    <EditorStoreContext value={store}>
+      {children}
+    </EditorStoreContext>
+  );
+}
+
+/**
+ * Subscribe to the per-entity editor store. Supports both call forms:
+ *   - `useEditorStore()`            → whole state (re-renders on any change)
+ *   - `useEditorStore(s => s.x)`    → selected slice
+ *
+ * Throws if used outside {@link EditorStoreProvider} — a missed provider
+ * boundary fails loudly at first render rather than silently reading a stale
+ * shared singleton (the bug this idiom exists to kill).
+ */
+export function useEditorStore(): EditorStore;
+export function useEditorStore<T>(selector: (state: EditorStore) => T): T;
+export function useEditorStore<T>(selector?: (state: EditorStore) => T) {
+  const store = use(EditorStoreContext);
+  if (!store) {
+    throw new Error('useEditorStore must be used within an EditorStoreProvider');
+  }
+  // When no selector is passed the public overload fixes T = EditorStore, so
+  // the identity fallback is sound; the cast just reconciles the union that the
+  // optional-param implementation signature produces.
+  return useStore(store, (selector ?? ((state: EditorStore) => state)) as (state: EditorStore) => T);
+}
+
+/**
+ * Returns the store's `StoreApi` for imperative `getState`/`setState`/`subscribe`
+ * outside the render path (event handlers, save callbacks). Throws outside the
+ * provider for the same reason as `useEditorStore`.
+ */
+export function useEditorStoreApi(): EditorStoreApi {
+  const store = use(EditorStoreContext);
+  if (!store) {
+    throw new Error('useEditorStoreApi must be used within an EditorStoreProvider');
+  }
+  return store;
+}

--- a/src/stores/editor-ui-store.ts
+++ b/src/stores/editor-ui-store.ts
@@ -1,0 +1,26 @@
+import { create } from 'zustand';
+
+/**
+ * Editor UI preferences that should persist *across* entities within a tab —
+ * the module-level singleton Zustand idiom.
+ *
+ * Kept deliberately separate from the per-entity store (see `editor-store.tsx`),
+ * which is scoped to a single entity id and torn down on navigation. State here
+ * is a cross-entity user preference — collapsing the side panel while editing
+ * entity A should keep it collapsed when you open entity B — so it must NOT
+ * reset when the per-entity store remounts.
+ *
+ * This is the singleton counterpart to the per-entity factory: ONE `create()`
+ * at module scope means one shared store for the whole app. `isSidePanelOpen` is
+ * just the example preference; a fork adds whatever cross-entity UI flags it
+ * needs here.
+ */
+type EditorUIStore = {
+  isSidePanelOpen: boolean;
+  setSidePanelOpen: (open: boolean) => void;
+};
+
+export const useEditorUIStore = create<EditorUIStore>(set => ({
+  isSidePanelOpen: true,
+  setSidePanelOpen: isSidePanelOpen => set({ isSidePanelOpen }),
+}));

--- a/src/stores/entity-dialog-store.test.ts
+++ b/src/stores/entity-dialog-store.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { useEntityDialogStore } from './entity-dialog-store';
+
+describe('entity-dialog-store', () => {
+  beforeEach(() => {
+    useEntityDialogStore.getState().close();
+  });
+
+  it('starts closed', () => {
+    expect(useEntityDialogStore.getState().mode).toEqual({ kind: 'closed' });
+  });
+
+  it('opens the create mode', () => {
+    useEntityDialogStore.getState().openCreate();
+
+    expect(useEntityDialogStore.getState().mode).toEqual({ kind: 'create' });
+  });
+
+  it('carries the entity id in edit mode', () => {
+    useEntityDialogStore.getState().openEdit('abc');
+
+    expect(useEntityDialogStore.getState().mode).toEqual({ kind: 'edit', entityId: 'abc' });
+  });
+
+  it('resets to closed', () => {
+    useEntityDialogStore.getState().openEdit('abc');
+    useEntityDialogStore.getState().close();
+
+    expect(useEntityDialogStore.getState().mode).toEqual({ kind: 'closed' });
+  });
+});

--- a/src/stores/entity-dialog-store.ts
+++ b/src/stores/entity-dialog-store.ts
@@ -1,0 +1,29 @@
+import { create } from 'zustand';
+
+/**
+ * Discriminated-union dialog store — a third distinct Zustand idiom.
+ *
+ * Modelling dialog state as a tagged union (rather than a loose
+ * `{ isOpen: boolean; mode: string; id?: string }`) makes illegal states
+ * unrepresentable: an `edit` dialog ALWAYS carries an `entityId`, a `closed`
+ * dialog NEVER does, and `tsc` enforces it at every consumer. A fork copies this
+ * for any create/edit modal driven from multiple call-sites.
+ */
+export type EntityDialogMode
+  = | { kind: 'closed' }
+    | { kind: 'create' }
+    | { kind: 'edit'; entityId: string };
+
+type EntityDialogStore = {
+  mode: EntityDialogMode;
+  openCreate: () => void;
+  openEdit: (entityId: string) => void;
+  close: () => void;
+};
+
+export const useEntityDialogStore = create<EntityDialogStore>(set => ({
+  mode: { kind: 'closed' },
+  openCreate: () => set({ mode: { kind: 'create' } }),
+  openEdit: (entityId: string) => set({ mode: { kind: 'edit', entityId } }),
+  close: () => set({ mode: { kind: 'closed' } }),
+}));


### PR DESCRIPTION
## What this adds

Ports ContentFlow's data-layer conventions into the template as **generic, copy-me examples** (one neutral `item` entity, not a CF domain entity). Every pattern ships as a single clean exemplar with co-located tests.

### Patterns
- **Centralized query-keys factory** (`src/libs/queries/keys.ts`) — single source of truth for TanStack keys; list keys `as const`, parameterized keys as functions so a bare prefix invalidates every variant. A wrong key is a `tsc` error.
- **Server-safe fetch-function pattern** (`src/libs/queries/item.ts`) — no `'use client'`, so an RSC can import `fetchItem`/`fetchItems` to prefetch on the server and hand the client the identical key + row shape (`ItemRow`). Uses supabase-js with a local row type, matching the template's documented "new query code uses supabase-js" + per-query local row type convention (since `supabase/types.ts` is a stub).
- **Wrapper-hooks with built-in invalidation** (`src/libs/hooks/use-item.ts`, `use-item-mutations.ts`) — read hooks reuse the fetch fns/keys; mutation wrappers return the raw `ActionResult` but invalidate intrinsically on success, so a call-site can't leave the list stale. Wrapped actions are stubs (`src/libs/actions/items.ts`) — the integration seam a fork repoints.
- **Preferences split** — server reader (`src/libs/preferences/email-preferences.ts`, admin client / RLS-bypass for out-of-request senders, defaults-on-failure) decoupled from the client read/write hook (`src/libs/hooks/use-user-preferences.ts`).
- **Zustand conventions (three idioms)** — per-entity scoped store factory + context (`editor-store.tsx`), cross-entity UI-prefs singleton (`editor-ui-store.ts`), and a discriminated-union dialog store that makes illegal states unrepresentable (`entity-dialog-store.ts`).
- **TanStack provider** (`src/components/providers/query-provider.tsx`) mounted once in `[locale]/layout.tsx`. `@tanstack/react-query` added (was not previously a dependency; no prior usages, so no duplication).

### Genericness
No ContentFlow specifics — no `contentflow` schema, LinkedIn/Twitter/WhatsApp, or posts/drafts/writing-styles. The only domain word is `posts`/`projects` cited as *example* rename targets in a comment.

## Findings

**Fixed (medium — architecture):** The list fetch (`fetchItems`) originally lived inside the `'use client'` `use-item.ts`, so an RSC couldn't import it — contradicting the module's documented server-safe-prefetch promise (which only `fetchItem` honored). Moved `fetchItems` into the server-safe `src/libs/queries/item.ts` alongside `fetchItem` (shared column projection, removed the duplicate `.select()` string), updated the hook to wrap it, and added `fetchItems` tests. Now both single + list fetch are RSC-importable and the doc is accurate.

**Skipped / noted (low — left intentional):** `use-user-preferences.ts` points at a `GET/PATCH /api/profile/preferences` endpoint that doesn't exist (an existing `/api/profile/update-preferences` route is similar but different). This is a deliberate, clearly-documented integration seam for a fork to implement, so it's left as-is for human review rather than wired to the existing route.

## Verify
lint ✅ (0 errors) · check-types ✅ · test ✅ (1177 passed) · build ✅

---
Part of **Wave 2 template contributions** — produce-only. Please review; do not auto-merge.