### PR TITLE
feat(platforms): generic single-provider OAuth layer (connect/callback flow, encrypted token storage, RLS)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -111,6 +111,11 @@ PERPLEXITY_API_KEY=pplx-...
 # 32-byte key as 64 hex chars. Generate with: openssl rand -hex 32
 TOKEN_ENCRYPTION_KEY=
 
+# --- Generic OAuth Provider (Optional - src/libs/platforms) ---
+# Credentials for the single-provider connect/callback flow. Inert until set.
+OAUTH_PROVIDER_CLIENT_ID=
+OAUTH_PROVIDER_CLIENT_SECRET=
+
 # Mem0 Memory Integration (Optional - disabled by default)
 ENABLE_MEM0=false
 MEM0_API_KEY=m0-...

--- a/migrations/0001_amused_morlun.sql
+++ b/migrations/0001_amused_morlun.sql
@@ -1,0 +1,21 @@
+CREATE TABLE "vt_saas"."platform_connections" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"provider" text NOT NULL,
+	"access_token" text NOT NULL,
+	"encryption_key_version" smallint DEFAULT 1 NOT NULL,
+	"refresh_token" text,
+	"token_expires_at" timestamp with time zone,
+	"provider_account_id" text NOT NULL,
+	"username" text NOT NULL,
+	"display_name" text,
+	"profile_picture_url" text,
+	"scope" text,
+	"status" text DEFAULT 'connected' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "uq_platform_connections_user_provider" UNIQUE("user_id","provider")
+);
+--> statement-breakpoint
+CREATE INDEX "idx_platform_connections_user_id" ON "vt_saas"."platform_connections" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "idx_platform_connections_token_expires_at" ON "vt_saas"."platform_connections" USING btree ("token_expires_at") WHERE token_expires_at IS NOT NULL;

--- a/migrations/meta/0001_snapshot.json
+++ b/migrations/meta/0001_snapshot.json
@@ -1,0 +1,1197 @@
+{
+  "id": "f44fc591-3910-4104-9b57-372a0a3b3d57",
+  "prevId": "ae5be468-afb4-4ac8-bb71-44586b7273b5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "vt_saas.admin_audit_log": {
+      "name": "admin_audit_log",
+      "schema": "vt_saas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "admin_id": {
+          "name": "admin_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_admin_audit_log_admin_id": {
+          "name": "idx_admin_audit_log_admin_id",
+          "columns": [
+            {
+              "expression": "admin_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_admin_audit_log_created_at": {
+          "name": "idx_admin_audit_log_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_admin_audit_log_action_created_at": {
+          "name": "idx_admin_audit_log_action_created_at",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "vt_saas.feedback": {
+      "name": "feedback",
+      "schema": "vt_saas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "feedback_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "feedback_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_feedback_user_id": {
+          "name": "idx_feedback_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_feedback_status": {
+          "name": "idx_feedback_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_feedback_created_at": {
+          "name": "idx_feedback_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_feedback_status_created": {
+          "name": "idx_feedback_status_created",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "vt_saas.mem0_memories": {
+      "name": "mem0_memories",
+      "schema": "vt_saas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_text": {
+          "name": "memory_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_type": {
+          "name": "memory_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_mem0_memories_user_id": {
+          "name": "idx_mem0_memories_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mem0_memories_conversation_id": {
+          "name": "idx_mem0_memories_conversation_id",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mem0_memories_conversation_id_vercel_conversations_id_fk": {
+          "name": "mem0_memories_conversation_id_vercel_conversations_id_fk",
+          "tableFrom": "mem0_memories",
+          "tableTo": "vercel_conversations",
+          "schemaTo": "vt_saas",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "vt_saas.memory_extraction_jobs": {
+      "name": "memory_extraction_jobs",
+      "schema": "vt_saas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_memory_jobs_conversation_id": {
+          "name": "idx_memory_jobs_conversation_id",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memory_jobs_status": {
+          "name": "idx_memory_jobs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memory_jobs_created_at": {
+          "name": "idx_memory_jobs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memory_extraction_jobs_conversation_id_vercel_conversations_id_fk": {
+          "name": "memory_extraction_jobs_conversation_id_vercel_conversations_id_fk",
+          "tableFrom": "memory_extraction_jobs",
+          "tableTo": "vercel_conversations",
+          "schemaTo": "vt_saas",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "vt_saas.platform_connections": {
+      "name": "platform_connections",
+      "schema": "vt_saas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encryption_key_version": {
+          "name": "encryption_key_version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_picture_url": {
+          "name": "profile_picture_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_platform_connections_user_id": {
+          "name": "idx_platform_connections_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_platform_connections_token_expires_at": {
+          "name": "idx_platform_connections_token_expires_at",
+          "columns": [
+            {
+              "expression": "token_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "token_expires_at IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_platform_connections_user_provider": {
+          "name": "uq_platform_connections_user_provider",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "provider"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "vt_saas.shareable_links": {
+      "name": "shareable_links",
+      "schema": "vt_saas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_count": {
+          "name": "access_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_shareable_links_created_by": {
+          "name": "idx_shareable_links_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_shareable_links_resource": {
+          "name": "idx_shareable_links_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "shareable_links_token_unique": {
+          "name": "shareable_links_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "vt_saas.threads": {
+      "name": "threads",
+      "schema": "vt_saas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_preview": {
+          "name": "last_message_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_threads_user_id": {
+          "name": "idx_threads_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_threads_user_archived": {
+          "name": "idx_threads_user_archived",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "threads_conversation_id_unique": {
+          "name": "threads_conversation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "conversation_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "vt_saas.user_preferences": {
+      "name": "user_preferences",
+      "schema": "vt_saas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_notifications": {
+          "name": "email_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_preferences_user_id": {
+          "name": "idx_user_preferences_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_preferences_username": {
+          "name": "idx_user_preferences_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_preferences_user_id_unique": {
+          "name": "user_preferences_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "user_preferences_username_unique": {
+          "name": "user_preferences_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "vt_saas.vercel_conversations": {
+      "name": "vercel_conversations",
+      "schema": "vt_saas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_preview": {
+          "name": "last_message_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_vercel_conversations_user_id": {
+          "name": "idx_vercel_conversations_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_vercel_conversations_user_archived": {
+          "name": "idx_vercel_conversations_user_archived",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "vt_saas.vercel_messages": {
+      "name": "vercel_messages",
+      "schema": "vt_saas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_vercel_messages_conversation_id": {
+          "name": "idx_vercel_messages_conversation_id",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_vercel_messages_created_at": {
+          "name": "idx_vercel_messages_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vercel_messages_conversation_id_vercel_conversations_id_fk": {
+          "name": "vercel_messages_conversation_id_vercel_conversations_id_fk",
+          "tableFrom": "vercel_messages",
+          "tableTo": "vercel_conversations",
+          "schemaTo": "vt_saas",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.feedback_status": {
+      "name": "feedback_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "reviewed",
+        "archived"
+      ]
+    },
+    "public.feedback_type": {
+      "name": "feedback_type",
+      "schema": "public",
+      "values": [
+        "bug",
+        "feature",
+        "praise"
+      ]
+    }
+  },
+  "schemas": {
+    "vt_saas": "vt_saas"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1772432359446,
       "tag": "0000_glorious_blockbuster",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1781538373976,
+      "tag": "0001_amused_morlun",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/auth/callback/[provider]/route.ts
+++ b/src/app/api/auth/callback/[provider]/route.ts
@@ -1,0 +1,135 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+
+import { cookies } from 'next/headers';
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+import { trackEventServer } from '@/libs/analytics/server';
+import { logger } from '@/libs/Logger';
+import { getOAuthProvider } from '@/libs/platforms/oauth-provider';
+import { storeOAuthTokens } from '@/libs/platforms/oauth-token-storage';
+import { createClient } from '@/libs/supabase/server';
+
+// Generic post-connect destination. Forks can point this at their own page;
+// the success/error result is carried as a query param.
+const CONNECT_REDIRECT_PATH = '/dashboard';
+
+/**
+ * Extracts the locale prefix from a path (e.g. '/en'), defaulting to '/en'.
+ * Mirrors the inline sign-in redirect convention in `src/proxy.ts`.
+ */
+function getLocalePrefix(pathname: string): string {
+  return pathname.match(/^\/([a-z]{2})(?:\/|$)/)?.[0]?.replace(/\/$/, '') ?? '/en';
+}
+
+function redirectTo(request: NextRequest, path: string): NextResponse {
+  return NextResponse.redirect(new URL(path, request.url));
+}
+
+function connectRedirect(request: NextRequest, query: string): NextResponse {
+  const localePrefix = getLocalePrefix(request.nextUrl.pathname);
+  return redirectTo(request, `${localePrefix}${CONNECT_REDIRECT_PATH}?${query}`);
+}
+
+function redirectToSignIn(request: NextRequest): NextResponse {
+  const localePrefix = getLocalePrefix(request.nextUrl.pathname);
+  return redirectTo(request, `${localePrefix}/sign-in`);
+}
+
+/**
+ * Timing-safe equality for the CSRF state value. Hash both sides to a fixed
+ * 32-byte digest first, mirroring the `withWebhookSecret` guard, so the
+ * equal-length requirement of `timingSafeEqual` can't leak length via timing.
+ */
+function statesMatch(a: string, b: string): boolean {
+  const expected = createHash('sha256').update(a).digest();
+  const received = createHash('sha256').update(b).digest();
+  return timingSafeEqual(expected, received);
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ provider: string }> },
+) {
+  const { provider: providerId } = await params;
+
+  const provider = getOAuthProvider(providerId);
+  if (!provider) {
+    return connectRedirect(request, 'error=unknown_provider');
+  }
+
+  const { searchParams } = request.nextUrl;
+  const code = searchParams.get('code');
+  const state = searchParams.get('state');
+  const error = searchParams.get('error');
+
+  const cookieStore = await cookies();
+  const stateCookieName = `oauth_state_${provider.id}`;
+
+  // Handle provider-side errors (user denied, etc.). Clear the state cookie on
+  // the way out — no code is issued here, so leaving it alive is just hygiene
+  // debt until its 5-minute maxAge expires.
+  if (error) {
+    cookieStore.delete(stateCookieName);
+    return connectRedirect(
+      request,
+      `error=${error === 'access_denied' ? 'access_denied' : 'oauth_error'}`,
+    );
+  }
+
+  // CSRF state validation (constant-time compare, then clear the cookie)
+  const savedState = cookieStore.get(stateCookieName)?.value;
+  cookieStore.delete(stateCookieName);
+
+  if (!state || !savedState || !statesMatch(state, savedState)) {
+    return connectRedirect(request, 'error=invalid_state');
+  }
+
+  if (!code) {
+    return connectRedirect(request, 'error=missing_code');
+  }
+
+  try {
+    // Exchange code for tokens
+    const tokenResponse = await provider.exchangeCode(code);
+
+    // Get authenticated user
+    const supabase = createClient(cookieStore);
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return redirectToSignIn(request);
+    }
+
+    // Store tokens via the provider seam
+    const result = await storeOAuthTokens({
+      provider,
+      userId: user.id,
+      providerToken: tokenResponse.access_token,
+      providerRefreshToken: tokenResponse.refresh_token,
+      scope: tokenResponse.scope ?? null,
+      supabase,
+      expiresIn: tokenResponse.expires_in,
+    });
+
+    if (!result.success) {
+      return connectRedirect(request, 'error=db_error');
+    }
+
+    trackEventServer(
+      'platform_connected',
+      { provider: provider.id },
+      user.id,
+    ).catch((err: unknown) => {
+      logger.warn({ err }, 'platform_connected tracking failed');
+    });
+
+    return connectRedirect(
+      request,
+      `success=${provider.id}_connected&name=${encodeURIComponent(result.username)}`,
+    );
+  } catch (err) {
+    logger.error({ error: err }, 'OAuth callback error');
+    return connectRedirect(request, 'error=token_exchange_failed');
+  }
+}

--- a/src/app/api/auth/connect/[provider]/route.ts
+++ b/src/app/api/auth/connect/[provider]/route.ts
@@ -1,0 +1,69 @@
+import crypto from 'node:crypto';
+
+import { cookies } from 'next/headers';
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+import { logger } from '@/libs/Logger';
+import { getOAuthProvider } from '@/libs/platforms/oauth-provider';
+import { createClient } from '@/libs/supabase/server';
+
+/**
+ * Extracts the locale prefix from a path (e.g. '/en'), defaulting to '/en'.
+ * Mirrors the inline sign-in redirect convention in `src/proxy.ts`.
+ */
+function getLocalePrefix(pathname: string): string {
+  return pathname.match(/^\/([a-z]{2})(?:\/|$)/)?.[0]?.replace(/\/$/, '') ?? '/en';
+}
+
+function redirectToSignIn(request: NextRequest): NextResponse {
+  const localePrefix = getLocalePrefix(request.nextUrl.pathname);
+  return NextResponse.redirect(new URL(`${localePrefix}/sign-in`, request.url));
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ provider: string }> },
+) {
+  const { provider: providerId } = await params;
+
+  const provider = getOAuthProvider(providerId);
+  if (!provider) {
+    const localePrefix = getLocalePrefix(request.nextUrl.pathname);
+    return NextResponse.redirect(
+      new URL(`${localePrefix}/dashboard?error=unknown_provider`, request.url),
+    );
+  }
+
+  const cookieStore = await cookies();
+  const supabase = createClient(cookieStore);
+
+  const { data: { user }, error } = await supabase.auth.getUser();
+  if (error || !user) {
+    return redirectToSignIn(request);
+  }
+
+  // Generate and store a CSRF state token in a short-lived, per-provider cookie
+  // (per-provider name so concurrent connects don't clobber each other).
+  // `getAuthUrl` throws if the provider's credentials aren't configured — turn
+  // that into a clean redirect instead of an unhandled 500 (mirrors the
+  // unknown-provider branch above).
+  try {
+    const state = crypto.randomBytes(16).toString('hex');
+    cookieStore.set(`oauth_state_${provider.id}`, state, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      maxAge: 300,
+      path: '/',
+    });
+
+    return NextResponse.redirect(provider.getAuthUrl(state));
+  } catch (err) {
+    logger.error({ error: err, provider: provider.id }, 'OAuth connect: provider not configured');
+    const localePrefix = getLocalePrefix(request.nextUrl.pathname);
+    return NextResponse.redirect(
+      new URL(`${localePrefix}/dashboard?error=provider_not_configured`, request.url),
+    );
+  }
+}

--- a/src/libs/Env.ts
+++ b/src/libs/Env.ts
@@ -36,6 +36,10 @@ export const Env = createEnv({
       .string()
       .regex(/^[0-9a-f]{64}$/i, 'TOKEN_ENCRYPTION_KEY must be 64 hex chars (32 bytes): openssl rand -hex 32')
       .optional(),
+    // Generic single-provider OAuth credentials (src/libs/platforms) - Optional,
+    // graceful degradation. The connect/callback flow is inert until both are set.
+    OAUTH_PROVIDER_CLIENT_ID: z.string().optional(),
+    OAUTH_PROVIDER_CLIENT_SECRET: z.string().optional(),
     // Mem0 (Memory Integration) - Optional to allow graceful degradation
     ENABLE_MEM0: z.enum(['true', 'false']).default('false'),
     MEM0_API_KEY: z.string().optional(),
@@ -81,6 +85,8 @@ export const Env = createEnv({
     TAVILY_API_KEY: process.env.TAVILY_API_KEY,
     PERPLEXITY_API_KEY: process.env.PERPLEXITY_API_KEY,
     TOKEN_ENCRYPTION_KEY: process.env.TOKEN_ENCRYPTION_KEY,
+    OAUTH_PROVIDER_CLIENT_ID: process.env.OAUTH_PROVIDER_CLIENT_ID,
+    OAUTH_PROVIDER_CLIENT_SECRET: process.env.OAUTH_PROVIDER_CLIENT_SECRET,
     ENABLE_MEM0: process.env.ENABLE_MEM0,
     MEM0_API_KEY: process.env.MEM0_API_KEY,
     CRON_SECRET: process.env.CRON_SECRET,

--- a/src/libs/analytics/events.ts
+++ b/src/libs/analytics/events.ts
@@ -34,6 +34,7 @@ export type EventName
     | 'profile_updated'
     | 'feature_first_use'
     | 'user_activated'
+    | 'platform_connected'
   // Error events
     | 'error_occurred'
   // Page events
@@ -156,6 +157,14 @@ export type ReferredSignupProperties = {
 };
 
 /**
+ * Properties for platform_connected event
+ * Tracks a successful third-party OAuth connection.
+ */
+export type PlatformConnectedProperties = {
+  provider: string;
+};
+
+/**
  * Type mapping from event names to their property types
  * This enables type-safe event tracking with TypeScript generics
  */
@@ -173,6 +182,7 @@ export type EventPropertiesMap = {
   profile_updated: ProfileUpdatedProperties;
   feature_first_use: FeatureFirstUseProperties;
   user_activated: UserActivatedProperties;
+  platform_connected: PlatformConnectedProperties;
   error_occurred: ErrorOccurredProperties;
   page_viewed: PageViewedProperties;
   landing_viewed: LandingViewedProperties;
@@ -197,6 +207,7 @@ export const EVENT_CATEGORIES: Record<EventName, EventCategory> = {
   profile_updated: EventCategory.Feature,
   feature_first_use: EventCategory.Feature,
   user_activated: EventCategory.Feature,
+  platform_connected: EventCategory.Feature,
   error_occurred: EventCategory.Error,
   page_viewed: EventCategory.Page,
   landing_viewed: EventCategory.Page,

--- a/src/libs/platforms/errors.test.ts
+++ b/src/libs/platforms/errors.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { sanitizePlatformError } from './errors';
+
+describe('sanitizePlatformError', () => {
+  it('strips the ". Details: …" diagnostics suffix', () => {
+    expect(
+      sanitizePlatformError('Failed to connect. Details: 401 unauthorized at internal.host'),
+    ).toBe('Failed to connect');
+  });
+
+  it('leaves a plain message untouched', () => {
+    expect(sanitizePlatformError('Failed to connect')).toBe('Failed to connect');
+  });
+});

--- a/src/libs/platforms/errors.ts
+++ b/src/libs/platforms/errors.ts
@@ -1,0 +1,11 @@
+/**
+ * Strips the `". Details: …"` suffix from a platform error message before
+ * surfacing it to the user. OAuth providers may append a `Details:` block with
+ * internal diagnostics that we want in logs/Sentry but not in the user-facing
+ * string.
+ */
+export const PLATFORM_ERROR_DETAILS_SUFFIX_RE = /\. Details:.*$/;
+
+export function sanitizePlatformError(message: string): string {
+  return message.replace(PLATFORM_ERROR_DETAILS_SUFFIX_RE, '');
+}

--- a/src/libs/platforms/get-platform-connections.ts
+++ b/src/libs/platforms/get-platform-connections.ts
@@ -1,0 +1,41 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import type { PlatformConnectionSafe, PlatformConnectionStatus } from './types';
+
+/**
+ * Fetch a user's platform connections in the SAFE shape (no encrypted tokens).
+ *
+ * The `.select()` allowlist deliberately omits `access_token` / `refresh_token`
+ * so tokens can never reach a response body — defense in depth alongside RLS.
+ */
+export async function getPlatformConnections(
+  // platform_connections is not in the generated supabase types.ts until
+  // `db:gen-types` runs against a live DB — accept any built client for now.
+  supabase: SupabaseClient<any, any, any>,
+  userId: string,
+): Promise<PlatformConnectionSafe[]> {
+  const { data, error } = await supabase
+    .from('platform_connections')
+    // Explicitly exclude access_token and refresh_token — never return encrypted tokens to client
+    .select('id, provider, provider_account_id, username, display_name, profile_picture_url, status, token_expires_at, created_at, updated_at')
+    .eq('user_id', userId);
+
+  if (error) {
+    throw error;
+  }
+
+  // Map snake_case DB columns to camelCase TypeScript
+  return (data ?? []).map((row: Record<string, unknown>) => ({
+    id: row.id as string,
+    userId,
+    provider: row.provider as PlatformConnectionSafe['provider'],
+    providerAccountId: row.provider_account_id as string,
+    username: row.username as string,
+    displayName: (row.display_name as string | null) ?? null,
+    profilePictureUrl: (row.profile_picture_url as string | null) ?? null,
+    status: row.status as PlatformConnectionStatus,
+    tokenExpiresAt: (row.token_expires_at as string | null) ?? null,
+    createdAt: row.created_at as string,
+    updatedAt: row.updated_at as string,
+  }));
+}

--- a/src/libs/platforms/oauth-provider.test.ts
+++ b/src/libs/platforms/oauth-provider.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { referenceOAuthProvider } from './oauth-provider';
+
+// Mock the Env module before importing oauth-provider.ts
+vi.mock('@/libs/Env', () => ({
+  Env: {
+    OAUTH_PROVIDER_CLIENT_ID: 'test-client-id',
+    OAUTH_PROVIDER_CLIENT_SECRET: 'test-client-secret',
+    NEXT_PUBLIC_APP_URL: 'http://localhost:3000',
+  },
+}));
+
+vi.mock('@/libs/Logger', () => ({
+  logger: { error: vi.fn() },
+}));
+
+describe('referenceOAuthProvider.getAuthUrl', () => {
+  it('returns a URL containing the client_id', () => {
+    const url = referenceOAuthProvider.getAuthUrl('test-state');
+
+    expect(url).toContain('client_id=test-client-id');
+  });
+
+  it('returns a URL pointing redirect_uri at the generic callback path', () => {
+    const url = referenceOAuthProvider.getAuthUrl('test-state');
+
+    expect(url).toContain('redirect_uri=');
+    expect(url).toContain('api%2Fauth%2Fcallback%2Fmy-provider');
+  });
+
+  it('returns a URL containing the state param', () => {
+    const state = 'abc123xyz';
+    const url = referenceOAuthProvider.getAuthUrl(state);
+
+    expect(url).toContain(`state=${state}`);
+  });
+
+  it('returns a URL containing the configured scopes', () => {
+    const url = referenceOAuthProvider.getAuthUrl('s');
+
+    // scope is URL-encoded
+    expect(url).toContain('scope=openid');
+    expect(url).toContain('email');
+  });
+
+  it('returns a URL with response_type=code', () => {
+    const url = referenceOAuthProvider.getAuthUrl('s');
+
+    expect(url).toContain('response_type=code');
+  });
+});
+
+describe('referenceOAuthProvider.exchangeCode', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('POSTs to the token endpoint with grant_type=authorization_code and code', async () => {
+    const mockFetch = vi.mocked(fetch);
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        access_token: 'acc',
+        expires_in: 3600,
+        token_type: 'Bearer' as const,
+        scope: 'openid profile',
+      }),
+    } as Response);
+
+    await referenceOAuthProvider.exchangeCode('auth-code-123');
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+
+    const [url, options] = mockFetch.mock.calls[0]!;
+
+    expect(url).toContain('/accessToken');
+    expect(options?.method).toBe('POST');
+
+    const body = options?.body?.toString() ?? '';
+
+    expect(body).toContain('grant_type=authorization_code');
+    expect(body).toContain('code=auth-code-123');
+  });
+
+  it('throws when the token endpoint returns non-OK status', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      text: async () => 'Bad Request',
+    } as Response);
+
+    await expect(referenceOAuthProvider.exchangeCode('bad-code')).rejects.toThrow('OAuth token exchange failed');
+  });
+});
+
+describe('referenceOAuthProvider.getUserInfo', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('GETs the userinfo endpoint with Authorization Bearer header', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        sub: 'provider-account-id',
+        name: 'Jane Smith',
+        given_name: 'Jane',
+        family_name: 'Smith',
+      }),
+    } as Response);
+
+    await referenceOAuthProvider.getUserInfo('my-access-token');
+
+    const [url, options] = vi.mocked(fetch).mock.calls[0]!;
+
+    expect(url).toContain('/userinfo');
+    expect((options?.headers as Record<string, string>)?.Authorization).toBe('Bearer my-access-token');
+  });
+
+  it('throws when the userinfo endpoint returns non-OK status', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      text: async () => 'Unauthorized',
+    } as Response);
+
+    await expect(referenceOAuthProvider.getUserInfo('expired-token')).rejects.toThrow('OAuth userinfo fetch failed');
+  });
+});
+
+describe('referenceOAuthProvider.refreshToken', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('POSTs to the token endpoint with grant_type=refresh_token', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        access_token: 'new-acc',
+        expires_in: 3600,
+        token_type: 'Bearer' as const,
+        scope: 'openid profile',
+      }),
+    } as Response);
+
+    await referenceOAuthProvider.refreshToken('my-refresh-token');
+
+    const [url, options] = vi.mocked(fetch).mock.calls[0]!;
+
+    expect(url).toContain('/accessToken');
+
+    const body = options?.body?.toString() ?? '';
+
+    expect(body).toContain('grant_type=refresh_token');
+    expect(body).toContain('refresh_token=my-refresh-token');
+  });
+
+  it('throws when the refresh endpoint returns non-OK status', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      text: async () => 'Bad Request',
+    } as Response);
+
+    await expect(referenceOAuthProvider.refreshToken('invalid-refresh')).rejects.toThrow('OAuth token refresh failed');
+  });
+});

--- a/src/libs/platforms/oauth-provider.ts
+++ b/src/libs/platforms/oauth-provider.ts
@@ -1,0 +1,168 @@
+import { Env } from '@/libs/Env';
+import { logger } from '@/libs/Logger';
+
+import type { OAuthTokenResponse, OAuthUserInfo } from './types';
+
+/**
+ * The key abstraction of the platforms layer.
+ *
+ * An `OAuthProvider` is the seam every consumer (connect/callback routes,
+ * token storage, refresh cron) talks to. Targeting a different first provider
+ * means swapping only the reference implementation below — this interface and
+ * all consumers stay put. Adding a second provider is a drop-in.
+ */
+export type OAuthProvider = {
+  /** Stable provider id (used in routes, the registry, and DB rows). */
+  readonly id: string;
+  /** Build the provider's authorization URL, carrying the CSRF `state`. */
+  getAuthUrl: (state: string) => string;
+  /** Exchange an authorization `code` for access/refresh tokens. */
+  exchangeCode: (code: string) => Promise<OAuthTokenResponse>;
+  /** Fetch the OpenID Connect userinfo for an access token. */
+  getUserInfo: (accessToken: string) => Promise<OAuthUserInfo>;
+  /** Exchange a refresh token for a fresh access token. */
+  refreshToken: (refreshToken: string) => Promise<OAuthTokenResponse>;
+};
+
+// ── Reference provider configuration ──────────────────────────────────────────
+// Neutral placeholder endpoints/scopes — the concrete implementation behind the
+// seam, NOT the contract. A fork targeting a real provider replaces only this
+// block with that provider's authorization/API URLs and scopes.
+//
+// Keep SCOPES to the minimum your integration needs (principle of least
+// privilege) — the OpenID baseline below is enough to identify a user.
+
+const PROVIDER_ID = 'my-provider';
+const AUTH_BASE = 'https://auth.example.com/oauth/v2';
+const API_BASE = 'https://api.example.com/v2';
+const SCOPES = 'openid profile email';
+
+/**
+ * Read a failed response's body for logging, truncated to a safe length.
+ * On the error paths this is an OAuth error payload, never tokens — but a
+ * non-standard provider could echo the submitted code/refresh_token in an error
+ * body, so we cap it rather than dumping the full response into logs.
+ */
+async function readErrorBody(res: Response): Promise<string> {
+  const body = await res.text().catch(() => '<unreadable>');
+  return body.length > 500 ? `${body.slice(0, 500)}…` : body;
+}
+
+function getAppUrl(): string {
+  return Env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000';
+}
+
+function getRedirectUri(): string {
+  return `${getAppUrl()}/api/auth/callback/${PROVIDER_ID}`;
+}
+
+function getCredentials(): { clientId: string; clientSecret: string } {
+  const clientId = Env.OAUTH_PROVIDER_CLIENT_ID;
+  const clientSecret = Env.OAUTH_PROVIDER_CLIENT_SECRET;
+  if (!clientId || !clientSecret) {
+    throw new Error('OAuth provider credentials are not configured');
+  }
+  return { clientId, clientSecret };
+}
+
+function getAuthUrl(state: string): string {
+  const clientId = Env.OAUTH_PROVIDER_CLIENT_ID;
+  if (!clientId) {
+    throw new Error('OAUTH_PROVIDER_CLIENT_ID is not configured');
+  }
+  const params = new URLSearchParams({
+    response_type: 'code',
+    client_id: clientId,
+    redirect_uri: getRedirectUri(),
+    scope: SCOPES,
+    state,
+  });
+  return `${AUTH_BASE}/authorization?${params.toString()}`;
+}
+
+async function exchangeCode(code: string): Promise<OAuthTokenResponse> {
+  const { clientId, clientSecret } = getCredentials();
+
+  const res = await fetch(`${AUTH_BASE}/accessToken`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: getRedirectUri(),
+      client_id: clientId,
+      client_secret: clientSecret,
+    }),
+  });
+
+  if (!res.ok) {
+    const body = await readErrorBody(res);
+    logger.error({ status: res.status, body, op: 'oauth_token_exchange' }, 'oauth provider call failed');
+    throw new Error(`OAuth token exchange failed: ${res.status}`);
+  }
+
+  return res.json() as Promise<OAuthTokenResponse>;
+}
+
+async function getUserInfo(accessToken: string): Promise<OAuthUserInfo> {
+  const res = await fetch(`${API_BASE}/userinfo`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+
+  if (!res.ok) {
+    const body = await readErrorBody(res);
+    logger.error({ status: res.status, body, op: 'oauth_userinfo' }, 'oauth provider call failed');
+    throw new Error(`OAuth userinfo fetch failed: ${res.status}`);
+  }
+
+  return res.json() as Promise<OAuthUserInfo>;
+}
+
+async function refreshToken(refreshTokenValue: string): Promise<OAuthTokenResponse> {
+  const { clientId, clientSecret } = getCredentials();
+
+  const res = await fetch(`${AUTH_BASE}/accessToken`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: refreshTokenValue,
+      client_id: clientId,
+      client_secret: clientSecret,
+    }),
+  });
+
+  if (!res.ok) {
+    const body = await readErrorBody(res);
+    logger.error({ status: res.status, body, op: 'oauth_token_refresh' }, 'oauth provider call failed');
+    throw new Error(`OAuth token refresh failed: ${res.status}`);
+  }
+
+  return res.json() as Promise<OAuthTokenResponse>;
+}
+
+/**
+ * Reference `OAuthProvider` implementation behind the seam. Swap the config
+ * block above (and these endpoints) to target a different provider; consumers
+ * import the registry, not this object's specifics.
+ */
+export const referenceOAuthProvider: OAuthProvider = {
+  id: PROVIDER_ID,
+  getAuthUrl,
+  exchangeCode,
+  getUserInfo,
+  refreshToken,
+};
+
+/**
+ * Provider registry, keyed by id. A second provider is a drop-in: add its
+ * implementation here. `getOAuthProvider` returns `null` for unknown ids so
+ * routes can fail with a clean error redirect.
+ */
+const PROVIDERS: Record<string, OAuthProvider> = {
+  [referenceOAuthProvider.id]: referenceOAuthProvider,
+};
+
+export function getOAuthProvider(id: string): OAuthProvider | null {
+  return PROVIDERS[id] ?? null;
+}

--- a/src/libs/platforms/oauth-token-storage.test.ts
+++ b/src/libs/platforms/oauth-token-storage.test.ts
@@ -1,0 +1,240 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { OAuthProvider } from './oauth-provider';
+import { storeOAuthTokens } from './oauth-token-storage';
+
+vi.mock('@/libs/Logger', () => ({
+  logger: { error: vi.fn() },
+}));
+
+const mockEncryptToken = vi.fn();
+
+vi.mock('@/libs/crypto/token-encryption', () => ({
+  encryptToken: (...args: unknown[]) => mockEncryptToken(...args),
+}));
+
+const MOCK_USER_INFO = {
+  sub: 'provider-account-123',
+  name: 'Jane Doe',
+  given_name: 'Jane',
+  family_name: 'Doe',
+  email: 'jane@example.com',
+  picture: 'https://cdn.example.com/photo.jpg',
+};
+
+const mockGetUserInfo = vi.fn();
+
+function makeProvider(): OAuthProvider {
+  return {
+    id: 'test-provider',
+    getAuthUrl: vi.fn(),
+    exchangeCode: vi.fn(),
+    getUserInfo: (...args: unknown[]) => mockGetUserInfo(...args),
+    refreshToken: vi.fn(),
+  };
+}
+
+function createMockSupabase({ upsertError = null }: { upsertError?: { message: string } | null } = {}) {
+  const upsert = vi.fn().mockResolvedValue({ error: upsertError });
+  const from = vi.fn().mockReturnValue({ upsert });
+
+  return { from, upsert } as const;
+}
+
+describe('storeOAuthTokens', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUserInfo.mockResolvedValue(MOCK_USER_INFO);
+    mockEncryptToken.mockImplementation((token: string) => `encrypted:${token}`);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetches user info, encrypts tokens, and upserts platform_connections', async () => {
+    const { from, upsert } = createMockSupabase();
+
+    const result = await storeOAuthTokens({
+      provider: makeProvider(),
+      userId: 'user-abc',
+      providerToken: 'access-token-123',
+      providerRefreshToken: 'refresh-token-456',
+      scope: 'openid profile email',
+      supabase: { from } as any,
+      expiresIn: 3600,
+    });
+
+    expect(result).toEqual({
+      success: true,
+      providerAccountId: 'provider-account-123',
+      username: 'Jane Doe',
+    });
+
+    // User info fetched via the provider seam with the access token
+    expect(mockGetUserInfo).toHaveBeenCalledWith('access-token-123');
+
+    // Both tokens were encrypted
+    expect(mockEncryptToken).toHaveBeenCalledWith('access-token-123');
+    expect(mockEncryptToken).toHaveBeenCalledWith('refresh-token-456');
+
+    // Upsert called with correct table
+    expect(from).toHaveBeenCalledWith('platform_connections');
+
+    // Upsert data matches expected shape
+    const upsertData = upsert.mock.calls[0]![0];
+
+    expect(upsertData.user_id).toBe('user-abc');
+    expect(upsertData.provider).toBe('test-provider');
+    expect(upsertData.access_token).toBe('encrypted:access-token-123');
+    expect(upsertData.refresh_token).toBe('encrypted:refresh-token-456');
+    expect(upsertData.provider_account_id).toBe('provider-account-123');
+    expect(upsertData.username).toBe('Jane Doe');
+    expect(upsertData.profile_picture_url).toBe('https://cdn.example.com/photo.jpg');
+    expect(upsertData.scope).toBe('openid profile email');
+    // status must be set explicitly: the column default only fires on INSERT, so
+    // a re-connect of an 'expired' row would otherwise stay 'expired'.
+    expect(upsertData.status).toBe('connected');
+
+    // Conflict resolution on user_id + provider
+    const upsertOptions = upsert.mock.calls[0]![1];
+
+    expect(upsertOptions).toEqual({ onConflict: 'user_id,provider' });
+  });
+
+  it('handles null refresh token (provider may not issue one)', async () => {
+    const { from, upsert } = createMockSupabase();
+
+    const result = await storeOAuthTokens({
+      provider: makeProvider(),
+      userId: 'user-abc',
+      providerToken: 'access-token-123',
+      providerRefreshToken: null,
+      supabase: { from } as any,
+    });
+
+    expect(result.success).toBe(true);
+
+    // Only access token should be encrypted
+    expect(mockEncryptToken).toHaveBeenCalledTimes(1);
+    expect(mockEncryptToken).toHaveBeenCalledWith('access-token-123');
+
+    // Refresh token should be null in upsert
+    expect(upsert.mock.calls[0]![0].refresh_token).toBeNull();
+  });
+
+  it('prefers preferred_username (provider handle) over the full name', async () => {
+    mockGetUserInfo.mockResolvedValue({
+      ...MOCK_USER_INFO,
+      preferred_username: 'janedoe',
+    });
+
+    const { from, upsert } = createMockSupabase();
+
+    const result = await storeOAuthTokens({
+      provider: makeProvider(),
+      userId: 'user-abc',
+      providerToken: 'token',
+      supabase: { from } as any,
+    });
+
+    // username takes the handle; display_name keeps the full name
+    expect(upsert.mock.calls[0]![0].username).toBe('janedoe');
+    expect(upsert.mock.calls[0]![0].display_name).toBe('Jane Doe');
+    expect(result).toMatchObject({ success: true, username: 'janedoe' });
+  });
+
+  it('defaults scope to null when not provided', async () => {
+    const { from, upsert } = createMockSupabase();
+
+    await storeOAuthTokens({
+      provider: makeProvider(),
+      userId: 'user-abc',
+      providerToken: 'token',
+      supabase: { from } as any,
+    });
+
+    expect(upsert.mock.calls[0]![0].scope).toBeNull();
+  });
+
+  it('handles missing profile picture', async () => {
+    mockGetUserInfo.mockResolvedValue({
+      ...MOCK_USER_INFO,
+      picture: undefined,
+    });
+
+    const { from, upsert } = createMockSupabase();
+
+    await storeOAuthTokens({
+      provider: makeProvider(),
+      userId: 'user-abc',
+      providerToken: 'token',
+      supabase: { from } as any,
+    });
+
+    expect(upsert.mock.calls[0]![0].profile_picture_url).toBeNull();
+  });
+
+  it('uses default 60-day expiry when expiresIn not provided', async () => {
+    const { from, upsert } = createMockSupabase();
+    const now = Date.now();
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+
+    await storeOAuthTokens({
+      provider: makeProvider(),
+      userId: 'user-abc',
+      providerToken: 'token',
+      supabase: { from } as any,
+    });
+
+    const tokenExpiresAt = upsert.mock.calls[0]![0].token_expires_at;
+    const expectedExpiry = new Date(now + 5_184_000 * 1000).toISOString();
+
+    expect(tokenExpiresAt).toBe(expectedExpiry);
+  });
+
+  it('returns db_error when upsert fails', async () => {
+    const { from } = createMockSupabase({
+      upsertError: { message: 'duplicate key violation' },
+    });
+
+    const result = await storeOAuthTokens({
+      provider: makeProvider(),
+      userId: 'user-abc',
+      providerToken: 'token',
+      supabase: { from } as any,
+    });
+
+    expect(result).toEqual({ success: false, error: 'db_error' });
+  });
+
+  it('returns error when getUserInfo throws', async () => {
+    mockGetUserInfo.mockRejectedValue(new Error('Provider API down'));
+
+    const { from } = createMockSupabase();
+
+    const result = await storeOAuthTokens({
+      provider: makeProvider(),
+      userId: 'user-abc',
+      providerToken: 'token',
+      supabase: { from } as any,
+    });
+
+    expect(result).toEqual({ success: false, error: 'Provider API down' });
+  });
+
+  it('returns unknown_error for non-Error throws', async () => {
+    mockGetUserInfo.mockRejectedValue('string error');
+
+    const { from } = createMockSupabase();
+
+    const result = await storeOAuthTokens({
+      provider: makeProvider(),
+      userId: 'user-abc',
+      providerToken: 'token',
+      supabase: { from } as any,
+    });
+
+    expect(result).toEqual({ success: false, error: 'unknown_error' });
+  });
+});

--- a/src/libs/platforms/oauth-token-storage.ts
+++ b/src/libs/platforms/oauth-token-storage.ts
@@ -1,0 +1,94 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import { encryptToken } from '@/libs/crypto/token-encryption';
+import { logger } from '@/libs/Logger';
+
+import type { OAuthProvider } from './oauth-provider';
+import type { OAuthCallbackResult } from './types';
+
+const DEFAULT_TOKEN_EXPIRY_SECONDS = 5_184_000; // 60 days
+
+// platform_connections is not in the generated supabase types.ts until
+// `db:gen-types` runs against a live DB, so callers pass any client built by
+// `@/libs/supabase/{server,admin}`. Narrow this once the table is in the
+// generated types and the createClient factory is typed.
+type PlatformSupabaseClient = SupabaseClient<any, any, any>;
+
+/**
+ * Stores OAuth tokens for a provider in `platform_connections`.
+ *
+ * Talks to the provider only through the `OAuthProvider` seam (`getUserInfo`),
+ * so a second provider drops in with no change here. Tokens are encrypted
+ * (AES-256-GCM) before being written; the safe fetcher never selects them back.
+ */
+export async function storeOAuthTokens({
+  provider,
+  userId,
+  providerToken,
+  providerRefreshToken,
+  scope = null,
+  supabase,
+  expiresIn = DEFAULT_TOKEN_EXPIRY_SECONDS,
+}: {
+  provider: OAuthProvider;
+  userId: string;
+  providerToken: string;
+  providerRefreshToken?: string | null;
+  /** Scopes granted on this connection (from the token response), if known. */
+  scope?: string | null;
+  supabase: PlatformSupabaseClient;
+  expiresIn?: number;
+}): Promise<OAuthCallbackResult> {
+  try {
+    // Fetch the provider profile using the access token (via the seam)
+    const userInfo = await provider.getUserInfo(providerToken);
+
+    // Encrypt tokens before storing
+    const encryptedAccessToken = encryptToken(providerToken);
+    const encryptedRefreshToken = providerRefreshToken
+      ? encryptToken(providerRefreshToken)
+      : null;
+
+    const tokenExpiresAt = new Date(
+      Date.now() + expiresIn * 1000,
+    ).toISOString();
+
+    // Upsert — handles both new connections and token refreshes on re-connect
+    const { error: upsertError } = await supabase
+      .from('platform_connections')
+      .upsert(
+        {
+          user_id: userId,
+          provider: provider.id,
+          access_token: encryptedAccessToken,
+          refresh_token: encryptedRefreshToken,
+          token_expires_at: tokenExpiresAt,
+          provider_account_id: userInfo.sub,
+          // Prefer a provider handle when available; fall back to the full name.
+          username: userInfo.preferred_username ?? userInfo.name,
+          display_name: userInfo.name,
+          profile_picture_url: userInfo.picture ?? null,
+          scope,
+          // Column default ('connected') only fires on INSERT — set it explicitly
+          // so re-connecting an 'expired' row is reset back to 'connected'.
+          status: 'connected',
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: 'user_id,provider' },
+      );
+
+    if (upsertError) {
+      logger.error({ error: upsertError }, 'OAuth token storage: platform_connections upsert failed');
+      return { success: false, error: 'db_error' };
+    }
+
+    return {
+      success: true,
+      providerAccountId: userInfo.sub,
+      username: userInfo.preferred_username ?? userInfo.name,
+    };
+  } catch (err) {
+    logger.error({ error: err }, 'OAuth token storage failed');
+    return { success: false, error: err instanceof Error ? err.message : 'unknown_error' };
+  }
+}

--- a/src/libs/platforms/types.ts
+++ b/src/libs/platforms/types.ts
@@ -1,0 +1,55 @@
+/**
+ * Generic single-provider OAuth types.
+ *
+ * The token/user-info shapes follow the OpenID Connect standard so they map
+ * cleanly onto most providers. To target a different first provider, swap the
+ * reference implementation in `oauth-provider.ts` — these types stay put.
+ */
+
+// Free-text provider id (single-provider today, extensible to many).
+export type PlatformType = string;
+
+export type PlatformConnectionStatus = 'connected' | 'expired' | 'disconnected';
+
+export type PlatformConnection = {
+  id: string;
+  userId: string;
+  provider: PlatformType;
+  accessToken: string; // encrypted at rest
+  refreshToken: string | null;
+  tokenExpiresAt: string | null; // ISO 8601
+  providerAccountId: string;
+  username: string;
+  displayName: string | null;
+  profilePictureUrl: string | null;
+  status: PlatformConnectionStatus;
+  createdAt: string; // ISO 8601
+  updatedAt: string; // ISO 8601
+};
+
+// Safe read model — never exposes tokens.
+export type PlatformConnectionSafe = Omit<PlatformConnection, 'accessToken' | 'refreshToken'>;
+
+export type OAuthTokenResponse = {
+  access_token: string;
+  expires_in: number; // seconds until expiry
+  refresh_token?: string;
+  refresh_token_expires_in?: number;
+  token_type: 'Bearer';
+  scope: string;
+};
+
+// OpenID Connect standard userinfo fields.
+export type OAuthUserInfo = {
+  sub: string; // stable provider account id
+  name: string; // full display name
+  preferred_username?: string; // provider handle / short username (OIDC optional)
+  given_name: string;
+  family_name: string;
+  email?: string;
+  picture?: string;
+};
+
+export type OAuthCallbackResult
+  = | { success: true; providerAccountId: string; username: string }
+    | { success: false; error: string };

--- a/src/models/schema/index.ts
+++ b/src/models/schema/index.ts
@@ -4,6 +4,7 @@ export { DB_SCHEMA_NAME, vtSaasSchema } from './_db-schema';
 // Re-export all table definitions + enums (sorted alphabetically by module)
 export { adminAuditLog } from './audit';
 export { feedback, feedbackStatusEnum, feedbackTypeEnum } from './feedback';
+export { platformConnections } from './platform-connections';
 export { userPreferences } from './preferences';
 export { shareableLinks } from './share-links';
 export { threads } from './threads';

--- a/src/models/schema/platform-connections.ts
+++ b/src/models/schema/platform-connections.ts
@@ -1,0 +1,41 @@
+import { sql } from 'drizzle-orm';
+import { index, smallint, text, timestamp, unique, uuid } from 'drizzle-orm/pg-core';
+
+import { vtSaasSchema } from './_db-schema';
+
+// Stores encrypted third-party OAuth credentials, one row per (user, provider).
+// `provider` is free-text (single-provider today, extensible to many).
+export const platformConnections = vtSaasSchema.table(
+  'platform_connections',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    userId: uuid('user_id').notNull(),
+    provider: text('provider').notNull(),
+    accessToken: text('access_token').notNull(), // stored AES-256-GCM encrypted
+    // Which TOKEN_ENCRYPTION_KEY version encrypted access_token/refresh_token.
+    // Lets the decrypt path branch on key version during a future key rotation.
+    encryptionKeyVersion: smallint('encryption_key_version').notNull().default(1),
+    refreshToken: text('refresh_token'), // nullable — not all providers issue refresh tokens
+    tokenExpiresAt: timestamp('token_expires_at', { withTimezone: true }),
+    providerAccountId: text('provider_account_id').notNull(), // stable provider account id (OIDC `sub`)
+    username: text('username').notNull(), // provider display name / handle
+    displayName: text('display_name'), // human-readable name (e.g. "Jane Smith")
+    profilePictureUrl: text('profile_picture_url'),
+    scope: text('scope'), // OAuth scopes granted on the connection
+    status: text('status').notNull().default('connected'),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  table => ({
+    userIdIdx: index('idx_platform_connections_user_id').on(table.userId),
+    userProviderUnique: unique('uq_platform_connections_user_provider').on(table.userId, table.provider),
+    // Backs a future every-N-min token-refresh cron:
+    // `SELECT … WHERE token_expires_at > NOW() AND … < NOW() + interval`.
+    tokenExpiresAtIdx: index('idx_platform_connections_token_expires_at')
+      .on(table.tokenExpiresAt)
+      .where(sql`token_expires_at IS NOT NULL`),
+  }),
+);
+
+export type PlatformConnectionRow = typeof platformConnections.$inferSelect;
+export type InsertPlatformConnection = typeof platformConnections.$inferInsert;

--- a/supabase/prod-setup.sql
+++ b/supabase/prod-setup.sql
@@ -177,6 +177,20 @@ DO $$ BEGIN
   END IF;
 END $$;
 
+-- platform_connections: user-owned third-party OAuth credentials (encrypted
+-- tokens). CASCADE so deleting a user erases their stored credentials, same
+-- rationale as mem0_memories.
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_schema = 'vt_saas' AND constraint_name = 'fk_platform_connections_auth_users'
+  ) THEN
+    ALTER TABLE "vt_saas"."platform_connections"
+      ADD CONSTRAINT fk_platform_connections_auth_users
+      FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+  END IF;
+END $$;
+
 -- ============================================================
 -- 4. ROW-LEVEL SECURITY
 -- ============================================================
@@ -281,6 +295,24 @@ CREATE POLICY "mem0_memories_update_own" ON "vt_saas"."mem0_memories"
   FOR UPDATE USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
 DROP POLICY IF EXISTS "mem0_memories_delete_own" ON "vt_saas"."mem0_memories";
 CREATE POLICY "mem0_memories_delete_own" ON "vt_saas"."mem0_memories"
+  FOR DELETE USING (auth.uid() = user_id);
+
+-- ---- platform_connections ----
+-- User-owned third-party OAuth credentials. Direct user_id → scope to the owner.
+-- DB-layer RLS here is defense in depth alongside the app-layer safe fetcher
+-- (get-platform-connections.ts) that excludes the encrypted token columns.
+ALTER TABLE "vt_saas"."platform_connections" ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "platform_connections_select_own" ON "vt_saas"."platform_connections";
+CREATE POLICY "platform_connections_select_own" ON "vt_saas"."platform_connections"
+  FOR SELECT USING (auth.uid() = user_id);
+DROP POLICY IF EXISTS "platform_connections_insert_own" ON "vt_saas"."platform_connections";
+CREATE POLICY "platform_connections_insert_own" ON "vt_saas"."platform_connections"
+  FOR INSERT WITH CHECK (auth.uid() = user_id);
+DROP POLICY IF EXISTS "platform_connections_update_own" ON "vt_saas"."platform_connections";
+CREATE POLICY "platform_connections_update_own" ON "vt_saas"."platform_connections"
+  FOR UPDATE USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+DROP POLICY IF EXISTS "platform_connections_delete_own" ON "vt_saas"."platform_connections";
+CREATE POLICY "platform_connections_delete_own" ON "vt_saas"."platform_connections"
   FOR DELETE USING (auth.uid() = user_id);
 
 -- ---- vercel_messages ----


### PR DESCRIPTION
## What

Ports ContentFlow's battle-tested third-party OAuth layer into the template as a **generic, single-provider** skeleton. The product-specific LinkedIn/Twitter coupling is removed; what remains is a clean seam any fork can point at its own provider.

### Added (`src/libs/platforms/`)
- **`oauth-provider.ts`** — the key abstraction: a generic `OAuthProvider` interface (`getAuthUrl`, `exchangeCode`, `getUserInfo`, `refreshToken`) plus **one reference implementation** behind the seam. A second provider is a drop-in.
- **`oauth-token-storage.ts`** — `storeOAuthTokens(provider, …)`: encrypts tokens (via the existing `@/libs/crypto/token-encryption`) and upserts `platform_connections`, calling the provider only through `getUserInfo()`.
- **`get-platform-connections.ts`** — safe fetcher whose `SELECT` allowlist excludes the token columns, so tokens can never reach a response body.
- **`errors.ts`** — strips internal diagnostics from provider errors before they're surfaced to users.
- **`types.ts`** — `PlatformConnectionSafe` (no token fields) + generic OAuth response/user-info types.

### Routes
- **`/api/auth/connect/[provider]`** — sets an httpOnly, `sameSite=lax`, 5-min CSRF state cookie and redirects into the provider's auth URL.
- **`/api/auth/callback/[provider]`** — `exchange → getUser → store → redirect` with a timing-safe state compare. The success/error redirect path is **parameterized** (no hardcoded product route).

### Schema & DB
- New `src/models/schema/platform-connections.ts` (generic `provider` / `provider_account_id`, encrypted access/refresh tokens, `expires_at`, `scope`, `status`, `encryption_key_version` for key rotation), registered in the schema index. Migration captured via `db:generate`.
- `supabase/prod-setup.sql`: idempotent cross-schema FK to `auth.users` (`ON DELETE CASCADE`) and **owner-only RLS** (`auth.uid() = user_id`), mirroring the existing `threads`/`mem0_memories` idioms — defense in depth alongside the app-layer safe fetcher.

### Config
- `Env.ts` + `.env.example`: generic `OAUTH_PROVIDER_CLIENT_ID` / `OAUTH_PROVIDER_CLIENT_SECRET` (optional). `TOKEN_ENCRYPTION_KEY` and `NEXT_PUBLIC_APP_URL` already existed and are reused.
- `analytics/events.ts`: type-safe `platform_connected` event added to `EventName`, `EventPropertiesMap`, and `EVENT_CATEGORIES`.

## Not included (deliberate)
- **Twitter/X** — dropped (dormant, not battle-tested; plan caveat #5). The seam makes adding it later trivial.
- **LinkedIn post-publish / image-upload** — product publishing, not auth; belongs with the publish flow.
- **`redirectUnauthToLanding` / `landing-auth-url`** — part of the separate "Auth URL builders" group; routes use an inline `/{locale}/sign-in` redirect matching `src/proxy.ts` for now.
- **Token-refresh cron** — `refreshToken()` is on the interface and the `token_expires_at` index is in place, but the Inngest cron that consumes it is a separate group.

## Notes for downstream
- The contract is the **`OAuthProvider` seam**, not the reference provider's specific endpoints/scopes. To target a different first provider, swap only the reference implementation — interface and all consumers stay put.
- `platform_connections` is an empty, RLS-protected, owner-only table on `db:migrate`; harmless if a fork never wires up the connect flow.
- Reuses the on-main `token-encryption` lib — encrypt/decrypt are **not** re-ported.

## Tests
- `oauth-provider.test.ts` — auth methods only (auth-url / exchange / userinfo / refresh).
- `oauth-token-storage.test.ts` — 7 cases (encrypt+upsert, null refresh, missing picture, default expiry, db error, getUserInfo throws, non-Error throw).
- `npm run check-types` + `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)