### PR TITLE
feat(ai): provider-agnostic structured-output schemas + prompt-builder scaffolding

### DIFF
--- a/src/libs/ai/helpers/voice-samples.test.ts
+++ b/src/libs/ai/helpers/voice-samples.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { VoiceSampleFetcher } from './voice-samples';
+import { loadVoiceSamples } from './voice-samples';
+
+describe('loadVoiceSamples', () => {
+  it('returns empty array when the user has no artifacts', async () => {
+    const fetcher: VoiceSampleFetcher = vi.fn(async () => []);
+
+    const result = await loadVoiceSamples(fetcher, 'u1');
+
+    expect(result).toEqual([]);
+  });
+
+  it('drops rows with null/empty content', async () => {
+    const fetcher: VoiceSampleFetcher = vi.fn(async () => [
+      { content: 'real content' },
+      { content: null },
+      { content: '' },
+    ]);
+
+    const result = await loadVoiceSamples(fetcher, 'u1');
+
+    expect(result).toEqual([{ content: 'real content' }]);
+  });
+
+  it('truncates content past the word cap with an ellipsis', async () => {
+    const longText = Array.from({ length: 300 }, (_, i) => `w${i}`).join(' ');
+    const fetcher: VoiceSampleFetcher = vi.fn(async () => [{ content: longText }]);
+
+    const [sample] = await loadVoiceSamples(fetcher, 'u1', { wordLimit: 10 });
+
+    expect(sample?.content.endsWith('…')).toBe(true);
+    expect(sample?.content.split(' ')).toHaveLength(10);
+  });
+
+  it('does not truncate content within the word cap', async () => {
+    const fetcher: VoiceSampleFetcher = vi.fn(async () => [{ content: 'short and sweet' }]);
+
+    const [sample] = await loadVoiceSamples(fetcher, 'u1', { wordLimit: 10 });
+
+    expect(sample?.content).toBe('short and sweet');
+  });
+
+  it('uses scoped results when the scoped query returns rows', async () => {
+    const fetcher = vi.fn(async (_userId, scopeId) =>
+      scopeId === 'style-1' ? [{ content: 'scoped sample' }] : [{ content: 'unscoped sample' }],
+    ) satisfies VoiceSampleFetcher;
+
+    const result = await loadVoiceSamples(fetcher, 'u1', { scopeId: 'style-1' });
+
+    expect(result).toEqual([{ content: 'scoped sample' }]);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(fetcher).toHaveBeenCalledWith('u1', 'style-1', 5);
+  });
+
+  it('falls back to unscoped when the scoped query is empty', async () => {
+    const fetcher = vi.fn(async (_userId, scopeId) =>
+      scopeId === 'style-1' ? [] : [{ content: 'unscoped sample' }],
+    ) satisfies VoiceSampleFetcher;
+
+    const result = await loadVoiceSamples(fetcher, 'u1', { scopeId: 'style-1' });
+
+    expect(result).toEqual([{ content: 'unscoped sample' }]);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(fetcher).toHaveBeenLastCalledWith('u1', null, 5);
+  });
+
+  it('skips the scoped query entirely when no scopeId is given', async () => {
+    const fetcher = vi.fn(async () => [{ content: 'unscoped sample' }]) satisfies VoiceSampleFetcher;
+
+    await loadVoiceSamples(fetcher, 'u1');
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(fetcher).toHaveBeenCalledWith('u1', null, 5);
+  });
+
+  it('passes a custom limit through to the fetcher', async () => {
+    const fetcher = vi.fn(async () => []) satisfies VoiceSampleFetcher;
+
+    await loadVoiceSamples(fetcher, 'u1', { limit: 3 });
+
+    expect(fetcher).toHaveBeenCalledWith('u1', null, 3);
+  });
+});

--- a/src/libs/ai/helpers/voice-samples.ts
+++ b/src/libs/ai/helpers/voice-samples.ts
@@ -1,0 +1,90 @@
+/**
+ * Voice-sample loader for prompt calibration.
+ *
+ * Loads a user's recent artifacts (published posts, generated docs, …) to use as
+ * voice reference samples in a generation prompt. The product-specific DB query
+ * is injected as a {@link VoiceSampleFetcher}, so this stays decoupled from any
+ * particular table/schema — wire it to a Supabase-JS query at the call site.
+ *
+ * The loader owns the generic calibration logic:
+ *  - scoped → unscoped fallback (try a style/category-filtered query first, then
+ *    fall back to any recent artifact)
+ *  - word-cap truncation so a few long samples can't blow the prompt budget
+ */
+
+export type VoiceSample = { content: string };
+
+/**
+ * Pluggable fetcher injected by the caller.
+ *
+ * @param userId  The user whose recent artifacts to load.
+ * @param scopeId Optional scope to filter by first (e.g. a style/category id).
+ *                When null/undefined, return the user's most recent artifacts.
+ * @param limit   Max rows to return.
+ */
+export type VoiceSampleFetcher = (
+  userId: string,
+  scopeId: string | null | undefined,
+  limit: number,
+) => Promise<{ content: string | null }[] | null>;
+
+const DEFAULT_WORD_LIMIT = 250;
+const DEFAULT_LIMIT = 5;
+const WHITESPACE_RE = /\s+/;
+
+/** Truncate text to approximately `maxWords` words. */
+function truncateWords(text: string, maxWords: number): string {
+  const words = text.split(WHITESPACE_RE);
+  if (words.length <= maxWords) {
+    return text;
+  }
+  return `${words.slice(0, maxWords).join(' ')}…`;
+}
+
+/** Map raw rows to VoiceSample[], dropping empty content and capping word count. */
+function toVoiceSamples(
+  data: { content: string | null }[] | null,
+  wordLimit: number,
+): VoiceSample[] {
+  if (!data || data.length === 0) {
+    return [];
+  }
+  return data
+    .filter((row): row is { content: string } => Boolean(row.content))
+    .map(row => ({ content: truncateWords(row.content, wordLimit) }));
+}
+
+export type LoadVoiceSamplesOptions = {
+  /** Optional scope (e.g. style/category id) to filter by before falling back. */
+  scopeId?: string | null;
+  /** Max samples to load (default: 5). */
+  limit?: number;
+  /** Per-sample word cap (default: 250). */
+  wordLimit?: number;
+};
+
+/**
+ * Load a user's recent artifacts as voice reference samples.
+ *
+ * When `scopeId` is provided, queries that scope first; if it yields nothing,
+ * falls back to the user's most recent artifacts across any scope. Returns an
+ * empty array for first-time users with no artifacts.
+ */
+export async function loadVoiceSamples(
+  fetcher: VoiceSampleFetcher,
+  userId: string,
+  options: LoadVoiceSamplesOptions = {},
+): Promise<VoiceSample[]> {
+  const { scopeId, limit = DEFAULT_LIMIT, wordLimit = DEFAULT_WORD_LIMIT } = options;
+
+  // Try the scoped query first
+  if (scopeId) {
+    const scoped = toVoiceSamples(await fetcher(userId, scopeId, limit), wordLimit);
+    if (scoped.length > 0) {
+      return scoped;
+    }
+  }
+
+  // Fallback: any recent artifact by this user
+  return toVoiceSamples(await fetcher(userId, null, limit), wordLimit);
+}

--- a/src/libs/ai/prompts/style-context.test.ts
+++ b/src/libs/ai/prompts/style-context.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from 'vitest';
+
+import type { StyleData } from './style-context';
+import { buildStyleContext } from './style-context';
+
+describe('buildStyleContext', () => {
+  describe('primary path (aiSummary present)', () => {
+    it('outputs only summary + strategic context + signature elements', () => {
+      const data: StyleData = {
+        aiSummary: 'Write with authority and warmth.',
+        tone: 'Professional but warm',
+        jargonLevel: 'industry_standard',
+        formalityCasualness: 4,
+        dataStorytelling: 2,
+        targetAudience: ['Engineering managers', 'Tech founders'],
+        professionalIdentity: ['Senior PM', 'Thought leader'],
+        contentGoal: ['Drive newsletter signups', 'Build authority'],
+        bannedWords: ['leverage', 'synergy'],
+        signaturePhrases: ['Here\'s the thing...', 'Stay curious.'],
+      };
+
+      const result = buildStyleContext(data, 'My Pro Style');
+
+      // Present: summary, strategic context, signature elements
+      expect(result).toContain('## Writing Style: My Pro Style');
+      expect(result).toContain('Write with authority and warmth.');
+      expect(result).toContain('### Write for');
+      expect(result).toContain('Audience: Engineering managers, Tech founders');
+      expect(result).toContain('Author identity: Senior PM, Thought leader');
+      expect(result).toContain('Content goal: Drive newsletter signups, Build authority');
+      expect(result).toContain('### Must Avoid\nleverage, synergy');
+      expect(result).toContain('### Signature Phrases (use naturally)\nHere\'s the thing..., Stay curious.');
+
+      // Absent: voice spectrum and guidelines (captured by summary)
+      expect(result).not.toContain('### Voice Profile');
+      expect(result).not.toContain('### Guidelines');
+      expect(result).not.toContain('Tone:');
+      expect(result).not.toContain('Jargon Level:');
+    });
+
+    it('places aiSummary before strategic context and signature elements', () => {
+      const data: StyleData = {
+        aiSummary: 'Voice DNA paragraph here.',
+        targetAudience: 'Developers',
+        bannedWords: ['synergy'],
+      };
+
+      const result = buildStyleContext(data, 'Order Test');
+
+      const summaryIndex = result.indexOf('Voice DNA paragraph here.');
+      const writeForIndex = result.indexOf('### Write for');
+      const avoidIndex = result.indexOf('### Must Avoid');
+
+      expect(summaryIndex).toBeGreaterThan(-1);
+      expect(writeForIndex).toBeGreaterThan(-1);
+      expect(avoidIndex).toBeGreaterThan(-1);
+      expect(summaryIndex).toBeLessThan(writeForIndex);
+      expect(writeForIndex).toBeLessThan(avoidIndex);
+    });
+  });
+
+  describe('fallback path (no aiSummary)', () => {
+    it('renders full structured fields when aiSummary is missing', () => {
+      const data: StyleData = {
+        tone: 'Professional but warm',
+        jargonLevel: 'industry_standard',
+        formalityCasualness: 4,
+        dataStorytelling: 2,
+        aspirationalRelatability: 1,
+        directNuanced: 5,
+        targetAudience: ['Engineering managers'],
+        bannedWords: ['leverage'],
+      };
+
+      const result = buildStyleContext(data, 'Fallback Style');
+
+      expect(result).toContain('### Voice Profile');
+      expect(result).toContain('Write conversationally, like talking to a colleague.');
+      expect(result).toContain('Favor data and research but weave in brief examples.');
+      expect(result).toContain('### Guidelines');
+      expect(result).toContain('- Tone: Professional but warm');
+      expect(result).toContain('- Jargon Level: industry standard');
+      expect(result).toContain('### Write for');
+      expect(result).toContain('### Must Avoid');
+    });
+
+    it('treats empty string aiSummary as fallback', () => {
+      const data: StyleData = {
+        aiSummary: '',
+        tone: 'Casual',
+        formalityCasualness: 5,
+      };
+
+      const result = buildStyleContext(data, 'Empty Summary');
+
+      expect(result).toContain('### Voice Profile');
+      expect(result).toContain('### Guidelines');
+      expect(result).toContain('- Tone: Casual');
+    });
+
+    it('skips out-of-range spectrum values without crashing', () => {
+      // Legacy/corrupt stored values could be 0, 6, or non-integers. The lookup
+      // must degrade gracefully rather than throw and break the consuming route.
+      const data = {
+        formalityCasualness: 0,
+        dataStorytelling: 6,
+        aspirationalRelatability: 1.5,
+        directNuanced: 4, // valid — should still render
+      } as unknown as StyleData;
+
+      const result = buildStyleContext(data, 'Corrupt');
+
+      expect(result).toContain('### Voice Profile');
+      // Only the valid value emits a line
+      expect(result).toContain('Present multiple perspectives before drawing conclusions.');
+      // Out-of-range values produce no spectrum lines
+      expect(result.match(/Voice Profile\n(- [^\n]+\n?)+/)?.[0]).toContain('Present multiple perspectives');
+    });
+
+    it('treats whitespace-only aiSummary as fallback', () => {
+      const data: StyleData = {
+        aiSummary: '   ',
+        tone: 'Direct',
+      };
+
+      const result = buildStyleContext(data, 'Whitespace Summary');
+
+      expect(result).toContain('### Guidelines');
+      expect(result).toContain('- Tone: Direct');
+    });
+  });
+
+  describe('shared behavior', () => {
+    it('includes strategic context in both paths', () => {
+      const withSummary = buildStyleContext(
+        { aiSummary: 'Some summary.', targetAudience: 'Devs' },
+        'With',
+      );
+      const withoutSummary = buildStyleContext(
+        { targetAudience: 'Devs' },
+        'Without',
+      );
+
+      expect(withSummary).toContain('### Write for\nAudience: Devs');
+      expect(withoutSummary).toContain('### Write for\nAudience: Devs');
+    });
+
+    it('includes signature elements in both paths', () => {
+      const withSummary = buildStyleContext(
+        { aiSummary: 'Summary.', bannedWords: ['leverage'], signaturePhrases: ['Stay curious.'] },
+        'With',
+      );
+      const withoutSummary = buildStyleContext(
+        { bannedWords: ['leverage'], signaturePhrases: ['Stay curious.'] },
+        'Without',
+      );
+
+      for (const result of [withSummary, withoutSummary]) {
+        expect(result).toContain('### Must Avoid\nleverage');
+        expect(result).toContain('### Signature Phrases (use naturally)\nStay curious.');
+      }
+    });
+
+    it('handles legacy string values for strategic context', () => {
+      const result = buildStyleContext(
+        { aiSummary: 'Summary.', targetAudience: 'Engineering managers at startups' },
+        'Legacy',
+      );
+
+      expect(result).toContain('Audience: Engineering managers at startups');
+    });
+
+    it('returns only the header for empty StyleData', () => {
+      const result = buildStyleContext({}, 'Empty Style');
+
+      expect(result).toBe('## Writing Style: Empty Style');
+    });
+
+    it('omits voice spectrum for neutral values (3) in fallback', () => {
+      const data: StyleData = {
+        formalityCasualness: 3,
+        dataStorytelling: 3,
+        aspirationalRelatability: 3,
+        directNuanced: 3,
+      };
+
+      const result = buildStyleContext(data, 'Neutral');
+
+      expect(result).not.toContain('### Voice Profile');
+    });
+  });
+});

--- a/src/libs/ai/prompts/style-context.ts
+++ b/src/libs/ai/prompts/style-context.ts
@@ -1,0 +1,137 @@
+/**
+ * Builder that compiles a user's stored style profile into a prompt-ready text
+ * section. This is the canonical "input → prompt string" builder pattern: a pure
+ * function with no IO, composed from small section builders.
+ *
+ * When `aiSummary` is present it's used as the sole voice signal, with strategic
+ * context and signature elements added as explicit supplements; otherwise it
+ * falls back to the full structured fields.
+ *
+ * {@link StyleData} is the generic input shape — wire it to whatever your product
+ * persists for a writing/voice profile (e.g. a `jsonb` column).
+ */
+
+import { formatEnum, formatStringOrArray, getSpectrumEntry, VOICE_SPECTRUM_KEYS } from './style-shared';
+
+/**
+ * Generic style-profile input for the prompt builders. All fields optional so a
+ * partially-configured profile still produces a valid (smaller) prompt section.
+ */
+export type StyleData = {
+  // Strategic context (single string or multi-select arrays)
+  targetAudience?: string | string[];
+  professionalIdentity?: string | string[];
+  contentGoal?: string | string[];
+
+  // Voice spectrum (1-5 scale, 3 = neutral) — see VOICE_SPECTRUM
+  formalityCasualness?: number;
+  dataStorytelling?: number;
+  aspirationalRelatability?: number;
+  directNuanced?: number;
+
+  // Structured voice & structure attributes (free-form or snake_case enums)
+  tone?: string;
+  jargonLevel?: string;
+  postLength?: string;
+  openingStyle?: string;
+  closingStyle?: string;
+  formattingPreference?: string;
+
+  // Signature elements (optional)
+  bannedWords?: string[];
+  signaturePhrases?: string[];
+
+  // AI-generated (not user-edited)
+  aiSummary?: string;
+};
+
+/**
+ * Compile a StyleData profile into a prompt-ready text section.
+ */
+export function buildStyleContext(styleData: StyleData, styleName: string): string {
+  const sections: string[] = [];
+
+  sections.push(`## Writing Style: ${styleName}`);
+
+  if (styleData.aiSummary?.trim()) {
+    // Primary path: aiSummary is the sole voice signal
+    sections.push(styleData.aiSummary);
+  } else {
+    // Fallback: no summary available, use structured fields
+    sections.push(...buildStructuredFallback(styleData));
+  }
+
+  // Strategic context — always explicit (factual, not stylistic)
+  const audience = formatStringOrArray(styleData.targetAudience);
+  const identity = formatStringOrArray(styleData.professionalIdentity);
+  const goal = formatStringOrArray(styleData.contentGoal);
+  if (audience || identity || goal) {
+    const lines: string[] = [];
+    if (audience) {
+      lines.push(`Audience: ${audience}`);
+    }
+    if (identity) {
+      lines.push(`Author identity: ${identity}`);
+    }
+    if (goal) {
+      lines.push(`Content goal: ${goal}`);
+    }
+    sections.push(`### Write for\n${lines.join('\n')}`);
+  }
+
+  // Signature elements — always explicit (concrete lists the summary can't capture verbatim)
+  if (styleData.bannedWords && styleData.bannedWords.length > 0) {
+    sections.push(`### Must Avoid\n${styleData.bannedWords.join(', ')}`);
+  }
+  if (styleData.signaturePhrases && styleData.signaturePhrases.length > 0) {
+    sections.push(`### Signature Phrases (use naturally)\n${styleData.signaturePhrases.join(', ')}`);
+  }
+
+  return sections.join('\n\n');
+}
+
+/**
+ * Build structured voice context from individual fields.
+ * Used as fallback when aiSummary is not available.
+ */
+function buildStructuredFallback(styleData: StyleData): string[] {
+  const sections: string[] = [];
+
+  // Voice spectrum instructions (skip neutral and out-of-range)
+  const spectrumLines: string[] = [];
+  for (const key of VOICE_SPECTRUM_KEYS) {
+    const entry = getSpectrumEntry(key, styleData[key]);
+    if (entry?.instruction) {
+      spectrumLines.push(`- ${entry.instruction}`);
+    }
+  }
+  if (spectrumLines.length > 0) {
+    sections.push(`### Voice Profile\n${spectrumLines.join('\n')}`);
+  }
+
+  // Guidelines (structured attributes)
+  const guidelines: string[] = [];
+  if (styleData.tone) {
+    guidelines.push(`- Tone: ${styleData.tone}`);
+  }
+  if (styleData.jargonLevel) {
+    guidelines.push(`- Jargon Level: ${formatEnum(styleData.jargonLevel)}`);
+  }
+  if (styleData.postLength) {
+    guidelines.push(`- Length: ${formatEnum(styleData.postLength)}`);
+  }
+  if (styleData.openingStyle) {
+    guidelines.push(`- Opening: ${formatEnum(styleData.openingStyle)}`);
+  }
+  if (styleData.closingStyle) {
+    guidelines.push(`- Closing: ${formatEnum(styleData.closingStyle)}`);
+  }
+  if (styleData.formattingPreference) {
+    guidelines.push(`- Formatting: ${formatEnum(styleData.formattingPreference)}`);
+  }
+  if (guidelines.length > 0) {
+    sections.push(`### Guidelines\n${guidelines.join('\n')}`);
+  }
+
+  return sections;
+}

--- a/src/libs/ai/prompts/style-shared.ts
+++ b/src/libs/ai/prompts/style-shared.ts
@@ -1,0 +1,92 @@
+/**
+ * Shared building blocks for style-aware prompt builders.
+ *
+ * The `VOICE_SPECTRUM` scale + helpers are product-agnostic: define a 4-axis
+ * voice profile (1–5 each), and the builders translate stored values into
+ * either short noun labels (for summary/context prompts) or imperative
+ * instructions (for generation-time prompts). Strip nothing here when forking —
+ * tune the axis copy to your product's voice.
+ */
+
+const UNDERSCORE_RE = /_/g;
+
+export const VOICE_SPECTRUM_KEYS = [
+  'formalityCasualness',
+  'dataStorytelling',
+  'aspirationalRelatability',
+  'directNuanced',
+] as const;
+
+export type VoiceSpectrumKey = typeof VOICE_SPECTRUM_KEYS[number];
+export type SpectrumValue = 1 | 2 | 3 | 4 | 5;
+
+export type SpectrumEntry = {
+  /** Short noun label, e.g. "very formal" — used as context in summary-style prompts. */
+  label: string;
+  /** Imperative instruction, e.g. "Write in a formal…" — used at generation time. Omitted for neutral (3). */
+  instruction?: string;
+};
+
+/**
+ * Single source of truth for the 4 voice spectrum dimensions.
+ * Each (key, 1–5) entry has a noun `label` for context-style prompts
+ * and an `instruction` for generation-time prompts (skipped for neutral 3).
+ */
+export const VOICE_SPECTRUM: Record<VoiceSpectrumKey, Record<SpectrumValue, SpectrumEntry>> = {
+  formalityCasualness: {
+    1: { label: 'very formal', instruction: 'Write in a formal, polished register. Avoid contractions and colloquialisms.' },
+    2: { label: 'mostly formal', instruction: 'Write in a mostly formal tone with occasional warmth.' },
+    3: { label: 'balanced formal/casual' },
+    4: { label: 'mostly casual', instruction: 'Write conversationally, like talking to a colleague.' },
+    5: { label: 'very casual', instruction: 'Write casually and informally, like a friendly chat.' },
+  },
+  dataStorytelling: {
+    1: { label: 'heavily data-driven', instruction: 'Lead with data, statistics, and evidence. Cite numbers.' },
+    2: { label: 'leans data-driven', instruction: 'Favor data and research but weave in brief examples.' },
+    3: { label: 'balanced data/storytelling' },
+    4: { label: 'leans storytelling', instruction: 'Lead with stories and anecdotes, supported by occasional data.' },
+    5: { label: 'heavily storytelling', instruction: 'Tell stories and share experiences. Avoid heavy data.' },
+  },
+  aspirationalRelatability: {
+    1: { label: 'very aspirational', instruction: 'Position as visionary — paint a picture of what\'s possible.' },
+    2: { label: 'leans aspirational', instruction: 'Lean aspirational but ground it in achievable steps.' },
+    3: { label: 'balanced aspirational/relatable' },
+    4: { label: 'leans relatable', instruction: 'Lean relatable — share struggles and honest takes.' },
+    5: { label: 'very relatable', instruction: 'Be deeply relatable — vulnerability and real talk.' },
+  },
+  directNuanced: {
+    1: { label: 'very direct', instruction: 'Be bold and assertive. State opinions as convictions.' },
+    2: { label: 'leans direct', instruction: 'Be direct but acknowledge key counterpoints.' },
+    3: { label: 'balanced direct/nuanced' },
+    4: { label: 'leans nuanced', instruction: 'Present multiple perspectives before drawing conclusions.' },
+    5: { label: 'very nuanced', instruction: 'Explore nuance thoroughly — avoid strong declarations.' },
+  },
+};
+
+/**
+ * Safely look up a spectrum entry. Returns null for any value that isn't a
+ * valid 1-5 integer — guards against legacy/corrupt stored values (e.g. 0, 6,
+ * 1.5) that would otherwise blow up downstream `.label` / `.instruction` reads.
+ */
+export function getSpectrumEntry(key: VoiceSpectrumKey, value: unknown): SpectrumEntry | null {
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 1 || value > 5) {
+    return null;
+  }
+  return VOICE_SPECTRUM[key][value as SpectrumValue] ?? null;
+}
+
+/** Humanize snake_case enum values: "industry_standard" → "industry standard" */
+export function formatEnum(value: string): string {
+  return value.replace(UNDERSCORE_RE, ' ');
+}
+
+/** Coerce string | string[] | undefined into a comma-joined string, or null when empty. */
+export function formatStringOrArray(value: string | string[] | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+  if (Array.isArray(value)) {
+    return value.length > 0 ? value.join(', ') : null;
+  }
+  return value.trim().length > 0 ? value : null;
+}

--- a/src/libs/ai/schemas/ai-suggestions.test.ts
+++ b/src/libs/ai/schemas/ai-suggestions.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  aiSuggestionSchema,
+  aiSuggestionSourceSchema,
+  namespaceSuggestionId,
+  suggestionBelongsToGroup,
+} from './ai-suggestions';
+
+describe('aiSuggestionSourceSchema', () => {
+  it('accepts a minimal source with explicit null optional fields', () => {
+    const result = aiSuggestionSourceSchema.parse({
+      url: 'https://example.com/article',
+      title: 'Some article',
+      publisher: null,
+      publishedAt: null,
+      summary: 'One-line summary of the article.',
+    });
+
+    expect(result.url).toBe('https://example.com/article');
+    expect(result.publisher).toBeNull();
+    expect(result.publishedAt).toBeNull();
+  });
+
+  it('accepts a fully populated source', () => {
+    const result = aiSuggestionSourceSchema.parse({
+      url: 'https://example.com/article',
+      title: 'Some article',
+      publisher: 'Example Times',
+      publishedAt: '2026-05-15',
+      summary: 'One-line summary.',
+    });
+
+    expect(result.publisher).toBe('Example Times');
+    expect(result.publishedAt).toBe('2026-05-15');
+  });
+
+  it('rejects missing optional fields (explicit null required)', () => {
+    const result = aiSuggestionSourceSchema.safeParse({
+      url: 'https://example.com',
+      title: 't',
+      summary: 's',
+    });
+
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('aiSuggestionSchema', () => {
+  const valid = {
+    id: 's1',
+    headline: 'Why hiring for technical fit over culture fit is the real reason early teams break',
+    rationale: [
+      'First Round Review study: 73% of pre-seed exits trace to founding-team friction.',
+      'Founders making early hires will trade list-checking for a values audit if they see the data.',
+      'Reinforces a niche of helping early-stage teams build culture-first rather than résumé-first.',
+    ],
+    sources: [
+      {
+        url: 'https://review.firstround.com/founding-team',
+        title: 'Why the first 3 hires define the company',
+        publisher: 'First Round Review',
+        publishedAt: '2026-05-16',
+        summary: 'A study of 200 early-stage exits points to founder/early-hire friction as the top failure mode.',
+      },
+    ],
+  };
+
+  it('accepts a complete suggestion', () => {
+    const result = aiSuggestionSchema.parse(valid);
+
+    expect(result.headline.startsWith('Why')).toBe(true);
+    expect(result.rationale).toHaveLength(3);
+    expect(result.sources).toHaveLength(1);
+  });
+
+  it('accepts zero sources', () => {
+    const result = aiSuggestionSchema.parse({ ...valid, sources: [] });
+
+    expect(result.sources).toEqual([]);
+  });
+
+  it('accepts 2 rationale bullets (relaxed from exact-3 — provider compliance)', () => {
+    const result = aiSuggestionSchema.safeParse({
+      ...valid,
+      rationale: ['evidence only', 'audience only'],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts 4 rationale bullets', () => {
+    const result = aiSuggestionSchema.safeParse({
+      ...valid,
+      rationale: ['a', 'b', 'c', 'd'],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects fewer than 2 rationale bullets', () => {
+    const result = aiSuggestionSchema.safeParse({
+      ...valid,
+      rationale: ['only one'],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects more than 4 rationale bullets', () => {
+    const result = aiSuggestionSchema.safeParse({
+      ...valid,
+      rationale: ['a', 'b', 'c', 'd', 'e'],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects more than 2 sources', () => {
+    const result = aiSuggestionSchema.safeParse({
+      ...valid,
+      sources: [valid.sources[0], valid.sources[0], valid.sources[0]],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('strips unknown extra fields', () => {
+    const result = aiSuggestionSchema.parse({
+      ...valid,
+      groupType: 'trending',
+    } as unknown as typeof valid);
+
+    expect('groupType' in result).toBe(false);
+  });
+});
+
+describe('suggestion-id namespacing', () => {
+  it('namespaces a positional id by group', () => {
+    expect(namespaceSuggestionId('g1', 2)).toBe('g1:s2');
+  });
+
+  it('matches ids belonging to a group', () => {
+    const id = namespaceSuggestionId('g1', 1);
+
+    expect(suggestionBelongsToGroup(id, 'g1')).toBe(true);
+    expect(suggestionBelongsToGroup(id, 'g2')).toBe(false);
+  });
+});

--- a/src/libs/ai/schemas/ai-suggestions.ts
+++ b/src/libs/ai/schemas/ai-suggestions.ts
@@ -1,0 +1,65 @@
+/**
+ * Structured-output schema for AI-generated suggestions backed by cited sources.
+ *
+ * Generic across products: a suggestion is one short idea, a few bullet rationale
+ * lines, and 0-N cited sources drawn from research results. The bounds are
+ * deliberately relaxed (ranges, not exact counts) so structured-output
+ * generations don't fail on off-by-one provider compliance.
+ */
+
+import { z } from 'zod';
+
+/** A single cited source backing a suggestion. */
+export const aiSuggestionSourceSchema = z.object({
+  url: z.string().describe('Canonical URL of the source. Must be a full https://… URL drawn from the research results.'),
+  title: z.string().describe('Source title'),
+  publisher: z.string().nullable().describe('Publisher name (e.g., "TechCrunch"). Use null when unknown.'),
+  publishedAt: z.string().nullable().describe('ISO date string when the source was published. Use null when unknown.'),
+  summary: z.string().describe('1–2 line summary of what this source actually says'),
+});
+
+/** Single suggestion returned by the generator. */
+export const aiSuggestionSchema = z.object({
+  id: z.string().describe('Stable identifier for this suggestion'),
+  headline: z
+    .string()
+    .describe('One short inquiry-style phrase (≤ ~120 chars). The reader should be curious enough to want the answer.'),
+  rationale: z
+    .array(z.string())
+    .min(2)
+    .max(4)
+    .describe('2–4 short bullets (≤ ~120 chars each) explaining why this suggestion is worth pursuing. Prefer exactly 3; relaxed to a range so structured-output generations don\'t fail on count.'),
+  sources: z
+    .array(aiSuggestionSourceSchema)
+    .min(0)
+    .max(2)
+    .describe('0–2 cited sources from the research; reference the actual results surfaced'),
+});
+
+/** Final flat API response shape. */
+export const aiSuggestionsResponseSchema = z.object({
+  suggestions: z.array(aiSuggestionSchema).min(1).max(15),
+});
+
+export type AiSuggestionSource = z.infer<typeof aiSuggestionSourceSchema>;
+export type AiSuggestion = z.infer<typeof aiSuggestionSchema>;
+export type AiSuggestionsResponse = z.infer<typeof aiSuggestionsResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// Suggestion-id namespacing
+//
+// Parallel generation groups each emit positional ids ("s1", "s2", …); namespace
+// them by groupId so they can't collide on a flat grid (React keys + lookup).
+// The encoding is produced server-side and decoded client-side, so it lives here
+// — the one module both sides already import — to keep the two ends from drifting.
+// ---------------------------------------------------------------------------
+
+/** Build the grid-unique id for the Nth (1-based) suggestion in a group. */
+export function namespaceSuggestionId(groupId: string, position: number): string {
+  return `${groupId}:s${position}`;
+}
+
+/** Whether a namespaced suggestion id belongs to the given group. */
+export function suggestionBelongsToGroup(id: string, groupId: string): boolean {
+  return id.startsWith(`${groupId}:`);
+}

--- a/src/libs/ai/schemas/draft-options.test.ts
+++ b/src/libs/ai/schemas/draft-options.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+
+import { draftOptionSchema, draftOptionsResponseSchema } from './draft-options';
+
+describe('draftOptionSchema', () => {
+  const validContent
+    = 'This is some draft content that is long enough to pass the minimum length validation requirement.';
+
+  it('validates a correct draft option', () => {
+    const result = draftOptionSchema.safeParse({
+      variant: 'concise',
+      content: validContent,
+      wordCount: 150,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('fails when variant is empty', () => {
+    const result = draftOptionSchema.safeParse({
+      variant: '',
+      content: validContent,
+      wordCount: 50,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('fails when content is missing', () => {
+    const result = draftOptionSchema.safeParse({
+      variant: 'detailed',
+      wordCount: 50,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('fails when wordCount is negative', () => {
+    const result = draftOptionSchema.safeParse({
+      variant: 'concise',
+      content: validContent,
+      wordCount: -1,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('fails when wordCount is not an integer', () => {
+    const result = draftOptionSchema.safeParse({
+      variant: 'concise',
+      content: validContent,
+      wordCount: 50.5,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('fails when content is too short (under 50 chars)', () => {
+    const result = draftOptionSchema.safeParse({
+      variant: 'concise',
+      content: 'Too short',
+      wordCount: 2,
+    });
+
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('draftOptionsResponseSchema', () => {
+  const validDraft = (variant: string) => ({
+    variant,
+    content: 'This is some draft content that is long enough to pass the minimum length validation requirement.',
+    wordCount: 150,
+  });
+
+  it('validates a response with a single draft', () => {
+    const result = draftOptionsResponseSchema.safeParse({
+      drafts: [validDraft('concise')],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('validates a response with the maximum 5 drafts', () => {
+    const result = draftOptionsResponseSchema.safeParse({
+      drafts: [
+        validDraft('a'),
+        validDraft('b'),
+        validDraft('c'),
+        validDraft('d'),
+        validDraft('e'),
+      ],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('fails with more than 5 drafts', () => {
+    const result = draftOptionsResponseSchema.safeParse({
+      drafts: [
+        validDraft('a'),
+        validDraft('b'),
+        validDraft('c'),
+        validDraft('d'),
+        validDraft('e'),
+        validDraft('f'),
+      ],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('fails when drafts array is empty', () => {
+    const result = draftOptionsResponseSchema.safeParse({ drafts: [] });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/libs/ai/schemas/draft-options.ts
+++ b/src/libs/ai/schemas/draft-options.ts
@@ -1,0 +1,24 @@
+/**
+ * Structured-output schema for multi-variant draft generation.
+ *
+ * Generic across products: the model returns N alternative drafts for a single
+ * input so the UI can offer a choice. The validator guards length/word-count
+ * bounds so a malformed LLM response fails at the boundary instead of leaking
+ * into the app. Constrain the count per call via {@link draftOptionsResponseSchema}.
+ */
+
+import { z } from 'zod';
+
+export const draftOptionSchema = z.object({
+  /** A short label distinguishing this draft from its siblings (e.g. "concise", "detailed"). */
+  variant: z.string().min(1).max(120).describe('A short label distinguishing this draft variant'),
+  content: z.string().min(50).max(5000).describe('The full draft content for this variant'),
+  wordCount: z.number().int().min(10).max(2000),
+});
+
+export const draftOptionsResponseSchema = z.object({
+  drafts: z.array(draftOptionSchema).min(1).max(5),
+});
+
+export type DraftOption = z.infer<typeof draftOptionSchema>;
+export type DraftOptionsResponse = z.infer<typeof draftOptionsResponseSchema>;

--- a/src/libs/ai/schemas/hashtags.test.ts
+++ b/src/libs/ai/schemas/hashtags.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { hashtagsResponseSchema } from './hashtags';
+
+describe('hashtagsResponseSchema', () => {
+  it('accepts 1 to 5 hashtags', () => {
+    expect(hashtagsResponseSchema.safeParse({ hashtags: ['ai'] }).success).toBe(true);
+    expect(
+      hashtagsResponseSchema.safeParse({ hashtags: ['a', 'b', 'c', 'd', 'e'] }).success,
+    ).toBe(true);
+  });
+
+  it('rejects an empty array', () => {
+    expect(hashtagsResponseSchema.safeParse({ hashtags: [] }).success).toBe(false);
+  });
+
+  it('rejects more than 5 hashtags', () => {
+    expect(
+      hashtagsResponseSchema.safeParse({ hashtags: ['a', 'b', 'c', 'd', 'e', 'f'] }).success,
+    ).toBe(false);
+  });
+
+  it('rejects a missing hashtags field', () => {
+    expect(hashtagsResponseSchema.safeParse({}).success).toBe(false);
+  });
+});

--- a/src/libs/ai/schemas/hashtags.ts
+++ b/src/libs/ai/schemas/hashtags.ts
@@ -1,0 +1,12 @@
+/** Structured-output schema for AI-generated hashtags (returned without the # prefix). */
+
+import { z } from 'zod';
+
+export const hashtagsResponseSchema = z.object({
+  hashtags: z
+    .array(z.string().describe('A relevant hashtag without the # prefix'))
+    .min(1)
+    .max(5),
+});
+
+export type HashtagsResponse = z.infer<typeof hashtagsResponseSchema>;


### PR DESCRIPTION
## What

Ports the **provider-agnostic AI scaffolding core** from a downstream product into the template, stripped of all product-domain specifics. Builds on the Wave-1 `src/libs/ai/telemetry.ts` already on `main`. Purely additive (11 new files, ~990 lines).

### Generic patterns added

**Structured-output Zod schema library** (`src/libs/ai/schemas/`):
- `draft-options.ts` — multi-variant draft generation validator (generic `variant` label + word-count bounds; count constrained per call).
- `ai-suggestions.ts` — suggestion-with-cited-sources validator + `namespaceSuggestionId`/`suggestionBelongsToGroup` id helpers. Bounds are relaxed (ranges, not exact counts) so structured-output generations don't fail on provider off-by-one.
- `hashtags.ts` — 1–5 hashtag validator.

**Prompt-builder architecture** (`src/libs/ai/prompts/`):
- `style-shared.ts` — the `VOICE_SPECTRUM` 4-axis/1–5 scale (single source of truth) + `getSpectrumEntry` (guards corrupt stored values), `formatEnum`, `formatStringOrArray`.
- `style-context.ts` — `buildStyleContext()` builder (pure `input → prompt string` with composed section builders; aiSummary-primary / structured-fallback paths). Ships a generic `StyleData` input type.

**Voice-sample loader** (`src/libs/ai/helpers/voice-samples.ts`):
- `loadVoiceSamples()` for prompt calibration — scoped→unscoped fallback + word-cap truncation. The product-specific DB query is injected as a pluggable `VoiceSampleFetcher`, so it's decoupled from any table/schema.

Plus co-located Zod `safeParse` + builder unit tests (51 new tests).

## Strip applied (no product specifics remain)

- Dropped the LinkedIn angle enum (`ANGLE_TEMPLATES` / `DraftAngle` / `ALL_DRAFT_ANGLES`) → generic free-form `variant` label.
- Renamed `postSuggestion*` → `aiSuggestion*`; genericized the LinkedIn-flavored source fields to neutral citation fields.
- Replaced the hardcoded `posts` table query in the voice loader with a pluggable fetcher.
- Defined a local generic `StyleData` type instead of importing the downstream `writing-styles` Drizzle schema; dropped the LinkedIn `Platform` field. No `linkedin`/`twitter`/product-schema references remain.

## Deferrals

- **AI `config.ts`** — not ported; it imports the subscriptions/quota subsystem (a later wave). Provider routing belongs with that work.
- Memory pipeline, generation/ideation/editing prompt *text*, and `src/app/api/ai/*` routes are intentionally out of scope (product-specific).

## Findings fixed during self-review

- Voice loader was tightly coupled to a non-existent `posts` table + `style_id`/`published_at` columns → refactored to a pluggable `VoiceSampleFetcher` so it reads as native template code and carries test coverage on the generic logic.

## Findings skipped (with reason)

- Doc-comment example "published posts, generated docs" in the voice loader left as-is — it's an illustrative list of artifact kinds, not a product binding.

## Verification

`lint` (0 errors), `check-types`, `test` (1198 passed), `build` all green locally.

---

Wave 2 template contribution — produce-only, do not merge.