### PR TITLE
feat(subscriptions): net-new Stripe billing + quota framework + config-gated reverse-trial

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -135,6 +135,25 @@ SENTRY_AUTH_TOKEN=
 INNGEST_EVENT_KEY=
 INNGEST_SIGNING_KEY=
 
+# --- Stripe (billing) ---
+# Optional — billing is disabled if unset. The Stripe client is lazy and all keys
+# are optional, so an unconfigured fork builds and runs unaffected.
+# Get keys at https://dashboard.stripe.com/apikeys; the webhook secret comes from
+# the endpoint you create for POST /api/stripe/webhook.
+STRIPE_SECRET_KEY=
+STRIPE_WEBHOOK_SECRET=
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=
+
+# --- Reverse-trial policy (opt-in) ---
+# ENABLE_REVERSE_TRIAL gates ONLY the TS layer: when 'true', the daily
+# force-expire + expiry-warning crons run; when 'false' they no-op. The actual
+# signup enrollment is the prod-setup.sql signup trigger, which is INDEPENDENTLY
+# opt-in (it ships enrolling users on the FREE tier; uncomment the trial variant
+# to enroll on a Pro trial).
+# ⚠️ DUAL-SOURCE: TRIAL_DAYS here must match the INTERVAL literal in that trigger.
+ENABLE_REVERSE_TRIAL=false
+TRIAL_DAYS=14
+
 # --- SEO ---
 NEXT_PUBLIC_SITE_URL=https://www.example.com
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,6 +57,7 @@
 - [Error Handling Guide](./error-handling-guide.md) - Error boundaries and patterns
 - [API Error Handling](./api-error-handling.md) - Error codes and responses
 - [Email System](./email-system.md) - Resend integration and templates
+- [Subscriptions & Billing](./subscriptions.md) - Tiers, quota framework, Stripe webhook, reverse-trial, lifecycle emails
 - [Admin Setup](./admin-setup.md) - Admin panel configuration
 - [CI/CD Pipeline](./ci-cd-pipeline.md) - Pipeline details
 - [CI/CD Troubleshooting](./ci-cd-troubleshooting.md) - Common CI issues

--- a/docs/subscriptions.md
+++ b/docs/subscriptions.md
@@ -1,0 +1,247 @@
+# Subscriptions & Billing
+
+End-to-end reference for the subscription subsystem: tier catalogue, the generic
+quota framework, Stripe billing, the config-gated reverse-trial, lifecycle
+emails, and the ops/bootstrap order.
+
+Everything here is **product-agnostic**. There are no AI-model or content
+specifics — the quota framework meters generic "units" and a product maps them to
+whatever it charges for.
+
+---
+
+## At a glance
+
+| Piece | Where |
+|---|---|
+| Schema (5 tables) | `src/models/schema/{subscription-tiers,user-subscriptions,tier-quotas,resource-usage,stripe-webhook-events}.ts` |
+| Quota framework | `src/libs/subscriptions/{period,usage,quota,get-subscription-usage}.ts` |
+| Stripe client + webhook | `src/libs/stripe/client.ts`, `src/app/api/stripe/webhook/route.ts` (idempotency ledger: `stripe_webhook_events`) |
+| Billing actions | `src/libs/actions/billing.ts` (`createCheckoutSession`, `createPortalSession`) |
+| Blocking helper | `src/libs/jobs/blocking.ts` (`blockScheduledTasksForUser`) |
+| Reverse-trial crons | `src/libs/inngest/functions/{force-expire-trials-and-promotions,trial-promotion-expiry-warnings}.ts` |
+| Lifecycle emails | `src/libs/email/sendSubscriptionEmails.tsx` + `templates/{ExpiryReminder,SubscriptionStarted,SubscriptionEnded,PromotionGranted}Email.tsx` |
+| UI | `src/components/subscriptions/*`, hook `src/libs/hooks/use-subscription-usage.ts` |
+| Config | `src/libs/Env.ts`, `.env.example`, `src/libs/analytics/events.ts` |
+| SQL homes | `supabase/seed.sql`, `supabase/prod-setup.sql` |
+
+---
+
+## Tiers & lifecycle states
+
+`subscription_tiers` is a lookup catalogue. Three generic slugs are seeded
+(`supabase/seed.sql`); a product keeps the slugs and replaces the display copy +
+Stripe price ids:
+
+- **free** — the default tier. No premium pool, a modest fallback budget.
+- **pro** — the paid tier (has Stripe price ids monthly/yearly).
+- **promotion** — optional, admin-granted full access with its own `expires_at`.
+  Coherent with the subsystem but adds surface; drop it if you don't need
+  admin-granted access.
+
+Each user has exactly one `user_subscriptions` row (created by the signup
+trigger). Its `status` is one of `active | trial | expired | cancelled`
+(text-typed union, guarded by a CHECK in prod-setup.sql). `billing_interval` is
+`monthly | yearly | null`.
+
+---
+
+## Quota framework (generic two-pool metering)
+
+The framework is AI-agnostic. Each `(tier, resource_type)` row in `tier_quotas`
+defines two pools a request draws from **in order**:
+
+- **premium** — used while budget remains (`premium_units_used < premium_period_limit`).
+- **fallback** — the always-configured pool used once premium is exhausted.
+
+`premium_unit_key` / `fallback_unit_key` are opaque labels (nullable premium key
+= no premium pool). A product maps them to whatever it meters: AI model ids, a
+rate-limit bucket, a credit type. **Units** are generic integers — tokens, API
+calls, generations.
+
+A pool with a **zero** `period_limit` is explicitly disabled for that tier (never
+"infinite budget"). Setting both limits to 0 blocks the resource entirely for
+that tier.
+
+### Rolling period + anchor reset
+
+`getCurrentPeriod(anchorAt)` (`period.ts`) returns the current rolling window
+(`PERIOD_MS`, default 7 days). The anchor is `user_subscriptions.current_period_anchor_at`
+(falling back to `started_at`). It is **reset to now on every tier transition**
+(trial→active, →free, etc.) so a user's first window after a change starts at the
+change, not at signup.
+
+### Resolving + gating
+
+`checkQuota(user, resourceType)` / `checkQuotaByUserId(userId, resourceType)`
+(`quota.ts`) return a `QuotaDecision`:
+
+- `enforce: true` (default) — full gate. `allowed` reflects real usage; emits a
+  `quota_limit_reached` analytics event when both pools are exhausted.
+- `enforce: false` — selection only; `allowed` is always true but `unitKey` is
+  still premium-aware (downgrades to fallback when premium is spent).
+
+State is cached in-memory for 60s; invalidate with `invalidateQuotaCache(userId, resourceType)`
+after recording usage or on a billing transition.
+
+`recordUsage(userId, resourceType, unitKey, units, premiumUnitKey)` (`usage.ts`)
+upserts the period ledger atomically, retrying once on transient pg errors
+(deadlock `40P01` / serialization `40001`) and warning Sentry (never throwing)
+if it still fails — usage recording must not break the user's request.
+
+### Lazy vs cron expiry
+
+A trial/promotion can expire between cron ticks. `quota.ts` handles this **lazily**:
+on the next quota read it detects the passed `trial_expires_at` / `expires_at`,
+demotes the user to free, blocks their scheduled tasks, and re-reads. The daily
+cron (below) is the eager counterpart.
+
+---
+
+## Stripe
+
+`getStripe()` (`client.ts`) is a lazy singleton — it only constructs when
+`STRIPE_SECRET_KEY` is set, so an unconfigured fork builds fine. The API version
+is pinned to the SDK's shipped version; bump it (and re-test) on a major upgrade.
+
+**Webhook** (`/api/stripe/webhook`) handles four events. It uses Stripe's own
+`constructEvent` signature verification — it is **intentionally not** routed
+through `withWebhookSecret` (that guards `X-Webhook-Secret` inbound hooks, a
+different mechanism). `runtime = 'nodejs'` is required.
+
+| Event | Effect |
+|---|---|
+| `checkout.session.completed` | Map price→tier, set status active/trial, reset anchor, send "started" email, track `subscription_converted` (checkout) |
+| `invoice.paid` | Confirm/restore `active`; if it observes a trial→active transition, reset anchor + track `subscription_converted` (trial_upgrade) |
+| `customer.subscription.updated` | Re-map tier, sync status, reset anchor on trial→active (track conversion), record `cancel_at` → `expires_at` |
+| `customer.subscription.deleted` | Downgrade to free, block scheduled tasks, send "ended" email, track `subscription_cancelled` |
+
+**Idempotency & ordering.** Every delivery is recorded in `stripe_webhook_events`
+(`event.id` PK) before processing; a re-delivery (Stripe retries the same id on a
+non-2xx) short-circuits with `200 { duplicate: true }` so the analytics events +
+lifecycle emails fire exactly once. If the handler throws after claiming the id,
+the claim is released so the retry re-processes cleanly. The trial→active anchor
+reset + `trial_upgrade` conversion are **order-independent**: whichever of
+`invoice.paid` / `customer.subscription.updated` observes the local status still
+`trial` performs them and flips the row to `active`; the later event sees `active`
+and skips — so they happen once regardless of delivery order.
+
+Cache invalidation is generic: it iterates the resource types defined across all
+tiers (vs a hardcoded resource list).
+
+**Billing actions** (`billing.ts`) return `ActionResult<T>` via `withActionAuth`:
+`createCheckoutSession(tierName, { interval })` and
+`createPortalSession({ intent })`. The success/return path is a single
+`BILLING_RETURN_PATH` const at the top of the file — repoint it to your billing
+page.
+
+---
+
+## Reverse-trial (opt-in)
+
+Reverse-trial = enroll every new user in an N-day trial on Pro (no card), then
+auto-demote. It is layered on top of the subsystem as **two independent opt-in
+switches**:
+
+1. **Signup enrollment** — the `handle_new_user_subscription` trigger in
+   `prod-setup.sql`. It ships enrolling users on the **free** tier
+   (safe-by-default). To enable the trial, swap in the commented Pro-trial
+   variant in that file and re-run it.
+2. **TS layer** — `ENABLE_REVERSE_TRIAL` (env). When `false` (default) the two
+   expiry crons no-op. Flip to `true` when you enable the trigger variant.
+
+> ⚠️ **Dual-source `TRIAL_DAYS` caveat.** The trial length lives in two places:
+> the `TRIAL_DAYS` env var (gates the TS crons / UI) **and** the `INTERVAL '14 days'`
+> literal in the SQL trigger (SQL can't read a TS env var). Keep them in sync.
+
+### Crons (Inngest)
+
+Both are registered in `src/app/api/inngest/route.ts` and no-op internally when
+`ENABLE_REVERSE_TRIAL` is off. Ordering matters — the warning runs **before** the
+demotion so the nudge lands first:
+
+- **09:00 UTC** — `trial-promotion-expiry-warnings`: sends T-3 / day-of / T+1
+  emails for trials + promotions, with a 12h idempotency guard per user
+  (`last_trial_warning_sent_at` / `last_promotion_warning_sent_at`).
+- **10:00 UTC** — `force-expire-trials-and-promotions`: demotes expired trials +
+  promotions to free, blocks their scheduled tasks, invalidates their caches.
+
+Both export their body as a named function so tests exercise the logic directly
+(matches the template's `scheduled-tasks.ts` pattern).
+
+### Blocking helper
+
+`blockScheduledTasksForUser(userId, reason)` (`src/libs/jobs/blocking.ts`)
+transitions a downgraded user's `scheduled` tasks to `blocked` (free-text
+`blocked_reason`). This is the documented use of the template's `scheduled_tasks.blocked`
+status — no new table, no subscription dependency on the jobs schema.
+
+---
+
+## Lifecycle emails
+
+Built on the template email system (`sendEmailAsync` fire-and-forget,
+`EmailLayout` primitives, the lifecycle sender persona). **All product copy is in
+props** (`appName` from `EMAIL_FROM_NAME`, `tierName` from the caller) — the
+templates carry no brand strings.
+
+- `ExpiryReminderEmail` — T-3 / day-of (`0`) / T+1 (`-1`) for trial or promotion.
+- `SubscriptionStartedEmail` — first paid subscription (Stripe sends its own receipt).
+- `SubscriptionEndedEmail` — downgrade to free.
+- `PromotionGrantedEmail` — admin-granted access with an expiry date.
+
+> **Promotion-grant entry point is intentionally product-owned.** The subsystem
+> ships the promotion *lifecycle* (expiry crons, lazy demotion, the
+> `PromotionGrantedEmail` template) but **no grant action** — `sendPromotionGrantedEmail`
+> has no caller by design. How a promotion is granted (an admin panel action, a
+> CLI, a one-off SQL update) is a product decision, so the grant surface is left to
+> the product shell — same as the `/subscriptions` page above. To wire one up, set
+> the user's tier to `promotion` with an `expires_at`, then call
+> `sendPromotionGrantedEmail`.
+
+---
+
+## UI
+
+The high-value, tested decision logic ships product-agnostic:
+
+- `expiry-banner.tsx` — `pickBanner()` / `thresholdForDays()` decide which
+  countdown banner (trial / promotion / cancelled-paid) to show.
+- `tier-cta.ts` — `getCtaConfig()` decides each tier card's CTA label/variant.
+- `trial-status-pill.tsx`, `tier-card.tsx`, `plan-gate-dialog.tsx` — display
+  surfaces with copy/tiers as props.
+
+Data flows through `useSubscriptionUsage()` (`src/libs/hooks/use-subscription-usage.ts`),
+a thin TanStack hook over `GET /api/subscriptions/usage` (which calls
+`getSubscriptionUsage`). The query key lives in the `queryKeys.subscription`
+factory; `useInvalidateSubscriptionUsage()` refreshes it after a billing action.
+
+A full `/subscriptions` page is intentionally left to the product shell — ship
+the primitives, compose the page per product.
+
+---
+
+## Bootstrap / ops order
+
+Fresh-environment order (see [`database-workflow.md`](./database-workflow.md) for
+the three-home model):
+
+1. `npm run db:migrate` — creates the 5 tables (journal-driven migration).
+2. `psql -f supabase/seed.sql` — seeds the tiers + quota rows. **Required before
+   step 3** if you enable the trial trigger (it RAISEs without the tiers), and
+   the quota free-tier safety net throws without the seeded free tier.
+3. `psql -f supabase/prod-setup.sql` — grants, signup trigger, cross-schema FKs,
+   RLS, and the status/`billing_interval` CHECK guards.
+
+**RLS:** `subscription_tiers` + `tier_quotas` are read-only for authenticated
+users; `user_subscriptions` is select-own (writes are server-only);
+`resource_usage` + `stripe_webhook_events` are server-only (RLS on, no policy).
+
+---
+
+## Related
+
+- [`database-workflow.md`](./database-workflow.md) — three-home migration model.
+- [`email-system.md`](./email-system.md) — the email primitives these build on.
+- [`patterns/background-jobs.md`](./patterns/background-jobs.md) — the
+  `scheduled_tasks` job patterns the blocking helper targets.

--- a/migrations/0003_misty_smiling_tiger.sql
+++ b/migrations/0003_misty_smiling_tiger.sql
@@ -1,0 +1,72 @@
+CREATE TABLE "vt_saas"."resource_usage" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"resource_type" text NOT NULL,
+	"period_start" date NOT NULL,
+	"period_end" date NOT NULL,
+	"premium_units_used" bigint DEFAULT 0 NOT NULL,
+	"fallback_units_used" bigint DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "resource_usage_user_resource_period_unique" UNIQUE("user_id","resource_type","period_start")
+);
+--> statement-breakpoint
+CREATE TABLE "vt_saas"."subscription_tiers" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" text NOT NULL,
+	"display_name" text NOT NULL,
+	"description" text,
+	"price_cents" integer,
+	"stripe_price_id_monthly" text,
+	"stripe_price_id_yearly" text,
+	"is_active" boolean DEFAULT true NOT NULL,
+	"sort_order" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "subscription_tiers_name_unique" UNIQUE("name")
+);
+--> statement-breakpoint
+CREATE TABLE "vt_saas"."tier_quotas" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tier_id" uuid NOT NULL,
+	"resource_type" text NOT NULL,
+	"premium_unit_key" text,
+	"premium_period_limit" bigint DEFAULT 0 NOT NULL,
+	"fallback_unit_key" text NOT NULL,
+	"fallback_period_limit" bigint NOT NULL,
+	"warning_threshold_pct" integer DEFAULT 90 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "tier_quotas_tier_resource_unique" UNIQUE("tier_id","resource_type")
+);
+--> statement-breakpoint
+CREATE TABLE "vt_saas"."user_subscriptions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"tier_id" uuid NOT NULL,
+	"status" text DEFAULT 'active' NOT NULL,
+	"billing_interval" text,
+	"has_trialed" boolean DEFAULT false NOT NULL,
+	"trial_expires_at" timestamp with time zone,
+	"stripe_subscription_id" text,
+	"stripe_customer_id" text,
+	"started_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"current_period_anchor_at" timestamp with time zone,
+	"expires_at" timestamp with time zone,
+	"last_trial_warning_sent_at" timestamp with time zone,
+	"last_promotion_warning_sent_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "user_subscriptions_user_id_unique" UNIQUE("user_id")
+);
+--> statement-breakpoint
+ALTER TABLE "vt_saas"."tier_quotas" ADD CONSTRAINT "tier_quotas_tier_id_subscription_tiers_id_fk" FOREIGN KEY ("tier_id") REFERENCES "vt_saas"."subscription_tiers"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "vt_saas"."user_subscriptions" ADD CONSTRAINT "user_subscriptions_tier_id_subscription_tiers_id_fk" FOREIGN KEY ("tier_id") REFERENCES "vt_saas"."subscription_tiers"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_resource_usage_user_id" ON "vt_saas"."resource_usage" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "idx_resource_usage_user_resource_period" ON "vt_saas"."resource_usage" USING btree ("user_id","resource_type","period_start");--> statement-breakpoint
+CREATE INDEX "idx_subscription_tiers_sort_order" ON "vt_saas"."subscription_tiers" USING btree ("sort_order");--> statement-breakpoint
+CREATE INDEX "idx_tier_quotas_tier_id" ON "vt_saas"."tier_quotas" USING btree ("tier_id");--> statement-breakpoint
+CREATE INDEX "idx_tier_quotas_tier_resource" ON "vt_saas"."tier_quotas" USING btree ("tier_id","resource_type");--> statement-breakpoint
+CREATE INDEX "idx_user_subscriptions_user_id" ON "vt_saas"."user_subscriptions" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "idx_user_subscriptions_tier_id" ON "vt_saas"."user_subscriptions" USING btree ("tier_id");--> statement-breakpoint
+CREATE INDEX "idx_user_subscriptions_status" ON "vt_saas"."user_subscriptions" USING btree ("status");

--- a/migrations/0004_black_nomad.sql
+++ b/migrations/0004_black_nomad.sql
@@ -1,0 +1,5 @@
+CREATE TABLE "vt_saas"."stripe_webhook_events" (
+	"event_id" text PRIMARY KEY NOT NULL,
+	"event_type" text NOT NULL,
+	"processed_at" timestamp with time zone DEFAULT now() NOT NULL
+);

--- a/migrations/meta/0003_snapshot.json
+++ b/migrations/meta/0003_snapshot.json
@@ -1,0 +1,1869 @@
+{
+  "id": "05e62a2f-d6c1-4dfb-8b86-b0e4f9e76ab3",
+  "prevId": "03ec8703-e229-495d-a42c-7641657b5273",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "vt_saas.admin_audit_log": {
+      "name": "admin_audit_log",
+      "schema": "vt_saas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "admin_id": {
+          "name": "admin_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_admin_audit_log_admin_id": {
+          "name": "idx_admin_audit_log_admin_id",
+          "columns": [
+            {
+              "expression": "admin_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_admin_audit_log_created_at": {
+          "name": "idx_admin_audit_log_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_admin_audit_log_action_created_at": {
+          "name": "idx_admin_audit_log_action_created_at",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "vt_saas.feedback": {
+      "name": "feedback",
+      "schema": "vt_saas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "feedback_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "feedback_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_feedback_user_id": {
+          "name": "idx_feedback_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_feedback_status": {
+          "name": "idx_feedback_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_feedback_created_at": {
+          "name": "idx_feedback_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_feedback_status_created": {
+          "name": "idx_feedback_status_created",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "vt_saas.mem0_memories": {
+      "name": "mem0_memories",
+      "schema": "vt_saas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_text": {
+          "name": "memory_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_type": {
+          "name": "memory_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_mem0_memories_user_id": {
+          "name": "idx_mem0_memories_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mem0_memories_conversation_id": {
+          "name": "idx_mem0_memories_conversation_id",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mem0_memories_conversation_id_vercel_conversations_id_fk": {
+          "name": "mem0_memories_conversation_id_vercel_conversations_id_fk",
+          "tableFrom": "mem0_memories",
+          "tableTo": "vercel_conversations",
+          "schemaTo": "vt_saas",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "vt_saas.memory_extraction_jobs": {
+      "name": "memory_extraction_jobs",
+      "schema": "vt_saas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_memory_jobs_conversation_id": {
+          "name": "idx_memory_jobs_conversation_id",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memory_jobs_status": {
+          "name": "idx_memory_jobs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memory_jobs_created_at": {
+          "name": "idx_memory_jobs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memory_extraction_jobs_conversation_id_vercel_conversations_id_fk": {
+          "name": "memory_extraction_jobs_conversation_id_vercel_conversations_id_fk",
+          "tableFrom": "memory_extraction_jobs",
+          "tableTo": "vercel_conversations",
+          "schemaTo": "vt_saas",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "vt_saas.platform_connections": {
+      "name": "platform_connections",
+      "schema": "vt_saas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encryption_key_version": {
+          "name": "encryption_key_version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_picture_url": {
+          "name": "profile_picture_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_platform_connections_user_id": {
+          "name": "idx_platform_connections_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_platform_connections_token_expires_at": {
+          "name": "idx_platform_connections_token_expires_at",
+          "columns": [
+            {
+              "expression": "token_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "token_expires_at IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_platform_connections_user_provider": {
+          "name": "uq_platform_connections_user_provider",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "provider"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "vt_saas.resource_usage": {
+      "name": "resource_usage",
+      "schema": "vt_saas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "premium_units_used": {
+          "name": "premium_units_used",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "fallback_units_used": {
+          "name": "fallback_units_used",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_resource_usage_user_id": {
+          "name": "idx_resource_usage_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_resource_usage_user_resource_period": {
+          "name": "idx_resource_usage_user_resource_period",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "resource_usage_user_resource_period_unique": {
+          "name": "resource_usage_user_resource_period_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "resource_type",
+            "period_start"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "vt_saas.scheduled_tasks": {
+      "name": "scheduled_tasks",
+      "schema": "vt_saas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "scheduled_task_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_scheduled_tasks_user_id": {
+          "name": "idx_scheduled_tasks_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scheduled_tasks_due": {
+          "name": "idx_scheduled_tasks_due",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'scheduled'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "vt_saas.shareable_links": {
+      "name": "shareable_links",
+      "schema": "vt_saas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_count": {
+          "name": "access_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_shareable_links_created_by": {
+          "name": "idx_shareable_links_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_shareable_links_resource": {
+          "name": "idx_shareable_links_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "shareable_links_token_unique": {
+          "name": "shareable_links_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "vt_saas.subscription_tiers": {
+      "name": "subscription_tiers",
+      "schema": "vt_saas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_cents": {
+          "name": "price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_price_id_monthly": {
+          "name": "stripe_price_id_monthly",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_price_id_yearly": {
+          "name": "stripe_price_id_yearly",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_subscription_tiers_sort_order": {
+          "name": "idx_subscription_tiers_sort_order",
+          "columns": [
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscription_tiers_name_unique": {
+          "name": "subscription_tiers_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "vt_saas.threads": {
+      "name": "threads",
+      "schema": "vt_saas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_preview": {
+          "name": "last_message_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_threads_user_id": {
+          "name": "idx_threads_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_threads_user_archived": {
+          "name": "idx_threads_user_archived",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "threads_conversation_id_unique": {
+          "name": "threads_conversation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "conversation_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "vt_saas.tier_quotas": {
+      "name": "tier_quotas",
+      "schema": "vt_saas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tier_id": {
+          "name": "tier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "premium_unit_key": {
+          "name": "premium_unit_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "premium_period_limit": {
+          "name": "premium_period_limit",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "fallback_unit_key": {
+          "name": "fallback_unit_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fallback_period_limit": {
+          "name": "fallback_period_limit",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "warning_threshold_pct": {
+          "name": "warning_threshold_pct",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 90
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tier_quotas_tier_id": {
+          "name": "idx_tier_quotas_tier_id",
+          "columns": [
+            {
+              "expression": "tier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tier_quotas_tier_resource": {
+          "name": "idx_tier_quotas_tier_resource",
+          "columns": [
+            {
+              "expression": "tier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tier_quotas_tier_id_subscription_tiers_id_fk": {
+          "name": "tier_quotas_tier_id_subscription_tiers_id_fk",
+          "tableFrom": "tier_quotas",
+          "tableTo": "subscription_tiers",
+          "schemaTo": "vt_saas",
+          "columnsFrom": [
+            "tier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tier_quotas_tier_resource_unique": {
+          "name": "tier_quotas_tier_resource_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tier_id",
+            "resource_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "vt_saas.user_preferences": {
+      "name": "user_preferences",
+      "schema": "vt_saas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_notifications": {
+          "name": "email_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_preferences_user_id": {
+          "name": "idx_user_preferences_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_preferences_username": {
+          "name": "idx_user_preferences_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_preferences_user_id_unique": {
+          "name": "user_preferences_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "user_preferences_username_unique": {
+          "name": "user_preferences_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "vt_saas.user_subscriptions": {
+      "name": "user_subscriptions",
+      "schema": "vt_saas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier_id": {
+          "name": "tier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "billing_interval": {
+          "name": "billing_interval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_trialed": {
+          "name": "has_trialed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trial_expires_at": {
+          "name": "trial_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "current_period_anchor_at": {
+          "name": "current_period_anchor_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_trial_warning_sent_at": {
+          "name": "last_trial_warning_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_promotion_warning_sent_at": {
+          "name": "last_promotion_warning_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_subscriptions_user_id": {
+          "name": "idx_user_subscriptions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_subscriptions_tier_id": {
+          "name": "idx_user_subscriptions_tier_id",
+          "columns": [
+            {
+              "expression": "tier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_subscriptions_status": {
+          "name": "idx_user_subscriptions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_subscriptions_tier_id_subscription_tiers_id_fk": {
+          "name": "user_subscriptions_tier_id_subscription_tiers_id_fk",
+          "tableFrom": "user_subscriptions",
+          "tableTo": "subscription_tiers",
+          "schemaTo": "vt_saas",
+          "columnsFrom": [
+            "tier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_subscriptions_user_id_unique": {
+          "name": "user_subscriptions_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "vt_saas.vercel_conversations": {
+      "name": "vercel_conversations",
+      "schema": "vt_saas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_preview": {
+          "name": "last_message_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_vercel_conversations_user_id": {
+          "name": "idx_vercel_conversations_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_vercel_conversations_user_archived": {
+          "name": "idx_vercel_conversations_user_archived",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "vt_saas.vercel_messages": {
+      "name": "vercel_messages",
+      "schema": "vt_saas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_vercel_messages_conversation_id": {
+          "name": "idx_vercel_messages_conversation_id",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_vercel_messages_created_at": {
+          "name": "idx_vercel_messages_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vercel_messages_conversation_id_vercel_conversations_id_fk": {
+          "name": "vercel_messages_conversation_id_vercel_conversations_id_fk",
+          "tableFrom": "vercel_messages",
+          "tableTo": "vercel_conversations",
+          "schemaTo": "vt_saas",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.feedback_status": {
+      "name": "feedback_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "reviewed",
+        "archived"
+      ]
+    },
+    "public.feedback_type": {
+      "name": "feedback_type",
+      "schema": "public",
+      "values": [
+        "bug",
+        "feature",
+        "praise"
+      ]
+    },
+    "public.scheduled_task_status": {
+      "name": "scheduled_task_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "claimed",
+        "running",
+        "done",
+        "failed",
+        "blocked"
+      ]
+    }
+  },
+  "schemas": {
+    "vt_saas": "vt_saas"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/0004_snapshot.json
+++ b/migrations/meta/0004_snapshot.json
@@ -1,0 +1,1901 @@
+{
+  "id": "6b268b15-9de8-4e80-b415-58dafa7e38c2",
+  "prevId": "05e62a2f-d6c1-4dfb-8b86-b0e4f9e76ab3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "vt_saas.admin_audit_log": {
+      "name": "admin_audit_log",
+      "schema": "vt_saas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "admin_id": {
+          "name": "admin_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_admin_audit_log_admin_id": {
+          "name": "idx_admin_audit_log_admin_id",
+          "columns": [
+            {
+              "expression": "admin_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_admin_audit_log_created_at": {
+          "name": "idx_admin_audit_log_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_admin_audit_log_action_created_at": {
+          "name": "idx_admin_audit_log_action_created_at",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "vt_saas.feedback": {
+      "name": "feedback",
+      "schema": "vt_saas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "feedback_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "feedback_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_feedback_user_id": {
+          "name": "idx_feedback_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_feedback_status": {
+          "name": "idx_feedback_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_feedback_created_at": {
+          "name": "idx_feedback_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_feedback_status_created": {
+          "name": "idx_feedback_status_created",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "vt_saas.mem0_memories": {
+      "name": "mem0_memories",
+      "schema": "vt_saas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_text": {
+          "name": "memory_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_type": {
+          "name": "memory_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_mem0_memories_user_id": {
+          "name": "idx_mem0_memories_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mem0_memories_conversation_id": {
+          "name": "idx_mem0_memories_conversation_id",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mem0_memories_conversation_id_vercel_conversations_id_fk": {
+          "name": "mem0_memories_conversation_id_vercel_conversations_id_fk",
+          "tableFrom": "mem0_memories",
+          "tableTo": "vercel_conversations",
+          "schemaTo": "vt_saas",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "vt_saas.memory_extraction_jobs": {
+      "name": "memory_extraction_jobs",
+      "schema": "vt_saas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_memory_jobs_conversation_id": {
+          "name": "idx_memory_jobs_conversation_id",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memory_jobs_status": {
+          "name": "idx_memory_jobs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memory_jobs_created_at": {
+          "name": "idx_memory_jobs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memory_extraction_jobs_conversation_id_vercel_conversations_id_fk": {
+          "name": "memory_extraction_jobs_conversation_id_vercel_conversations_id_fk",
+          "tableFrom": "memory_extraction_jobs",
+          "tableTo": "vercel_conversations",
+          "schemaTo": "vt_saas",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "vt_saas.platform_connections": {
+      "name": "platform_connections",
+      "schema": "vt_saas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encryption_key_version": {
+          "name": "encryption_key_version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_picture_url": {
+          "name": "profile_picture_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_platform_connections_user_id": {
+          "name": "idx_platform_connections_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_platform_connections_token_expires_at": {
+          "name": "idx_platform_connections_token_expires_at",
+          "columns": [
+            {
+              "expression": "token_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "token_expires_at IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_platform_connections_user_provider": {
+          "name": "uq_platform_connections_user_provider",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "provider"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "vt_saas.resource_usage": {
+      "name": "resource_usage",
+      "schema": "vt_saas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "premium_units_used": {
+          "name": "premium_units_used",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "fallback_units_used": {
+          "name": "fallback_units_used",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_resource_usage_user_id": {
+          "name": "idx_resource_usage_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_resource_usage_user_resource_period": {
+          "name": "idx_resource_usage_user_resource_period",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "resource_usage_user_resource_period_unique": {
+          "name": "resource_usage_user_resource_period_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "resource_type",
+            "period_start"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "vt_saas.scheduled_tasks": {
+      "name": "scheduled_tasks",
+      "schema": "vt_saas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "scheduled_task_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_scheduled_tasks_user_id": {
+          "name": "idx_scheduled_tasks_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scheduled_tasks_due": {
+          "name": "idx_scheduled_tasks_due",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'scheduled'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "vt_saas.shareable_links": {
+      "name": "shareable_links",
+      "schema": "vt_saas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_count": {
+          "name": "access_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_shareable_links_created_by": {
+          "name": "idx_shareable_links_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_shareable_links_resource": {
+          "name": "idx_shareable_links_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "shareable_links_token_unique": {
+          "name": "shareable_links_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "vt_saas.stripe_webhook_events": {
+      "name": "stripe_webhook_events",
+      "schema": "vt_saas",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "vt_saas.subscription_tiers": {
+      "name": "subscription_tiers",
+      "schema": "vt_saas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_cents": {
+          "name": "price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_price_id_monthly": {
+          "name": "stripe_price_id_monthly",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_price_id_yearly": {
+          "name": "stripe_price_id_yearly",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_subscription_tiers_sort_order": {
+          "name": "idx_subscription_tiers_sort_order",
+          "columns": [
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscription_tiers_name_unique": {
+          "name": "subscription_tiers_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "vt_saas.threads": {
+      "name": "threads",
+      "schema": "vt_saas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_preview": {
+          "name": "last_message_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_threads_user_id": {
+          "name": "idx_threads_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_threads_user_archived": {
+          "name": "idx_threads_user_archived",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "threads_conversation_id_unique": {
+          "name": "threads_conversation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "conversation_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "vt_saas.tier_quotas": {
+      "name": "tier_quotas",
+      "schema": "vt_saas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tier_id": {
+          "name": "tier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "premium_unit_key": {
+          "name": "premium_unit_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "premium_period_limit": {
+          "name": "premium_period_limit",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "fallback_unit_key": {
+          "name": "fallback_unit_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fallback_period_limit": {
+          "name": "fallback_period_limit",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "warning_threshold_pct": {
+          "name": "warning_threshold_pct",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 90
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tier_quotas_tier_id": {
+          "name": "idx_tier_quotas_tier_id",
+          "columns": [
+            {
+              "expression": "tier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tier_quotas_tier_resource": {
+          "name": "idx_tier_quotas_tier_resource",
+          "columns": [
+            {
+              "expression": "tier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tier_quotas_tier_id_subscription_tiers_id_fk": {
+          "name": "tier_quotas_tier_id_subscription_tiers_id_fk",
+          "tableFrom": "tier_quotas",
+          "tableTo": "subscription_tiers",
+          "schemaTo": "vt_saas",
+          "columnsFrom": [
+            "tier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tier_quotas_tier_resource_unique": {
+          "name": "tier_quotas_tier_resource_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tier_id",
+            "resource_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "vt_saas.user_preferences": {
+      "name": "user_preferences",
+      "schema": "vt_saas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_notifications": {
+          "name": "email_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_preferences_user_id": {
+          "name": "idx_user_preferences_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_preferences_username": {
+          "name": "idx_user_preferences_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_preferences_user_id_unique": {
+          "name": "user_preferences_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "user_preferences_username_unique": {
+          "name": "user_preferences_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "vt_saas.user_subscriptions": {
+      "name": "user_subscriptions",
+      "schema": "vt_saas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier_id": {
+          "name": "tier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "billing_interval": {
+          "name": "billing_interval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_trialed": {
+          "name": "has_trialed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trial_expires_at": {
+          "name": "trial_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "current_period_anchor_at": {
+          "name": "current_period_anchor_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_trial_warning_sent_at": {
+          "name": "last_trial_warning_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_promotion_warning_sent_at": {
+          "name": "last_promotion_warning_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_subscriptions_user_id": {
+          "name": "idx_user_subscriptions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_subscriptions_tier_id": {
+          "name": "idx_user_subscriptions_tier_id",
+          "columns": [
+            {
+              "expression": "tier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_subscriptions_status": {
+          "name": "idx_user_subscriptions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_subscriptions_tier_id_subscription_tiers_id_fk": {
+          "name": "user_subscriptions_tier_id_subscription_tiers_id_fk",
+          "tableFrom": "user_subscriptions",
+          "tableTo": "subscription_tiers",
+          "schemaTo": "vt_saas",
+          "columnsFrom": [
+            "tier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_subscriptions_user_id_unique": {
+          "name": "user_subscriptions_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "vt_saas.vercel_conversations": {
+      "name": "vercel_conversations",
+      "schema": "vt_saas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_preview": {
+          "name": "last_message_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_vercel_conversations_user_id": {
+          "name": "idx_vercel_conversations_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_vercel_conversations_user_archived": {
+          "name": "idx_vercel_conversations_user_archived",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "vt_saas.vercel_messages": {
+      "name": "vercel_messages",
+      "schema": "vt_saas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_vercel_messages_conversation_id": {
+          "name": "idx_vercel_messages_conversation_id",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_vercel_messages_created_at": {
+          "name": "idx_vercel_messages_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vercel_messages_conversation_id_vercel_conversations_id_fk": {
+          "name": "vercel_messages_conversation_id_vercel_conversations_id_fk",
+          "tableFrom": "vercel_messages",
+          "tableTo": "vercel_conversations",
+          "schemaTo": "vt_saas",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.feedback_status": {
+      "name": "feedback_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "reviewed",
+        "archived"
+      ]
+    },
+    "public.feedback_type": {
+      "name": "feedback_type",
+      "schema": "public",
+      "values": [
+        "bug",
+        "feature",
+        "praise"
+      ]
+    },
+    "public.scheduled_task_status": {
+      "name": "scheduled_task_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "claimed",
+        "running",
+        "done",
+        "failed",
+        "blocked"
+      ]
+    }
+  },
+  "schemas": {
+    "vt_saas": "vt_saas"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -22,6 +22,20 @@
       "when": 1781570650316,
       "tag": "0002_far_the_enforcers",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1781572197730,
+      "tag": "0003_misty_smiling_tiger",
+      "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1781573033903,
+      "tag": "0004_black_nomad",
+      "breakpoints": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,6 +80,7 @@
         "resend": "^6.12.2",
         "sharp": "^0.34.5",
         "sonner": "^2.0.7",
+        "stripe": "^22.2.1",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0",
         "vaul": "^1.1.2",
@@ -48705,6 +48706,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stripe": {
+      "version": "22.2.1",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.2.1.tgz",
+      "integrity": "sha512-ULAtq25USBEx3yeN5zimEkfYVFETVMP5om25Ryr8ol11P62imaCZLBIEW78T7zm7Wg3wnZi+80S72yf3LCpNhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/stubborn-fs": {

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "resend": "^6.12.2",
     "sharp": "^0.34.5",
     "sonner": "^2.0.7",
+    "stripe": "^22.2.1",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
     "vaul": "^1.1.2",

--- a/src/app/api/inngest/route.ts
+++ b/src/app/api/inngest/route.ts
@@ -1,15 +1,21 @@
 import { serve } from 'inngest/next';
 
 import { inngest } from '@/libs/inngest/client';
+import { forceExpireTrialsAndPromotionsFunction } from '@/libs/inngest/functions/force-expire-trials-and-promotions';
 import {
   processSingleTask,
   scheduledTasksCron,
 } from '@/libs/inngest/functions/scheduled-tasks';
+import { trialPromotionExpiryWarningsFunction } from '@/libs/inngest/functions/trial-promotion-expiry-warnings';
 
 // Register functions in production (real cloud env) and local dev (Inngest Dev
 // Server CLI on port 8288). Preview/branch deploys on Vercel have
 // NODE_ENV=production but VERCEL_ENV=preview, so they stay empty — otherwise each
 // preview would spawn its own Inngest branch environment and run crons independently.
+//
+// The reverse-trial crons are always registered but no-op internally when
+// ENABLE_REVERSE_TRIAL is off (so toggling the policy needs no redeploy of this
+// route).
 const shouldRegister
   = process.env.VERCEL_ENV === 'production'
     || process.env.NODE_ENV === 'development';
@@ -17,6 +23,11 @@ const shouldRegister
 export const { GET, POST, PUT } = serve({
   client: inngest,
   functions: shouldRegister
-    ? [scheduledTasksCron, processSingleTask]
+    ? [
+        scheduledTasksCron,
+        processSingleTask,
+        forceExpireTrialsAndPromotionsFunction,
+        trialPromotionExpiryWarningsFunction,
+      ]
     : [],
 });

--- a/src/app/api/stripe/webhook/route.test.ts
+++ b/src/app/api/stripe/webhook/route.test.ts
@@ -1,0 +1,260 @@
+// @vitest-environment node
+//
+// Focused coverage for the Stripe webhook idempotency guard (event.id dedup).
+// Stripe re-delivers the same event.id on a non-2xx; the dedup ledger must let
+// the handler (and its non-idempotent side effects: analytics + emails) run once
+// on first-seen, and short-circuit a re-delivery.
+import type Stripe from 'stripe';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+const mockConstructEvent = vi.fn();
+
+vi.mock('@/libs/stripe/client', () => ({
+  getStripe: () => ({
+    webhooks: { constructEvent: mockConstructEvent },
+    subscriptions: { retrieve: vi.fn() },
+  }),
+}));
+
+vi.mock('@/libs/Env', () => ({
+  Env: { STRIPE_WEBHOOK_SECRET: 'whsec_test' },
+}));
+
+vi.mock('@sentry/nextjs', () => ({ captureException: vi.fn() }));
+
+vi.mock('@/libs/Logger', () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+const mockTrackEventServer = vi.fn().mockResolvedValue(undefined);
+vi.mock('@/libs/analytics/server', () => ({
+  trackEventServer: (...a: unknown[]) => mockTrackEventServer(...a),
+}));
+
+const mockSendEnded = vi.fn();
+vi.mock('@/libs/email/sendSubscriptionEmails', () => ({
+  sendSubscriptionEndedEmail: (...a: unknown[]) => mockSendEnded(...a),
+  sendSubscriptionStartedEmail: vi.fn(),
+}));
+
+vi.mock('@/libs/jobs/blocking', () => ({
+  blockScheduledTasksForUser: vi.fn().mockResolvedValue(0),
+}));
+
+vi.mock('@/libs/subscriptions/quota', () => ({
+  invalidateQuotaCache: vi.fn(),
+}));
+
+vi.mock('@/libs/supabase/admin', () => ({
+  createAdminClient: () => ({
+    auth: {
+      admin: {
+        getUserById: vi.fn().mockResolvedValue({
+          data: { user: { email: 'u@example.com', user_metadata: {} } },
+          error: null,
+        }),
+      },
+    },
+  }),
+}));
+
+// ── DB mock ────────────────────────────────────────────────────────────────
+// recordWebhookEvent: insert(...).values(...).onConflictDoNothing(...).returning()
+// releaseWebhookEvent: delete(...).where(...)
+// handleSubscriptionDeleted: several select(...).from(...).where(...).limit(1)
+//   + update(...).set(...).where(...)
+const insertReturning = vi.fn();
+const mockDelete = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
+
+// Sequential select results queue for the handler's reads.
+let selectResults: unknown[][] = [];
+let selectIdx = 0;
+function nextSelect(): Promise<unknown[]> {
+  const r = selectResults[selectIdx] ?? [];
+  selectIdx++;
+  return Promise.resolve(r);
+}
+const selectChain = {
+  select: vi.fn(() => selectChain),
+  from: vi.fn(() => selectChain),
+  where: vi.fn(() => selectChain),
+  limit: vi.fn(() => nextSelect()),
+};
+const updateChain = {
+  set: vi.fn(() => updateChain),
+  where: vi.fn().mockResolvedValue(undefined),
+};
+
+vi.mock('@/libs/DB', () => ({
+  db: {
+    insert: () => ({
+      values: () => ({
+        onConflictDoNothing: () => ({ returning: () => insertReturning() }),
+      }),
+    }),
+    delete: () => mockDelete(),
+    select: () => selectChain,
+    // invalidateAllQuotaCaches iterates distinct resource types; return none.
+    selectDistinct: () => ({ from: vi.fn().mockResolvedValue([]) }),
+    update: () => updateChain,
+  },
+}));
+
+const { POST } = await import('./route');
+
+function makeRequest(): Request {
+  return new Request('http://localhost/api/stripe/webhook', {
+    method: 'POST',
+    headers: { 'stripe-signature': 'sig' },
+    body: 'rawbody',
+  });
+}
+
+function deletedEvent(): Stripe.Event {
+  return {
+    id: 'evt_dup_1',
+    type: 'customer.subscription.deleted',
+    data: { object: { id: 'sub_123' } },
+  } as unknown as Stripe.Event;
+}
+
+describe('POST /api/stripe/webhook — idempotency', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Restore default behaviour (clearAllMocks wipes implementations).
+    selectChain.select.mockReturnValue(selectChain);
+    selectChain.from.mockReturnValue(selectChain);
+    selectChain.where.mockReturnValue(selectChain);
+    selectChain.limit.mockImplementation(() => nextSelect());
+    updateChain.set.mockReturnValue(updateChain);
+    updateChain.where.mockResolvedValue(undefined);
+    mockDelete.mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+    selectIdx = 0;
+    // Handler reads for customer.subscription.deleted:
+    //   1. user_subscriptions row → { userId, tierId }
+    //   2. free tier lookup → { id }
+    //   3. getTierName → { displayName }
+    selectResults = [
+      [{ userId: 'user-1', tierId: 'tier-pro' }],
+      [{ id: 'tier-free' }],
+      [{ displayName: 'Pro', name: 'pro' }],
+    ];
+    mockConstructEvent.mockReturnValue(deletedEvent());
+  });
+
+  it('first delivery: records event, runs handler, fires side effects', async () => {
+    insertReturning.mockResolvedValueOnce([{ eventId: 'evt_dup_1' }]); // first-seen
+
+    const res = await POST(makeRequest() as never);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ received: true });
+    // Side effects fired exactly once.
+    expect(mockSendEnded).toHaveBeenCalledTimes(1);
+    expect(mockTrackEventServer).toHaveBeenCalledWith(
+      'subscription_cancelled',
+      expect.anything(),
+      'user-1',
+    );
+  });
+
+  it('re-delivery of the same event.id: short-circuits, no side effects', async () => {
+    insertReturning.mockResolvedValueOnce([]); // conflict → already processed
+
+    const res = await POST(makeRequest() as never);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ received: true, duplicate: true });
+    // Handler never ran → no emails, no analytics, no DB update.
+    expect(mockSendEnded).not.toHaveBeenCalled();
+    expect(mockTrackEventServer).not.toHaveBeenCalled();
+    expect(updateChain.set).not.toHaveBeenCalled();
+  });
+
+  it('handler error after claim: releases the event id so Stripe can retry', async () => {
+    insertReturning.mockResolvedValueOnce([{ eventId: 'evt_dup_1' }]); // first-seen
+    // Force the handler to throw: no matching subscription row AND make the email
+    // path explode is hard; instead drive a thrown error from the update step.
+    updateChain.where.mockRejectedValueOnce(new Error('db down'));
+
+    const res = await POST(makeRequest() as never);
+
+    expect(res.status).toBe(500);
+    // The claim was released so the retry isn't treated as a duplicate.
+    expect(mockDelete).toHaveBeenCalledTimes(1);
+  });
+});
+
+function invoicePaidEvent(id: string): Stripe.Event {
+  return {
+    id,
+    type: 'invoice.paid',
+    data: {
+      object: {
+        parent: { subscription_details: { subscription: 'sub_777' } },
+      },
+    },
+  } as unknown as Stripe.Event;
+}
+
+describe('POST /api/stripe/webhook — order-independent trial→active conversion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    selectChain.select.mockReturnValue(selectChain);
+    selectChain.from.mockReturnValue(selectChain);
+    selectChain.where.mockReturnValue(selectChain);
+    selectChain.limit.mockImplementation(() => nextSelect());
+    updateChain.set.mockReturnValue(updateChain);
+    updateChain.where.mockResolvedValue(undefined);
+    mockDelete.mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+    selectIdx = 0;
+    insertReturning.mockResolvedValue([{ eventId: 'evt_x' }]); // always first-seen
+  });
+
+  it('invoice.paid arriving FIRST on a trial sub resets anchor + fires trial_upgrade once', async () => {
+    // Reads: 1. sub row (status=trial) ; 2. getTierName
+    selectResults = [
+      [{ userId: 'user-9', currentStatus: 'trial', billingInterval: 'monthly', tierId: 'tier-pro' }],
+      [{ displayName: 'Pro', name: 'pro' }],
+    ];
+    mockConstructEvent.mockReturnValue(invoicePaidEvent('evt_inv_1'));
+
+    const res = await POST(makeRequest() as never);
+
+    expect(res.status).toBe(200);
+    // Anchor reset is in the update set.
+    expect(updateChain.set).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'active', currentPeriodAnchorAt: expect.any(Date) }),
+    );
+    // Conversion fired exactly once with trial_upgrade source.
+    expect(mockTrackEventServer).toHaveBeenCalledWith(
+      'subscription_converted',
+      expect.objectContaining({ conversion_source: 'trial_upgrade', billing_interval: 'monthly', tier_name: 'Pro' }),
+      'user-9',
+    );
+  });
+
+  it('invoice.paid on an already-active sub does NOT reset anchor or re-fire conversion', async () => {
+    // The later event (status already active): no anchor reset, no conversion.
+    selectResults = [
+      [{ userId: 'user-9', currentStatus: 'active', billingInterval: 'monthly', tierId: 'tier-pro' }],
+    ];
+    mockConstructEvent.mockReturnValue(invoicePaidEvent('evt_inv_2'));
+
+    const res = await POST(makeRequest() as never);
+
+    expect(res.status).toBe(200);
+    expect(updateChain.set).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'active' }),
+    );
+
+    // No anchor reset on the active-path update.
+    const setArg = (updateChain.set.mock.calls as unknown[][])[0]?.[0] as Record<string, unknown>;
+
+    expect(setArg).not.toHaveProperty('currentPeriodAnchorAt');
+    expect(mockTrackEventServer).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -1,0 +1,523 @@
+import { Buffer } from 'node:buffer';
+
+import * as Sentry from '@sentry/nextjs';
+import { eq, or } from 'drizzle-orm';
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import type Stripe from 'stripe';
+
+import { trackEventServer } from '@/libs/analytics/server';
+import { db } from '@/libs/DB';
+import {
+  sendSubscriptionEndedEmail,
+  sendSubscriptionStartedEmail,
+} from '@/libs/email/sendSubscriptionEmails';
+import { Env } from '@/libs/Env';
+import { blockScheduledTasksForUser } from '@/libs/jobs/blocking';
+import { logger } from '@/libs/Logger';
+import { getStripe } from '@/libs/stripe/client';
+import { invalidateQuotaCache } from '@/libs/subscriptions/quota';
+import { createAdminClient } from '@/libs/supabase/admin';
+import type { BillingInterval } from '@/models/Schema';
+import { stripeWebhookEvents, subscriptionTiers, tierQuotas, userSubscriptions } from '@/models/Schema';
+
+// Stripe verifies the request with its OWN signature scheme (constructEvent
+// below), so this route is intentionally NOT routed through withWebhookSecret
+// (that guards X-Webhook-Secret inbound hooks — a different mechanism).
+export const runtime = 'nodejs'; // Required for Buffer and crypto
+
+// ---------------------------------------------------------------------------
+// POST handler — Stripe webhook
+// ---------------------------------------------------------------------------
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const webhookSecret = Env.STRIPE_WEBHOOK_SECRET;
+  if (!webhookSecret) {
+    logger.error('STRIPE_WEBHOOK_SECRET not configured');
+    return NextResponse.json({ error: 'Webhook not configured' }, { status: 500 });
+  }
+
+  const signature = request.headers.get('stripe-signature');
+  if (!signature) {
+    return NextResponse.json({ error: 'Missing stripe-signature header' }, { status: 400 });
+  }
+
+  let event: Stripe.Event;
+  try {
+    const rawBody = Buffer.from(await request.arrayBuffer());
+    event = getStripe().webhooks.constructEvent(rawBody, signature, webhookSecret);
+  } catch (err) {
+    Sentry.captureException(err, {
+      contexts: { stripe: { action: 'webhook/signatureVerification' } },
+    });
+    logger.error({ err }, 'Stripe webhook signature verification failed');
+    return NextResponse.json({ error: 'Invalid signature' }, { status: 400 });
+  }
+
+  // Idempotency guard. On a non-2xx response Stripe re-delivers the SAME event.id.
+  // The status writes below are idempotent, but the side effects (analytics +
+  // lifecycle emails) are not. Record the event id once before processing and
+  // short-circuit a re-delivery so those side effects fire exactly once.
+  const firstSeen = await recordWebhookEvent(event.id, event.type);
+  if (!firstSeen) {
+    logger.info({ eventId: event.id, eventType: event.type }, 'Stripe webhook: duplicate event — skipping');
+    return NextResponse.json({ received: true, duplicate: true }, { status: 200 });
+  }
+
+  try {
+    await handleWebhookEvent(event);
+  } catch (err) {
+    // The handler failed AFTER we claimed the event id. Release the claim so
+    // Stripe's retry re-processes this delivery cleanly (rather than being skipped
+    // as a "duplicate" of a delivery that never finished).
+    await releaseWebhookEvent(event.id);
+    Sentry.captureException(err, {
+      contexts: { stripe: { eventType: event.type, action: 'webhook/handleEvent' } },
+    });
+    logger.error({ err, eventType: event.type }, 'Stripe webhook handler error');
+    // Return 500 for transient errors so Stripe retries.
+    return NextResponse.json({ error: 'Webhook handler error' }, { status: 500 });
+  }
+
+  return NextResponse.json({ received: true }, { status: 200 });
+}
+
+// ---------------------------------------------------------------------------
+// Idempotency ledger
+// ---------------------------------------------------------------------------
+
+/**
+ * Claims a Stripe `event.id` in the dedup ledger. Returns `true` when this is the
+ * first time we've seen the event (insert succeeded), `false` when a row already
+ * existed (a re-delivery). Uses ON CONFLICT DO NOTHING so concurrent deliveries
+ * race safely — exactly one wins the insert.
+ */
+async function recordWebhookEvent(eventId: string, eventType: string): Promise<boolean> {
+  const inserted = await db
+    .insert(stripeWebhookEvents)
+    .values({ eventId, eventType })
+    .onConflictDoNothing({ target: stripeWebhookEvents.eventId })
+    .returning();
+  return inserted.length > 0;
+}
+
+/** Releases a claimed event id so a failed delivery can be retried. */
+async function releaseWebhookEvent(eventId: string): Promise<void> {
+  try {
+    await db.delete(stripeWebhookEvents).where(eq(stripeWebhookEvents.eventId, eventId));
+  } catch (err) {
+    // Best-effort: if the release fails the worst case is a dropped retry, which
+    // Sentry will surface via the original handler error. Don't mask that error.
+    logger.warn({ err, eventId }, 'Stripe webhook: failed to release event claim after handler error');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Event dispatch
+// ---------------------------------------------------------------------------
+
+async function handleWebhookEvent(event: Stripe.Event): Promise<void> {
+  switch (event.type) {
+    case 'checkout.session.completed':
+      await handleCheckoutCompleted(event.data.object as Stripe.Checkout.Session);
+      break;
+    case 'invoice.paid':
+      await handleInvoicePaid(event.data.object as Stripe.Invoice);
+      break;
+    case 'customer.subscription.updated':
+      await handleSubscriptionUpdated(event.data.object as Stripe.Subscription);
+      break;
+    case 'customer.subscription.deleted':
+      await handleSubscriptionDeleted(event.data.object as Stripe.Subscription);
+      break;
+    default:
+      logger.info({ eventType: event.type }, 'Unhandled Stripe webhook event type');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolves a Stripe price ID to a tier row + billing interval. The tier table
+ * has separate `stripe_price_id_monthly` / `stripe_price_id_yearly` columns;
+ * both map to the same tier.
+ */
+async function resolveTierByPriceId(priceId: string): Promise<{
+  tierId: string;
+  billingInterval: BillingInterval;
+} | null> {
+  const [tier] = await db
+    .select({
+      id: subscriptionTiers.id,
+      stripePriceIdMonthly: subscriptionTiers.stripePriceIdMonthly,
+      stripePriceIdYearly: subscriptionTiers.stripePriceIdYearly,
+    })
+    .from(subscriptionTiers)
+    .where(or(
+      eq(subscriptionTiers.stripePriceIdMonthly, priceId),
+      eq(subscriptionTiers.stripePriceIdYearly, priceId),
+    ))
+    .limit(1);
+
+  if (!tier) {
+    return null;
+  }
+
+  const billingInterval: BillingInterval
+    = tier.stripePriceIdYearly === priceId ? 'yearly' : 'monthly';
+
+  return { tierId: tier.id, billingInterval };
+}
+
+/**
+ * Invalidates every cached quota state for a user. Generic: iterates the
+ * resource types defined across all tiers (the quota cache is keyed by
+ * user+resourceType) rather than a hardcoded resource list.
+ */
+async function invalidateAllQuotaCaches(userId: string): Promise<void> {
+  const rows = await db
+    .selectDistinct({ resourceType: tierQuotas.resourceType })
+    .from(tierQuotas);
+  for (const { resourceType } of rows) {
+    invalidateQuotaCache(userId, resourceType);
+  }
+}
+
+async function getUserEmailAndName(userId: string): Promise<{ email: string; name?: string } | null> {
+  try {
+    const admin = createAdminClient();
+    const { data, error } = await admin.auth.admin.getUserById(userId);
+    if (error || !data?.user?.email) {
+      return null;
+    }
+    const userMeta = data.user.user_metadata as Record<string, unknown> | undefined;
+    const name = typeof userMeta?.display_name === 'string'
+      ? userMeta.display_name
+      : typeof userMeta?.full_name === 'string'
+        ? userMeta.full_name
+        : undefined;
+    return { email: data.user.email, name };
+  } catch (err) {
+    logger.error({ err, userId }, 'getUserEmailAndName: failed to fetch user');
+    return null;
+  }
+}
+
+/** Display name for the tier behind a Stripe subscription (for emails/analytics). */
+async function getTierName(tierId: string): Promise<string> {
+  const [tier] = await db
+    .select({ displayName: subscriptionTiers.displayName, name: subscriptionTiers.name })
+    .from(subscriptionTiers)
+    .where(eq(subscriptionTiers.id, tierId))
+    .limit(1);
+  return tier?.displayName ?? tier?.name ?? 'Pro';
+}
+
+// ---------------------------------------------------------------------------
+// checkout.session.completed
+// ---------------------------------------------------------------------------
+
+async function handleCheckoutCompleted(session: Stripe.Checkout.Session): Promise<void> {
+  const userId = session.metadata?.user_id;
+  if (!userId) {
+    logger.warn({ sessionId: session.id }, 'checkout.session.completed: missing user_id in metadata');
+    return;
+  }
+
+  const stripeSubscriptionId = typeof session.subscription === 'string'
+    ? session.subscription
+    : session.subscription?.id;
+  const stripeCustomerId = typeof session.customer === 'string'
+    ? session.customer
+    : session.customer?.id;
+
+  if (!stripeSubscriptionId || !stripeCustomerId) {
+    logger.warn({ sessionId: session.id }, 'checkout.session.completed: missing subscription or customer');
+    return;
+  }
+
+  const subscription = await getStripe().subscriptions.retrieve(stripeSubscriptionId, {
+    expand: ['items.data.price'],
+  });
+
+  const priceId = subscription.items.data[0]?.price.id;
+  if (!priceId) {
+    logger.warn({ stripeSubscriptionId }, 'checkout.session.completed: no price ID on subscription');
+    return;
+  }
+
+  const tierInfo = await resolveTierByPriceId(priceId);
+  if (!tierInfo) {
+    logger.warn({ priceId }, 'checkout.session.completed: no tier matched price ID');
+    return;
+  }
+
+  const isTrialing = subscription.status === 'trialing';
+  const trialExpiresAt = isTrialing && subscription.trial_end
+    ? new Date(subscription.trial_end * 1000)
+    : null;
+
+  await db
+    .update(userSubscriptions)
+    .set({
+      tierId: tierInfo.tierId,
+      status: isTrialing ? 'trial' : 'active',
+      billingInterval: tierInfo.billingInterval,
+      hasTrialed: true,
+      trialExpiresAt,
+      stripeSubscriptionId,
+      stripeCustomerId,
+      currentPeriodAnchorAt: new Date(),
+      expiresAt: null,
+      updatedAt: new Date(),
+    })
+    .where(eq(userSubscriptions.userId, userId));
+
+  await invalidateAllQuotaCaches(userId);
+
+  if (!isTrialing) {
+    const tierName = await getTierName(tierInfo.tierId);
+
+    // Welcome email for the first paid subscription. Stripe sends its own receipt.
+    const userInfo = await getUserEmailAndName(userId);
+    if (userInfo) {
+      sendSubscriptionStartedEmail({
+        email: userInfo.email,
+        name: userInfo.name,
+        tierName,
+        billingInterval: tierInfo.billingInterval,
+      });
+    }
+
+    trackEventServer(
+      'subscription_converted',
+      {
+        billing_interval: tierInfo.billingInterval,
+        tier_name: tierName,
+        conversion_source: 'checkout',
+      },
+      userId,
+    ).catch(err => logger.warn({ err, userId }, 'subscription_converted tracking failed'));
+  }
+
+  logger.info(
+    { userId, tierId: tierInfo.tierId, billingInterval: tierInfo.billingInterval, isTrialing },
+    'Subscription activated via checkout',
+  );
+}
+
+// ---------------------------------------------------------------------------
+// invoice.paid
+// ---------------------------------------------------------------------------
+
+async function handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
+  const subRef = invoice.parent?.subscription_details?.subscription;
+  const stripeSubscriptionId = typeof subRef === 'string'
+    ? subRef
+    : subRef?.id;
+
+  if (!stripeSubscriptionId) {
+    return;
+  }
+
+  const [sub] = await db
+    .select({
+      userId: userSubscriptions.userId,
+      currentStatus: userSubscriptions.status,
+      billingInterval: userSubscriptions.billingInterval,
+      tierId: userSubscriptions.tierId,
+    })
+    .from(userSubscriptions)
+    .where(eq(userSubscriptions.stripeSubscriptionId, stripeSubscriptionId))
+    .limit(1);
+
+  if (!sub) {
+    logger.warn({ stripeSubscriptionId }, 'invoice.paid: no matching user_subscriptions row');
+    return;
+  }
+
+  // Order-independent trial→active conversion. The anchor reset + the
+  // trial_upgrade conversion event must fire exactly once, regardless of whether
+  // invoice.paid or customer.subscription.updated arrives first. We key the
+  // transition on the LOCAL status: whichever event observes status==='trial'
+  // performs it and flips the row to 'active'; the later event sees 'active' and
+  // skips. (Previously this lived ONLY in handleSubscriptionUpdated, so an
+  // invoice.paid arriving first silently dropped both.)
+  const isTrialUpgrade = sub.currentStatus === 'trial';
+
+  await db
+    .update(userSubscriptions)
+    .set({
+      status: 'active',
+      // Reset the rolling quota window to start at conversion.
+      ...(isTrialUpgrade ? { currentPeriodAnchorAt: new Date() } : {}),
+      updatedAt: new Date(),
+    })
+    .where(eq(userSubscriptions.stripeSubscriptionId, stripeSubscriptionId));
+
+  await invalidateAllQuotaCaches(sub.userId);
+
+  if (isTrialUpgrade && sub.billingInterval) {
+    const tierName = await getTierName(sub.tierId);
+    trackEventServer(
+      'subscription_converted',
+      {
+        billing_interval: sub.billingInterval,
+        tier_name: tierName,
+        conversion_source: 'trial_upgrade',
+      },
+      sub.userId,
+    ).catch(err => logger.warn({ err, userId: sub.userId }, 'subscription_converted tracking failed'));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// customer.subscription.updated
+// ---------------------------------------------------------------------------
+
+async function handleSubscriptionUpdated(subscription: Stripe.Subscription): Promise<void> {
+  const priceId = subscription.items.data[0]?.price.id;
+
+  const [sub] = await db
+    .select({
+      userId: userSubscriptions.userId,
+      currentStatus: userSubscriptions.status,
+    })
+    .from(userSubscriptions)
+    .where(eq(userSubscriptions.stripeSubscriptionId, subscription.id))
+    .limit(1);
+
+  if (!sub) {
+    logger.warn({ subscriptionId: subscription.id }, 'customer.subscription.updated: no matching row');
+    return;
+  }
+
+  // Map Stripe status to local status.
+  const statusMap: Record<string, 'active' | 'cancelled' | 'expired' | 'trial'> = {
+    active: 'active',
+    trialing: 'trial',
+    past_due: 'active', // Still has access while Stripe retries payment
+    canceled: 'cancelled',
+    unpaid: 'expired',
+  };
+  const localStatus = statusMap[subscription.status] ?? 'active';
+
+  // Re-resolve tier in case the plan changed.
+  const updates: Partial<typeof userSubscriptions.$inferInsert> = {
+    status: localStatus,
+    updatedAt: new Date(),
+  };
+
+  let tierName = 'Pro';
+  if (priceId) {
+    const tierInfo = await resolveTierByPriceId(priceId);
+    if (tierInfo) {
+      updates.tierId = tierInfo.tierId;
+      updates.billingInterval = tierInfo.billingInterval;
+      tierName = await getTierName(tierInfo.tierId);
+    }
+  }
+
+  // Trial → active conversion: reset the period anchor so the user gets a fresh
+  // quota window starting at conversion.
+  if (sub.currentStatus === 'trial' && localStatus === 'active') {
+    updates.currentPeriodAnchorAt = new Date();
+  }
+
+  // Pending cancellation: trust `cancel_at`. Stripe's flexible billing encodes
+  // "cancel at period end" by setting `cancel_at` to the period-end timestamp
+  // while leaving the legacy `cancel_at_period_end` flag false, so read
+  // `cancel_at` directly.
+  updates.expiresAt = subscription.cancel_at
+    ? new Date(subscription.cancel_at * 1000)
+    : null;
+
+  // Keep trial_expires_at in sync for trialing subs.
+  if (localStatus === 'trial' && subscription.trial_end) {
+    updates.trialExpiresAt = new Date(subscription.trial_end * 1000);
+  }
+
+  await db
+    .update(userSubscriptions)
+    .set(updates)
+    .where(eq(userSubscriptions.stripeSubscriptionId, subscription.id));
+
+  await invalidateAllQuotaCaches(sub.userId);
+
+  // Track trial → active conversion.
+  if (sub.currentStatus === 'trial' && localStatus === 'active' && updates.billingInterval) {
+    trackEventServer(
+      'subscription_converted',
+      {
+        billing_interval: updates.billingInterval,
+        tier_name: tierName,
+        conversion_source: 'trial_upgrade',
+      },
+      sub.userId,
+    ).catch(err => logger.warn({ err, userId: sub.userId }, 'subscription_converted tracking failed'));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// customer.subscription.deleted
+// ---------------------------------------------------------------------------
+
+async function handleSubscriptionDeleted(subscription: Stripe.Subscription): Promise<void> {
+  const [sub] = await db
+    .select({ userId: userSubscriptions.userId, tierId: userSubscriptions.tierId })
+    .from(userSubscriptions)
+    .where(eq(userSubscriptions.stripeSubscriptionId, subscription.id))
+    .limit(1);
+
+  if (!sub) {
+    logger.warn({ subscriptionId: subscription.id }, 'customer.subscription.deleted: no matching row');
+    return;
+  }
+
+  const [freeTier] = await db
+    .select({ id: subscriptionTiers.id })
+    .from(subscriptionTiers)
+    .where(eq(subscriptionTiers.name, 'free'))
+    .limit(1);
+
+  if (!freeTier) {
+    logger.error('customer.subscription.deleted: free tier not found in DB');
+    return;
+  }
+
+  const tierName = await getTierName(sub.tierId);
+
+  await db
+    .update(userSubscriptions)
+    .set({
+      tierId: freeTier.id,
+      status: 'cancelled',
+      billingInterval: null,
+      stripeSubscriptionId: null,
+      currentPeriodAnchorAt: new Date(),
+      expiresAt: null,
+      updatedAt: new Date(),
+    })
+    .where(eq(userSubscriptions.stripeSubscriptionId, subscription.id));
+
+  // Block any in-flight scheduled tasks so they don't run without an active
+  // subscription.
+  await blockScheduledTasksForUser(sub.userId, 'subscription_cancelled');
+
+  await invalidateAllQuotaCaches(sub.userId);
+
+  const userInfo = await getUserEmailAndName(sub.userId);
+  if (userInfo) {
+    sendSubscriptionEndedEmail({ email: userInfo.email, name: userInfo.name, tierName });
+  }
+
+  trackEventServer(
+    'subscription_cancelled',
+    { tier_name: tierName },
+    sub.userId,
+  ).catch(err => logger.warn({ err, userId: sub.userId }, 'subscription_cancelled tracking failed'));
+
+  logger.info({ userId: sub.userId }, 'User downgraded to free tier after subscription deletion');
+}

--- a/src/app/api/subscriptions/usage/route.ts
+++ b/src/app/api/subscriptions/usage/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+
+import { internalError, logApiError } from '@/libs/api/errors';
+import { withAuth } from '@/libs/api/middleware/withAuth';
+import { getSubscriptionUsage } from '@/libs/subscriptions/get-subscription-usage';
+
+/**
+ * GET /api/subscriptions/usage
+ *
+ * Returns the authenticated user's subscription + tier + quota + usage payload —
+ * the single read powering every subscription UI surface (the
+ * `useSubscriptionUsage` hook, expiry banner, trial pill, plan cards).
+ */
+export const GET = withAuth(async (_request, { user }): Promise<Response> => {
+  try {
+    const usage = await getSubscriptionUsage(user.id);
+    if (!usage) {
+      // null = a fatal data-integrity issue (e.g. the free tier isn't seeded).
+      return internalError('Failed to load subscription usage');
+    }
+    return NextResponse.json(usage);
+  } catch (error: unknown) {
+    logApiError(error, {
+      endpoint: '/api/subscriptions/usage',
+      method: 'GET',
+    });
+    return internalError();
+  }
+});

--- a/src/components/subscriptions/expiry-banner-logic.ts
+++ b/src/components/subscriptions/expiry-banner-logic.ts
@@ -1,0 +1,120 @@
+import { differenceInDays, format } from 'date-fns';
+
+/**
+ * Pure decision logic for the expiry banner, split out of `expiry-banner.tsx` so
+ * it can be unit-tested and so the component file only exports a component
+ * (react-refresh/only-export-components). Product-agnostic.
+ */
+
+// Where the trial / promotion banner CTA links. A product repoints this.
+export const BILLING_PATH = '/subscriptions';
+export const BANNER_THRESHOLDS = [7, 3, 1] as const;
+// localStorage namespace for "dismissed at threshold" state. A fork can swap
+// this for an appName-derived prefix; it just needs to be unique per product.
+export const STORAGE_PREFIX = 'vt-saas:expiry-banner-dismissed';
+
+export type BannerVariant = 'trial' | 'promotion' | 'cancelled-paid';
+
+export type BannerData = {
+  variant: BannerVariant;
+  daysLeft: number;
+  endDate: string; // ISO
+};
+
+/**
+ * Decides which expiry banner — if any — to show, based on the user's
+ * subscription state. Covers three cases:
+ *   - Trial expiry (status='trial', trialExpiresAt within 7 days)
+ *   - Promotion expiry (tier='promotion', expiresAt within 7 days)
+ *   - Paid cancellation winding down (tier='pro', status='active', expiresAt set
+ *     — Stripe `cancel_at_period_end` set this)
+ */
+export function pickBanner(args: {
+  status: 'active' | 'trial' | 'expired' | 'cancelled';
+  tierName: string;
+  trialExpiresAt: string | null;
+  expiresAt: string | null;
+  now?: Date;
+}): BannerData | null {
+  const now = args.now ?? new Date();
+
+  if (args.status === 'trial' && args.trialExpiresAt) {
+    const days = differenceInDays(new Date(args.trialExpiresAt), now);
+    if (days <= 7) {
+      return { variant: 'trial', daysLeft: Math.max(0, days), endDate: args.trialExpiresAt };
+    }
+  }
+
+  if (args.tierName === 'promotion' && args.expiresAt) {
+    const days = differenceInDays(new Date(args.expiresAt), now);
+    if (days <= 7) {
+      return { variant: 'promotion', daysLeft: Math.max(0, days), endDate: args.expiresAt };
+    }
+  }
+
+  if (args.tierName === 'pro' && args.status === 'active' && args.expiresAt) {
+    // cancel_at_period_end set — paid until expiresAt, then downgraded.
+    const days = differenceInDays(new Date(args.expiresAt), now);
+    return { variant: 'cancelled-paid', daysLeft: Math.max(0, days), endDate: args.expiresAt };
+  }
+
+  return null;
+}
+
+export function copyForBanner(banner: BannerData): { title: string; cta: string; href: string } {
+  // Include the year so dates aren't ambiguous near year boundaries.
+  const formattedDate = format(new Date(banner.endDate), 'MMM d, yyyy');
+
+  if (banner.variant === 'trial') {
+    if (banner.daysLeft === 0) {
+      return {
+        title: 'Your trial ends today. Subscribe to keep your plan.',
+        cta: 'Subscribe',
+        href: BILLING_PATH,
+      };
+    }
+    return {
+      title: `Your trial ends in ${banner.daysLeft} day${banner.daysLeft === 1 ? '' : 's'} (${formattedDate}). Subscribe to keep your plan.`,
+      cta: 'Subscribe',
+      href: BILLING_PATH,
+    };
+  }
+
+  if (banner.variant === 'promotion') {
+    if (banner.daysLeft === 0) {
+      return {
+        title: 'Your free access ends today. Subscribe to keep your plan.',
+        cta: 'Subscribe',
+        href: BILLING_PATH,
+      };
+    }
+    return {
+      title: `Your free access ends in ${banner.daysLeft} day${banner.daysLeft === 1 ? '' : 's'} (${formattedDate}). Subscribe to keep your plan.`,
+      cta: 'Subscribe',
+      href: BILLING_PATH,
+    };
+  }
+
+  // cancelled-paid
+  if (banner.daysLeft === 0) {
+    return {
+      title: `Your subscription ends today (${formattedDate}). Renew to keep your plan.`,
+      cta: 'Reactivate',
+      href: BILLING_PATH,
+    };
+  }
+  return {
+    title: `Your subscription ends on ${formattedDate}. Renew to keep your plan.`,
+    cta: 'Reactivate',
+    href: BILLING_PATH,
+  };
+}
+
+export function thresholdForDays(daysLeft: number): number | null {
+  for (const t of BANNER_THRESHOLDS) {
+    if (daysLeft <= t) {
+      return t;
+    }
+  }
+  return null;
+}

--- a/src/components/subscriptions/expiry-banner.test.ts
+++ b/src/components/subscriptions/expiry-banner.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest';
+
+import { pickBanner, thresholdForDays } from './expiry-banner-logic';
+
+const now = new Date('2026-05-05T12:00:00Z');
+
+function isoIn(daysFromNow: number): string {
+  return new Date(now.getTime() + daysFromNow * 24 * 60 * 60 * 1000).toISOString();
+}
+
+describe('pickBanner', () => {
+  it('returns trial banner when trial expires within 7 days', () => {
+    const banner = pickBanner({
+      status: 'trial',
+      tierName: 'pro',
+      trialExpiresAt: isoIn(3),
+      expiresAt: null,
+      now,
+    });
+
+    expect(banner).toEqual({
+      variant: 'trial',
+      daysLeft: 3,
+      endDate: isoIn(3),
+    });
+  });
+
+  it('returns null when trial expiry is more than 7 days out', () => {
+    const banner = pickBanner({
+      status: 'trial',
+      tierName: 'pro',
+      trialExpiresAt: isoIn(10),
+      expiresAt: null,
+      now,
+    });
+
+    expect(banner).toBeNull();
+  });
+
+  it('clamps daysLeft to 0 when trial is already past expiry', () => {
+    const banner = pickBanner({
+      status: 'trial',
+      tierName: 'pro',
+      trialExpiresAt: isoIn(-1),
+      expiresAt: null,
+      now,
+    });
+
+    expect(banner?.daysLeft).toBe(0);
+  });
+
+  it('returns promotion banner when promotion expires within 7 days', () => {
+    const banner = pickBanner({
+      status: 'active',
+      tierName: 'promotion',
+      trialExpiresAt: null,
+      expiresAt: isoIn(5),
+      now,
+    });
+
+    expect(banner).toEqual({
+      variant: 'promotion',
+      daysLeft: 5,
+      endDate: isoIn(5),
+    });
+  });
+
+  it('returns null when promotion expiry is more than 7 days out', () => {
+    const banner = pickBanner({
+      status: 'active',
+      tierName: 'promotion',
+      trialExpiresAt: null,
+      expiresAt: isoIn(20),
+      now,
+    });
+
+    expect(banner).toBeNull();
+  });
+
+  it('returns cancelled-paid banner for active pro with expires_at set (any horizon)', () => {
+    // cancel_at_period_end populates expires_at; we want the banner visible the
+    // entire wind-down window, not just within 7 days.
+    const banner = pickBanner({
+      status: 'active',
+      tierName: 'pro',
+      trialExpiresAt: null,
+      expiresAt: isoIn(20),
+      now,
+    });
+
+    expect(banner).toEqual({
+      variant: 'cancelled-paid',
+      daysLeft: 20,
+      endDate: isoIn(20),
+    });
+  });
+
+  it('returns null for active pro without expires_at (no cancellation pending)', () => {
+    const banner = pickBanner({
+      status: 'active',
+      tierName: 'pro',
+      trialExpiresAt: null,
+      expiresAt: null,
+      now,
+    });
+
+    expect(banner).toBeNull();
+  });
+
+  it('returns null for active free user', () => {
+    const banner = pickBanner({
+      status: 'active',
+      tierName: 'free',
+      trialExpiresAt: null,
+      expiresAt: null,
+      now,
+    });
+
+    expect(banner).toBeNull();
+  });
+
+  it('returns null for expired-trial free user (status flipped, banner gone)', () => {
+    const banner = pickBanner({
+      status: 'expired',
+      tierName: 'free',
+      trialExpiresAt: isoIn(-1),
+      expiresAt: null,
+      now,
+    });
+
+    expect(banner).toBeNull();
+  });
+
+  it('prefers trial banner over promotion when both could apply (trial wins)', () => {
+    const banner = pickBanner({
+      status: 'trial',
+      tierName: 'promotion', // shouldn't happen in practice
+      trialExpiresAt: isoIn(2),
+      expiresAt: isoIn(5),
+      now,
+    });
+
+    expect(banner?.variant).toBe('trial');
+  });
+});
+
+describe('thresholdForDays', () => {
+  // Iterates [7, 3, 1] and returns the first bucket days-left fits under — i.e.
+  // the widest matching threshold (the dismissal key is keyed on this).
+  it('maps days-left to the widest matching threshold bucket', () => {
+    expect(thresholdForDays(1)).toBe(7);
+    expect(thresholdForDays(3)).toBe(7);
+    expect(thresholdForDays(5)).toBe(7);
+    expect(thresholdForDays(7)).toBe(7);
+  });
+
+  it('returns null when days-left exceeds every threshold', () => {
+    expect(thresholdForDays(8)).toBeNull();
+  });
+});

--- a/src/components/subscriptions/expiry-banner.tsx
+++ b/src/components/subscriptions/expiry-banner.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { Loader2 } from 'lucide-react';
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/button';
+import { createPortalSession } from '@/libs/actions/billing';
+import { useSubscriptionUsage } from '@/libs/hooks/use-subscription-usage';
+
+import {
+  copyForBanner,
+  pickBanner,
+  STORAGE_PREFIX,
+  thresholdForDays,
+} from './expiry-banner-logic';
+
+export function ExpiryBanner() {
+  const { data } = useSubscriptionUsage();
+  const [dismissed, setDismissed] = useState(false);
+  const [reactivating, setReactivating] = useState(false);
+
+  const banner = data
+    ? pickBanner({
+        status: data.subscription.status,
+        tierName: data.tier.name,
+        trialExpiresAt: data.subscription.trialExpiresAt,
+        expiresAt: data.subscription.expiresAt,
+      })
+    : null;
+
+  // Reset dismissed state when banner identity changes.
+  useEffect(() => {
+    setDismissed(false);
+  }, [banner?.variant, banner?.endDate]);
+
+  // Read localStorage to see if this threshold was already dismissed.
+  useEffect(() => {
+    if (!banner || banner.daysLeft === 0) {
+      return;
+    }
+    const threshold = thresholdForDays(banner.daysLeft);
+    if (!threshold) {
+      return;
+    }
+    try {
+      const key = `${STORAGE_PREFIX}:${banner.variant}:${threshold}`;
+      if (typeof window !== 'undefined' && window.localStorage.getItem(key)) {
+        setDismissed(true);
+      }
+    } catch {
+      // localStorage unavailable; show by default
+    }
+  }, [banner]);
+
+  if (!banner || dismissed) {
+    return null;
+  }
+
+  const { title, cta, href } = copyForBanner(banner);
+  const isDayOf = banner.daysLeft === 0;
+  const isReactivate = banner.variant === 'cancelled-paid';
+
+  const handleReactivate = async () => {
+    setReactivating(true);
+    try {
+      const result = await createPortalSession({ intent: 'reactivate' });
+      if (result.error) {
+        toast.error(result.error.message);
+        setReactivating(false);
+        return;
+      }
+      window.location.href = result.data.portalUrl;
+    } catch {
+      toast.error('Failed to open billing portal. Please try again.');
+      setReactivating(false);
+    }
+  };
+
+  const handleDismiss = () => {
+    if (isDayOf) {
+      return;
+    }
+    const threshold = thresholdForDays(banner.daysLeft);
+    if (threshold) {
+      try {
+        window.localStorage.setItem(
+          `${STORAGE_PREFIX}:${banner.variant}:${threshold}`,
+          new Date().toISOString(),
+        );
+      } catch {
+        // ignore
+      }
+    }
+    setDismissed(true);
+  };
+
+  return (
+    <div
+      role="status"
+      className="flex items-center justify-between gap-3 border-b border-amber-200 bg-amber-50 px-4 py-2 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-100"
+    >
+      <span className="flex-1">{title}</span>
+      <div className="flex shrink-0 items-center gap-2">
+        {isReactivate
+          ? (
+              <Button size="sm" variant="default" onClick={handleReactivate} disabled={reactivating}>
+                {reactivating && <Loader2 className="mr-2 size-4 animate-spin" />}
+                {cta}
+              </Button>
+            )
+          : (
+              <Button asChild size="sm" variant="default">
+                <Link href={href}>{cta}</Link>
+              </Button>
+            )}
+        {!isDayOf && (
+          <Button size="sm" variant="ghost" onClick={handleDismiss}>
+            Dismiss
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/subscriptions/plan-gate-dialog.tsx
+++ b/src/components/subscriptions/plan-gate-dialog.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { format } from 'date-fns';
+import Link from 'next/link';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { useSubscriptionUsage } from '@/libs/hooks/use-subscription-usage';
+
+// Where the upgrade CTA links. A product repoints this.
+const BILLING_PATH = '/subscriptions';
+
+type Props = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Optional ISO date the quota resets on, surfaced in the copy. */
+  resetsAt?: string | null;
+};
+
+/**
+ * Generic plan-gate upsell dialog shown when a user exhausts a quota. On a top
+ * tier (pro/promotion) it just states when the quota resets; otherwise it
+ * surfaces an upgrade CTA. A product passes its own open/close state (e.g. from
+ * a quota error on a gated action).
+ *
+ * One reusable gate in place of feature-specific upsell dialogs.
+ */
+export function PlanGateDialog({ open, onOpenChange, resetsAt }: Props) {
+  const { data } = useSubscriptionUsage();
+
+  const isTopTier = data?.tier.name === 'pro' || data?.tier.name === 'promotion';
+  const formattedDate = resetsAt ? format(new Date(resetsAt), 'MMM d') : 'soon';
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>You've hit your limit</DialogTitle>
+          <DialogDescription>
+            {isTopTier
+              ? `You're on the top tier — your quota resets on ${formattedDate}.`
+              : `You've used your quota for this period — it resets on ${formattedDate}. Upgrade for higher limits.`}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          {!isTopTier && (
+            <Button asChild onClick={() => onOpenChange(false)}>
+              <Link href={BILLING_PATH}>Upgrade</Link>
+            </Button>
+          )}
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Close
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/subscriptions/tier-card.tsx
+++ b/src/components/subscriptions/tier-card.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import { Check, Loader2 } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card';
+import { cn } from '@/utils/Helpers';
+
+type BillingInterval = 'monthly' | 'yearly';
+
+export type TierCardProps = {
+  name: string;
+  displayName: string;
+  priceCents: number | null;
+  /** Optional small badge above the feature list (e.g. a plan tagline). */
+  badgeLabel?: string;
+  features: readonly string[];
+  ctaLabel: string;
+  // 'destructive-outline' is a semantic intent (a downgrade) mapped below to an
+  // outline button with destructive colours — not a built-in shadcn variant.
+  ctaVariant: 'default' | 'outline' | 'destructive-outline';
+  isCurrentPlan: boolean;
+  isRecommended: boolean;
+  isLoading?: boolean;
+  /** Render the CTA as a non-actionable, disabled button. */
+  disabled?: boolean;
+  onCtaClick: () => void;
+  /** Optional: enable billing-interval toggle. When set, priceCents is the monthly price. */
+  billingInterval?: BillingInterval;
+  yearlyPriceCents?: number;
+  onBillingIntervalChange?: (interval: BillingInterval) => void;
+};
+
+function formatPrice(priceCents: number | null, interval: BillingInterval): string {
+  if (priceCents === null) {
+    return 'Invite Only';
+  }
+  if (priceCents === 0) {
+    return '$0/month';
+  }
+  return interval === 'yearly'
+    ? `$${priceCents / 100}/year`
+    : `$${priceCents / 100}/month`;
+}
+
+export function TierCard({
+  displayName,
+  priceCents,
+  badgeLabel,
+  features,
+  ctaLabel,
+  ctaVariant,
+  isCurrentPlan,
+  isRecommended,
+  isLoading,
+  disabled,
+  onCtaClick,
+  billingInterval,
+  yearlyPriceCents,
+  onBillingIntervalChange,
+}: TierCardProps) {
+  const showToggle = Boolean(billingInterval && onBillingIntervalChange && yearlyPriceCents);
+  const activeInterval: BillingInterval = billingInterval ?? 'monthly';
+  const displayPriceCents = showToggle && activeInterval === 'yearly'
+    ? (yearlyPriceCents ?? priceCents)
+    : priceCents;
+
+  return (
+    <Card
+      className={cn(
+        'relative flex flex-col transition-all duration-200 hover:-translate-y-1 hover:shadow-lg',
+        isRecommended && 'border-2 border-primary/40',
+      )}
+    >
+      {isRecommended && (
+        <div className="absolute -top-3.5 left-1/2 -translate-x-1/2">
+          <span className="rounded-full bg-primary px-3 py-1 text-xs font-semibold text-primary-foreground">
+            Recommended
+          </span>
+        </div>
+      )}
+
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between gap-3">
+          <h3 className="text-xl font-bold">{displayName}</h3>
+          {showToggle && onBillingIntervalChange && (
+            <div className="inline-flex rounded-full border bg-muted/30 p-0.5">
+              <button
+                type="button"
+                onClick={() => onBillingIntervalChange('monthly')}
+                className={cn(
+                  'rounded-full px-3 py-1 text-xs font-medium transition-colors',
+                  activeInterval === 'monthly'
+                    ? 'bg-background shadow-sm'
+                    : 'text-muted-foreground hover:text-foreground',
+                )}
+              >
+                Monthly
+              </button>
+              <button
+                type="button"
+                onClick={() => onBillingIntervalChange('yearly')}
+                className={cn(
+                  'rounded-full px-3 py-1 text-xs font-medium transition-colors',
+                  activeInterval === 'yearly'
+                    ? 'bg-background shadow-sm'
+                    : 'text-muted-foreground hover:text-foreground',
+                )}
+              >
+                Yearly
+                <span className="ml-1.5 rounded-full bg-emerald-100 px-1.5 py-0.5 text-[10px] font-semibold text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200">
+                  2 months free
+                </span>
+              </button>
+            </div>
+          )}
+        </div>
+        <p className="text-3xl font-bold">
+          {formatPrice(displayPriceCents, activeInterval)}
+        </p>
+      </CardHeader>
+
+      <CardContent className="flex-1 space-y-3">
+        {badgeLabel && (
+          <span className="inline-block rounded-md bg-muted px-2.5 py-1 text-xs font-medium text-muted-foreground">
+            {badgeLabel}
+          </span>
+        )}
+
+        <ul className="space-y-2">
+          {features.map(feature => (
+            <li key={feature} className="flex items-start gap-2 text-sm">
+              <Check className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+              <span>{feature}</span>
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+
+      <CardFooter>
+        {ctaVariant === 'destructive-outline'
+          ? (
+              <Button
+                variant="outline"
+                className="w-full border-destructive text-destructive hover:bg-destructive/10"
+                disabled={isCurrentPlan || isLoading || disabled}
+                onClick={onCtaClick}
+              >
+                {isLoading && <Loader2 className="mr-2 size-4 animate-spin" />}
+                {ctaLabel}
+              </Button>
+            )
+          : (
+              <Button
+                variant={ctaVariant}
+                className="w-full"
+                disabled={isCurrentPlan || isLoading || disabled}
+                onClick={onCtaClick}
+              >
+                {isLoading && <Loader2 className="mr-2 size-4 animate-spin" />}
+                {ctaLabel}
+              </Button>
+            )}
+      </CardFooter>
+    </Card>
+  );
+}

--- a/src/components/subscriptions/tier-cta.test.ts
+++ b/src/components/subscriptions/tier-cta.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import { getCtaConfig } from './tier-cta';
+
+describe('getCtaConfig', () => {
+  it('marks the matching card as the current plan', () => {
+    expect(getCtaConfig('free', 'free')).toEqual({
+      label: 'Current Plan',
+      variant: 'default',
+      isCurrentPlan: true,
+    });
+    expect(getCtaConfig('pro', 'pro')).toMatchObject({ isCurrentPlan: true });
+  });
+
+  it('offers an upgrade from free to pro', () => {
+    expect(getCtaConfig('free', 'pro')).toEqual({
+      label: 'Upgrade to Pro',
+      variant: 'default',
+      isCurrentPlan: false,
+    });
+  });
+
+  it('offers a downgrade from pro to free', () => {
+    expect(getCtaConfig('pro', 'free')).toEqual({
+      label: 'Downgrade',
+      variant: 'destructive-outline',
+      isCurrentPlan: false,
+    });
+  });
+
+  describe('promotion tier', () => {
+    it('offers an upgrade to pro so promo users can lock in paid access', () => {
+      expect(getCtaConfig('promotion', 'pro')).toEqual({
+        label: 'Upgrade to Pro',
+        variant: 'default',
+        isCurrentPlan: false,
+      });
+    });
+
+    it('renders the free card as a non-actionable fallback (no "downgrade")', () => {
+      const cta = getCtaConfig('promotion', 'free');
+
+      expect(cta.disabled).toBe(true);
+      expect(cta.isCurrentPlan).toBe(false);
+      // Not the destructive "Downgrade" CTA — promotion users have no Stripe
+      // customer, so the billing-portal downgrade flow doesn't apply to them.
+      expect(cta.variant).not.toBe('destructive-outline');
+    });
+  });
+});

--- a/src/components/subscriptions/tier-cta.ts
+++ b/src/components/subscriptions/tier-cta.ts
@@ -1,0 +1,62 @@
+/**
+ * Pure CTA-mapping logic for the subscriptions tier grid.
+ *
+ * Product-agnostic and fully unit-tested: given the user's current tier and a
+ * card's tier, decide the button label/variant. Kept out of the client
+ * component so it can be tested without React/Server-Action imports.
+ *
+ * `variant` is a label the consuming component maps to a button variant — note
+ * 'destructive-outline' is a semantic intent (a downgrade), not a built-in
+ * shadcn variant; map it to `outline` + a destructive text colour, or add a
+ * variant.
+ */
+
+/** Tier ordering for comparison: lower index = lower tier. */
+export const TIER_ORDER = ['free', 'pro'] as const;
+
+export type CtaConfig = {
+  label: string;
+  variant: 'default' | 'outline' | 'destructive-outline';
+  isCurrentPlan: boolean;
+  /** Non-actionable card (rendered, but the button is disabled). */
+  disabled?: boolean;
+};
+
+function displayName(tierName: string): string {
+  return tierName.charAt(0).toUpperCase() + tierName.slice(1);
+}
+
+/**
+ * Decide the CTA label/variant for a tier card, given the user's current tier.
+ *
+ * Promotion users get paid-equivalent access for free until the grant expires.
+ * They sit above free and below paid: surface an upgrade path to the paid tier
+ * (so they can lock in paid access before the promo ends), and render free as a
+ * non-actionable fallback rather than a real "downgrade" — promotion users have
+ * no Stripe customer, so the billing-portal downgrade flow doesn't apply.
+ */
+export function getCtaConfig(userTierName: string, cardTierName: string): CtaConfig {
+  if (userTierName === cardTierName) {
+    return { label: 'Current Plan', variant: 'default', isCurrentPlan: true };
+  }
+
+  if (userTierName === 'promotion') {
+    if (cardTierName === 'free') {
+      return { label: 'Free plan', variant: 'outline', isCurrentPlan: false, disabled: true };
+    }
+    return { label: `Upgrade to ${displayName(cardTierName)}`, variant: 'default', isCurrentPlan: false };
+  }
+
+  const userIndex = TIER_ORDER.indexOf(userTierName as typeof TIER_ORDER[number]);
+  const cardIndex = TIER_ORDER.indexOf(cardTierName as typeof TIER_ORDER[number]);
+
+  if (cardIndex > userIndex) {
+    return { label: `Upgrade to ${displayName(cardTierName)}`, variant: 'default', isCurrentPlan: false };
+  }
+
+  // Downgrade
+  if (cardTierName === 'free') {
+    return { label: 'Downgrade', variant: 'destructive-outline', isCurrentPlan: false };
+  }
+  return { label: `Downgrade to ${displayName(cardTierName)}`, variant: 'destructive-outline', isCurrentPlan: false };
+}

--- a/src/components/subscriptions/trial-status-pill.tsx
+++ b/src/components/subscriptions/trial-status-pill.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { differenceInDays } from 'date-fns';
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+
+import { useSubscriptionUsage } from '@/libs/hooks/use-subscription-usage';
+import { cn } from '@/utils/Helpers';
+
+type Props = {
+  /** When true, render as a compact dot-only indicator (sidebar collapsed). */
+  collapsed?: boolean;
+};
+
+// Where the pill links. A product repoints this to its billing page.
+const BILLING_PATH = 'subscriptions';
+
+/**
+ * Persistent pill for users on an active trial or promotion, surfacing
+ * "X days left" so trialing users have ambient awareness from day 1.
+ *
+ * Returns null for paid, free, or expired users — those cases are covered by
+ * other UI (banners, upsell modal, billing-portal link).
+ */
+export function TrialStatusPill({ collapsed = false }: Props) {
+  const params = useParams();
+  const locale = params.locale as string;
+  const { data } = useSubscriptionUsage();
+
+  if (!data) {
+    return null;
+  }
+
+  const { subscription, tier } = data;
+  const now = new Date();
+
+  let daysLeft: number | null = null;
+  let label = '';
+
+  if (subscription.status === 'trial' && subscription.trialExpiresAt) {
+    daysLeft = Math.max(0, differenceInDays(new Date(subscription.trialExpiresAt), now));
+    label = 'Trial';
+  } else if (tier.name === 'promotion' && subscription.expiresAt) {
+    daysLeft = Math.max(0, differenceInDays(new Date(subscription.expiresAt), now));
+    label = 'Free access';
+  } else {
+    return null;
+  }
+
+  const urgent = daysLeft <= 3;
+  const dayWord = daysLeft === 1 ? 'day' : 'days';
+
+  return (
+    <Link
+      href={`/${locale}/${BILLING_PATH}`}
+      aria-label={`${label} — ${daysLeft} ${dayWord} left`}
+      className={cn(
+        'flex items-center gap-2 rounded-md border px-3 py-1.5 text-xs font-medium transition-colors',
+        urgent
+          ? 'border-amber-300 bg-amber-50 text-amber-900 hover:bg-amber-100 dark:border-amber-800/60 dark:bg-amber-950/40 dark:text-amber-100'
+          : 'border-border bg-muted/40 text-muted-foreground hover:bg-muted',
+        collapsed && 'justify-center px-2',
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className={cn(
+          'inline-block size-2 shrink-0 rounded-full',
+          urgent ? 'bg-amber-500' : 'bg-emerald-500',
+        )}
+      />
+      {!collapsed && (
+        <span className="truncate">
+          {label}
+          {' · '}
+          {daysLeft}
+          {' '}
+          {dayWord}
+          {' '}
+          left
+        </span>
+      )}
+    </Link>
+  );
+}

--- a/src/libs/Env.ts
+++ b/src/libs/Env.ts
@@ -51,11 +51,25 @@ export const Env = createEnv({
     // (the Inngest Dev Server works without these keys).
     INNGEST_EVENT_KEY: z.string().min(1).optional(),
     INNGEST_SIGNING_KEY: z.string().min(1).optional(),
+    // Stripe (billing) — optional; billing is disabled if unset. The Stripe
+    // client is lazy (see src/libs/stripe/client.ts) so an unconfigured fork
+    // builds and runs unaffected.
+    STRIPE_SECRET_KEY: z.string().min(1).optional(),
+    STRIPE_WEBHOOK_SECRET: z.string().min(1).optional(),
+    // Reverse-trial policy (opt-in). ENABLE_REVERSE_TRIAL gates ONLY the TS layer
+    // (the expiry crons no-op when off, and UI banners). Actual signup enrollment
+    // is the prod-setup signup trigger, which is independently opt-in — keep
+    // TRIAL_DAYS here in sync with the literal in that trigger (the dual-source
+    // caveat is documented in docs/subscriptions.md).
+    TRIAL_DAYS: z.coerce.number().int().positive().default(14),
+    ENABLE_REVERSE_TRIAL: z.enum(['true', 'false']).default('false'),
   },
   client: {
     NEXT_PUBLIC_APP_URL: z.string().optional(),
     NEXT_PUBLIC_SUPABASE_URL: z.string().min(1),
     NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string().min(1),
+    // Stripe publishable key — optional (billing disabled if unset).
+    NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: z.string().optional(),
   },
   shared: {
     NODE_ENV: z.enum(['test', 'development', 'production']).optional(),
@@ -93,9 +107,14 @@ export const Env = createEnv({
     WEBHOOK_SECRET: process.env.WEBHOOK_SECRET,
     INNGEST_EVENT_KEY: process.env.INNGEST_EVENT_KEY,
     INNGEST_SIGNING_KEY: process.env.INNGEST_SIGNING_KEY,
+    STRIPE_SECRET_KEY: process.env.STRIPE_SECRET_KEY,
+    STRIPE_WEBHOOK_SECRET: process.env.STRIPE_WEBHOOK_SECRET,
+    TRIAL_DAYS: process.env.TRIAL_DAYS,
+    ENABLE_REVERSE_TRIAL: process.env.ENABLE_REVERSE_TRIAL,
     NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
     NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL,
     NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY,
     NODE_ENV: process.env.NODE_ENV,
   },
 });

--- a/src/libs/actions/billing.test.ts
+++ b/src/libs/actions/billing.test.ts
@@ -1,0 +1,270 @@
+import { cookies } from 'next/headers';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { db } from '@/libs/DB';
+import { getStripe } from '@/libs/stripe/client';
+import { createClient } from '@/libs/supabase/server';
+
+// --- Mocks ---
+
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(),
+}));
+
+vi.mock('@/libs/supabase/server', () => ({
+  createClient: vi.fn(),
+}));
+
+vi.mock('@/libs/DB', () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    transaction: vi.fn(),
+  },
+}));
+
+vi.mock('@/libs/Logger', () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+const mockStripe = {
+  checkout: {
+    sessions: {
+      create: vi.fn(),
+    },
+  },
+  billingPortal: {
+    sessions: {
+      create: vi.fn(),
+    },
+  },
+};
+
+vi.mock('@/libs/stripe/client', () => ({
+  getStripe: () => mockStripe,
+}));
+
+// Suppress unused import warnings
+void cookies;
+void createClient;
+void db;
+void getStripe;
+
+// --- Helpers ---
+
+const mockCookieStore = {} as Awaited<ReturnType<typeof cookies>>;
+const mockUser = {
+  id: 'user-123',
+  email: 'user@test.com',
+};
+
+function mockAuth(user: unknown = mockUser, error: unknown = null) {
+  (cookies as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(mockCookieStore);
+  (createClient as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user }, error }),
+    },
+  });
+}
+
+function mockDbChain(result: unknown[] = []) {
+  const chain = {
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue(result),
+  };
+  (db.select as unknown as ReturnType<typeof vi.fn>).mockReturnValue(chain);
+  return chain;
+}
+
+// --- Tests ---
+
+describe('createCheckoutSession', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns UNAUTHORIZED when user is not authenticated', async () => {
+    mockAuth(null, { message: 'Not logged in' });
+
+    const { createCheckoutSession } = await import('./billing');
+    const result = await createCheckoutSession('pro');
+
+    expect(result.error?.code).toBe('UNAUTHORIZED');
+  });
+
+  it('returns FORBIDDEN when tier has no stripe price id', async () => {
+    mockAuth();
+    mockDbChain([{ id: 'tier-1', name: 'free', stripePriceIdMonthly: null, stripePriceIdYearly: null }]);
+
+    const { createCheckoutSession } = await import('./billing');
+    const result = await createCheckoutSession('free');
+
+    expect(result.error?.code).toBe('FORBIDDEN');
+    expect(result.error?.message).toBe('This tier is not available for purchase');
+  });
+
+  it('returns FORBIDDEN when tier is not found', async () => {
+    mockAuth();
+    mockDbChain([]);
+
+    const { createCheckoutSession } = await import('./billing');
+    const result = await createCheckoutSession('nonexistent');
+
+    expect(result.error?.code).toBe('FORBIDDEN');
+  });
+
+  it('creates checkout session with existing stripe customer', async () => {
+    mockAuth();
+
+    // First select (tier lookup) -> tier with price ID
+    // Second select (user subscription lookup) -> has stripe customer
+    const selectCallCount = { count: 0 };
+    const chain = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockImplementation(() => {
+        selectCallCount.count++;
+        if (selectCallCount.count === 1) {
+          return [{ id: 'tier-pro', name: 'pro', stripePriceIdMonthly: 'price_test_pro', stripePriceIdYearly: null }];
+        }
+        return [{ stripeCustomerId: 'cus_existing_123' }];
+      }),
+    };
+    (db.select as unknown as ReturnType<typeof vi.fn>).mockReturnValue(chain);
+
+    (mockStripe.checkout.sessions.create as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      url: 'https://checkout.stripe.com/test',
+    });
+
+    const { createCheckoutSession } = await import('./billing');
+    const result = await createCheckoutSession('pro');
+
+    expect(result.data?.checkoutUrl).toBe('https://checkout.stripe.com/test');
+    expect(result.error).toBeNull();
+
+    // Verify Stripe was called with customer (not customer_email).
+    const createCall = (mockStripe.checkout.sessions.create as unknown as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+
+    expect(createCall).toBeDefined();
+    expect(createCall.customer).toBe('cus_existing_123');
+    expect(createCall.customer_email).toBeUndefined();
+    expect(createCall.metadata.user_id).toBe('user-123');
+  });
+
+  it('creates checkout session with customer_email when no existing customer', async () => {
+    mockAuth();
+
+    const selectCallCount = { count: 0 };
+    const chain = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockImplementation(() => {
+        selectCallCount.count++;
+        if (selectCallCount.count === 1) {
+          return [{ id: 'tier-pro', name: 'pro', stripePriceIdMonthly: 'price_test_pro', stripePriceIdYearly: null }];
+        }
+        return [{ stripeCustomerId: null }];
+      }),
+    };
+    (db.select as unknown as ReturnType<typeof vi.fn>).mockReturnValue(chain);
+
+    (mockStripe.checkout.sessions.create as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      url: 'https://checkout.stripe.com/test2',
+    });
+
+    const { createCheckoutSession } = await import('./billing');
+    const result = await createCheckoutSession('pro');
+
+    expect(result.data?.checkoutUrl).toBe('https://checkout.stripe.com/test2');
+
+    const createCall = (mockStripe.checkout.sessions.create as unknown as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+
+    expect(createCall.customer_email).toBe('user@test.com');
+    expect(createCall.customer).toBeUndefined();
+  });
+
+  it('returns SERVICE_UNAVAILABLE when checkout session has no URL', async () => {
+    mockAuth();
+
+    const selectCallCount = { count: 0 };
+    const chain = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockImplementation(() => {
+        selectCallCount.count++;
+        if (selectCallCount.count === 1) {
+          return [{ id: 'tier-pro', name: 'pro', stripePriceIdMonthly: 'price_test_pro', stripePriceIdYearly: null }];
+        }
+        return [{ stripeCustomerId: null }];
+      }),
+    };
+    (db.select as unknown as ReturnType<typeof vi.fn>).mockReturnValue(chain);
+
+    (mockStripe.checkout.sessions.create as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      url: null,
+    });
+
+    const { createCheckoutSession } = await import('./billing');
+    const result = await createCheckoutSession('pro');
+
+    expect(result.error?.code).toBe('SERVICE_UNAVAILABLE');
+  });
+});
+
+describe('createPortalSession', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns UNAUTHORIZED when user is not authenticated', async () => {
+    mockAuth(null, { message: 'Not logged in' });
+
+    const { createPortalSession } = await import('./billing');
+    const result = await createPortalSession();
+
+    expect(result.error?.code).toBe('UNAUTHORIZED');
+  });
+
+  it('returns NOT_FOUND when user has no stripe customer', async () => {
+    mockAuth();
+    mockDbChain([{ stripeCustomerId: null }]);
+
+    const { createPortalSession } = await import('./billing');
+    const result = await createPortalSession();
+
+    expect(result.error?.code).toBe('NOT_FOUND');
+    expect(result.error?.message).toBe('No billing account found. Please subscribe first.');
+  });
+
+  it('returns NOT_FOUND when no subscription row exists', async () => {
+    mockAuth();
+    mockDbChain([]);
+
+    const { createPortalSession } = await import('./billing');
+    const result = await createPortalSession();
+
+    expect(result.error?.code).toBe('NOT_FOUND');
+  });
+
+  it('creates portal session successfully', async () => {
+    mockAuth();
+    mockDbChain([{ stripeCustomerId: 'cus_test_123' }]);
+
+    (mockStripe.billingPortal.sessions.create as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      url: 'https://billing.stripe.com/portal/test',
+    });
+
+    const { createPortalSession } = await import('./billing');
+    const result = await createPortalSession();
+
+    expect(result.data?.portalUrl).toBe('https://billing.stripe.com/portal/test');
+    expect(result.error).toBeNull();
+
+    const createCall = (mockStripe.billingPortal.sessions.create as unknown as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+
+    expect(createCall.customer).toBe('cus_test_123');
+  });
+});

--- a/src/libs/actions/billing.ts
+++ b/src/libs/actions/billing.ts
@@ -1,0 +1,156 @@
+'use server';
+
+import * as Sentry from '@sentry/nextjs';
+import { eq } from 'drizzle-orm';
+import Stripe from 'stripe';
+
+import { withActionAuth } from '@/libs/api/withActionAuth';
+import { db } from '@/libs/DB';
+import { logger } from '@/libs/Logger';
+import { getStripe } from '@/libs/stripe/client';
+import type { BillingInterval } from '@/models/Schema';
+import { subscriptionTiers, userSubscriptions } from '@/models/Schema';
+import { getBaseUrl } from '@/utils/Helpers';
+
+import type { ActionResult } from './types';
+
+// Where Stripe redirects the user back to after checkout / the billing portal.
+// A product repoints this to its own billing page (it's the only product-route
+// coupling in this file).
+const BILLING_RETURN_PATH = '/subscriptions';
+
+type CheckoutOptions = {
+  /** Default 'monthly'. Determines which Stripe price ID is used. */
+  interval?: BillingInterval;
+};
+
+function priceIdForInterval(
+  tier: { stripePriceIdMonthly: string | null; stripePriceIdYearly: string | null },
+  interval: BillingInterval,
+): string | null {
+  return interval === 'yearly' ? tier.stripePriceIdYearly : tier.stripePriceIdMonthly;
+}
+
+const createCheckoutSessionInner = withActionAuth(async (
+  { user },
+  input: { tierName: string; options: CheckoutOptions },
+): Promise<ActionResult<{ checkoutUrl: string }>> => {
+  const { tierName, options } = input;
+  const interval = options.interval ?? 'monthly';
+
+  try {
+    const [tier] = await db
+      .select()
+      .from(subscriptionTiers)
+      .where(eq(subscriptionTiers.name, tierName))
+      .limit(1);
+
+    if (!tier) {
+      return { data: null, error: { message: 'This tier is not available for purchase', code: 'FORBIDDEN' } };
+    }
+
+    if (!tier.stripePriceIdMonthly && !tier.stripePriceIdYearly) {
+      return { data: null, error: { message: 'This tier is not available for purchase', code: 'FORBIDDEN' } };
+    }
+
+    const priceId = priceIdForInterval(tier, interval);
+    if (!priceId) {
+      return { data: null, error: { message: 'This billing interval is not available for this tier', code: 'FORBIDDEN' } };
+    }
+
+    const [sub] = await db
+      .select({ stripeCustomerId: userSubscriptions.stripeCustomerId })
+      .from(userSubscriptions)
+      .where(eq(userSubscriptions.userId, user.id))
+      .limit(1);
+
+    const appUrl = getBaseUrl();
+
+    const session = await getStripe().checkout.sessions.create({
+      mode: 'subscription',
+      line_items: [{ price: priceId, quantity: 1 }],
+      ...(sub?.stripeCustomerId
+        ? { customer: sub.stripeCustomerId }
+        : { customer_email: user.email }),
+      metadata: { user_id: user.id, billing_interval: interval },
+      success_url: `${appUrl}${BILLING_RETURN_PATH}?checkout=success`,
+      cancel_url: `${appUrl}${BILLING_RETURN_PATH}`,
+    });
+
+    if (!session.url) {
+      logger.error('Stripe checkout session created but no URL returned');
+      return { data: null, error: { message: 'Failed to create checkout session', code: 'SERVICE_UNAVAILABLE' } };
+    }
+
+    return { data: { checkoutUrl: session.url }, error: null };
+  } catch (err) {
+    Sentry.captureException(err, {
+      contexts: { billing: { tierName, action: 'createCheckoutSession' } },
+    });
+    if (err instanceof Stripe.errors.StripeError) {
+      logger.error({ err }, 'Stripe API error in createCheckoutSession');
+      return { data: null, error: { message: 'Payment service error. Please try again.', code: 'SERVICE_UNAVAILABLE' } };
+    }
+    logger.error({ err }, 'Unexpected error in createCheckoutSession');
+    return { data: null, error: { message: 'Failed to create checkout session', code: 'INTERNAL_ERROR' } };
+  }
+});
+
+export async function createCheckoutSession(
+  tierName: string,
+  options: CheckoutOptions = {},
+): Promise<ActionResult<{ checkoutUrl: string }>> {
+  return createCheckoutSessionInner({ tierName, options });
+}
+
+const createPortalSessionInner = withActionAuth(async (
+  { user },
+  options: { intent?: 'reactivate' | 'manage' },
+): Promise<ActionResult<{ portalUrl: string }>> => {
+  try {
+    const [sub] = await db
+      .select({ stripeCustomerId: userSubscriptions.stripeCustomerId })
+      .from(userSubscriptions)
+      .where(eq(userSubscriptions.userId, user.id))
+      .limit(1);
+
+    if (!sub?.stripeCustomerId) {
+      return { data: null, error: { message: 'No billing account found. Please subscribe first.', code: 'NOT_FOUND' } };
+    }
+
+    const appUrl = getBaseUrl();
+
+    // Tag the return URL with the portal intent so the UI can show the right
+    // toast when the user returns. Validates against a fixed allow-list.
+    const validIntents = ['reactivate', 'manage'] as const;
+    const intent = validIntents.includes(options.intent as typeof validIntents[number])
+      ? options.intent
+      : undefined;
+    const returnUrl = intent
+      ? `${appUrl}${BILLING_RETURN_PATH}?portal=${intent}`
+      : `${appUrl}${BILLING_RETURN_PATH}`;
+
+    const portalSession = await getStripe().billingPortal.sessions.create({
+      customer: sub.stripeCustomerId,
+      return_url: returnUrl,
+    });
+
+    return { data: { portalUrl: portalSession.url }, error: null };
+  } catch (err) {
+    Sentry.captureException(err, {
+      contexts: { billing: { action: 'createPortalSession' } },
+    });
+    if (err instanceof Stripe.errors.StripeError) {
+      logger.error({ err }, 'Stripe API error in createPortalSession');
+      return { data: null, error: { message: 'Payment service error. Please try again.', code: 'SERVICE_UNAVAILABLE' } };
+    }
+    logger.error({ err }, 'Unexpected error in createPortalSession');
+    return { data: null, error: { message: 'Failed to create billing portal session', code: 'INTERNAL_ERROR' } };
+  }
+});
+
+export async function createPortalSession(
+  options: { intent?: 'reactivate' | 'manage' } = {},
+): Promise<ActionResult<{ portalUrl: string }>> {
+  return createPortalSessionInner(options);
+}

--- a/src/libs/analytics/events.ts
+++ b/src/libs/analytics/events.ts
@@ -10,6 +10,7 @@ export enum EventCategory {
   Auth = 'auth',
   Onboarding = 'onboarding',
   Feature = 'feature',
+  Subscription = 'subscription',
   Error = 'error',
   Page = 'page',
 }
@@ -35,6 +36,11 @@ export type EventName
     | 'feature_first_use'
     | 'user_activated'
     | 'platform_connected'
+  // Subscription events
+    | 'subscription_converted'
+    | 'subscription_cancelled'
+    | 'trial_expired'
+    | 'quota_limit_reached'
   // Error events
     | 'error_occurred'
   // Page events
@@ -92,6 +98,43 @@ export type ProfileUpdatedProperties = {
  */
 export type FeatureFirstUseProperties = {
   feature_name: string;
+};
+
+/**
+ * Properties for subscription_converted event
+ * Fired when a user starts a paid subscription (direct checkout or trial upgrade).
+ */
+export type SubscriptionConvertedProperties = {
+  billing_interval: 'monthly' | 'yearly';
+  tier_name: string;
+  conversion_source: 'checkout' | 'trial_upgrade';
+};
+
+/**
+ * Properties for subscription_cancelled event
+ * Fired when a paid subscription ends and the user is downgraded.
+ */
+export type SubscriptionCancelledProperties = {
+  tier_name: string;
+  billing_interval?: 'monthly' | 'yearly';
+};
+
+/**
+ * Properties for trial_expired event
+ * Fired when a reverse-trial is demoted to free — by the daily cron or lazily
+ * on the next quota read.
+ */
+export type TrialExpiredProperties = {
+  trigger_source: 'cron' | 'lazy_quota_check';
+};
+
+/**
+ * Properties for quota_limit_reached event
+ * Fired when a user exhausts every pool for a resource type in the current period.
+ */
+export type QuotaLimitReachedProperties = {
+  resource_type: string;
+  tier_name: string;
 };
 
 /**
@@ -183,6 +226,10 @@ export type EventPropertiesMap = {
   feature_first_use: FeatureFirstUseProperties;
   user_activated: UserActivatedProperties;
   platform_connected: PlatformConnectedProperties;
+  subscription_converted: SubscriptionConvertedProperties;
+  subscription_cancelled: SubscriptionCancelledProperties;
+  trial_expired: TrialExpiredProperties;
+  quota_limit_reached: QuotaLimitReachedProperties;
   error_occurred: ErrorOccurredProperties;
   page_viewed: PageViewedProperties;
   landing_viewed: LandingViewedProperties;
@@ -208,6 +255,10 @@ export const EVENT_CATEGORIES: Record<EventName, EventCategory> = {
   feature_first_use: EventCategory.Feature,
   user_activated: EventCategory.Feature,
   platform_connected: EventCategory.Feature,
+  subscription_converted: EventCategory.Subscription,
+  subscription_cancelled: EventCategory.Subscription,
+  trial_expired: EventCategory.Subscription,
+  quota_limit_reached: EventCategory.Subscription,
   error_occurred: EventCategory.Error,
   page_viewed: EventCategory.Page,
   landing_viewed: EventCategory.Page,

--- a/src/libs/email/sendSubscriptionEmails.tsx
+++ b/src/libs/email/sendSubscriptionEmails.tsx
@@ -1,0 +1,176 @@
+import { render } from '@react-email/render';
+
+import { getBaseUrl } from '@/utils/Helpers';
+
+import { getLifecycleFromAddress } from './config';
+import { sendEmail } from './sendEmail';
+import { sendEmailAsync } from './sendEmailAsync';
+import { ExpiryReminderEmail } from './templates/ExpiryReminderEmail';
+import { PromotionGrantedEmail } from './templates/PromotionGrantedEmail';
+import { SubscriptionEndedEmail } from './templates/SubscriptionEndedEmail';
+import { SubscriptionStartedEmail } from './templates/SubscriptionStartedEmail';
+import type { ExpiryDaysRemaining, ExpiryReminderKind } from './types';
+
+// Subscription emails are lifecycle/nurture — use the human-named lifecycle
+// sender persona (same as the welcome email). All product/brand copy lives in
+// template props: appName comes from EMAIL_FROM_NAME, tierName from the caller.
+function appName(): string {
+  return process.env.EMAIL_FROM_NAME || 'VT SaaS Template';
+}
+
+function subjectForExpiry(
+  kind: ExpiryReminderKind,
+  daysRemaining: ExpiryDaysRemaining,
+): string {
+  const noun = kind === 'trial' ? 'trial' : 'promotion';
+  if (daysRemaining === -1) {
+    return `Your ${noun} has ended`;
+  }
+  if (daysRemaining === 0) {
+    return `Your ${noun} ends today`;
+  }
+  return `Your ${noun} ends in 3 days`;
+}
+
+/**
+ * Send a T-3, day-of, or T+1 expiry email for either a trial or promotion.
+ * Fire-and-forget — failures are logged but do not block the caller.
+ */
+export function sendExpiryReminderEmail(args: {
+  email: string;
+  name?: string;
+  tierName: string;
+  kind: ExpiryReminderKind;
+  daysRemaining: ExpiryDaysRemaining;
+}): void {
+  const { email, name, tierName, kind, daysRemaining } = args;
+  const appUrl = getBaseUrl();
+  const template = (
+    <ExpiryReminderEmail
+      recipientEmail={email}
+      recipientName={name}
+      appName={appName()}
+      appUrl={appUrl}
+      tierName={tierName}
+      kind={kind}
+      daysRemaining={daysRemaining}
+    />
+  );
+
+  sendEmailAsync(
+    async () => {
+      const text = await render(template, { plainText: true });
+      return sendEmail(email, subjectForExpiry(kind, daysRemaining), template, {
+        from: getLifecycleFromAddress(),
+        text,
+        tags: [
+          { name: 'type', value: 'expiry_reminder' },
+          { name: 'kind', value: kind },
+          { name: 'days_remaining', value: String(daysRemaining) },
+        ],
+        emailType: 'expiry_reminder',
+      });
+    },
+    { emailType: 'expiry_reminder', recipientHint: email },
+  );
+}
+
+export function sendSubscriptionStartedEmail(args: {
+  email: string;
+  name?: string;
+  tierName: string;
+  billingInterval: 'monthly' | 'yearly';
+}): void {
+  const { email, name, tierName, billingInterval } = args;
+  const appUrl = getBaseUrl();
+  const template = (
+    <SubscriptionStartedEmail
+      recipientEmail={email}
+      recipientName={name}
+      appName={appName()}
+      appUrl={appUrl}
+      tierName={tierName}
+      billingInterval={billingInterval}
+    />
+  );
+
+  sendEmailAsync(
+    async () => {
+      const text = await render(template, { plainText: true });
+      return sendEmail(email, `You're on ${tierName}`, template, {
+        from: getLifecycleFromAddress(),
+        text,
+        tags: [
+          { name: 'type', value: 'subscription_started' },
+          { name: 'billing_interval', value: billingInterval },
+        ],
+        emailType: 'subscription_started',
+      });
+    },
+    { emailType: 'subscription_started', recipientHint: email },
+  );
+}
+
+export function sendSubscriptionEndedEmail(args: {
+  email: string;
+  name?: string;
+  tierName: string;
+}): void {
+  const { email, name, tierName } = args;
+  const appUrl = getBaseUrl();
+  const template = (
+    <SubscriptionEndedEmail
+      recipientEmail={email}
+      recipientName={name}
+      appName={appName()}
+      appUrl={appUrl}
+      tierName={tierName}
+    />
+  );
+
+  sendEmailAsync(
+    async () => {
+      const text = await render(template, { plainText: true });
+      return sendEmail(email, `Your ${tierName} subscription has ended`, template, {
+        from: getLifecycleFromAddress(),
+        text,
+        tags: [{ name: 'type', value: 'subscription_ended' }],
+        emailType: 'subscription_ended',
+      });
+    },
+    { emailType: 'subscription_ended', recipientHint: email },
+  );
+}
+
+export function sendPromotionGrantedEmail(args: {
+  email: string;
+  name?: string;
+  tierName: string;
+  expiresAt: string;
+}): void {
+  const { email, name, tierName, expiresAt } = args;
+  const appUrl = getBaseUrl();
+  const template = (
+    <PromotionGrantedEmail
+      recipientEmail={email}
+      recipientName={name}
+      appName={appName()}
+      appUrl={appUrl}
+      tierName={tierName}
+      expiresAt={expiresAt}
+    />
+  );
+
+  sendEmailAsync(
+    async () => {
+      const text = await render(template, { plainText: true });
+      return sendEmail(email, `You've been granted ${tierName} access`, template, {
+        from: getLifecycleFromAddress(),
+        text,
+        tags: [{ name: 'type', value: 'promotion_granted' }],
+        emailType: 'promotion_granted',
+      });
+    },
+    { emailType: 'promotion_granted', recipientHint: email },
+  );
+}

--- a/src/libs/email/templates/ExpiryReminderEmail.tsx
+++ b/src/libs/email/templates/ExpiryReminderEmail.tsx
@@ -1,0 +1,78 @@
+import type { ExpiryDaysRemaining, ExpiryReminderEmailData, ExpiryReminderKind } from '../types';
+import {
+  EmailButton,
+  EmailHeading,
+  EmailLayout,
+  EmailText,
+} from './EmailLayout';
+import { safeGreeting } from './helpers';
+
+export type { ExpiryDaysRemaining, ExpiryReminderKind } from '../types';
+
+type ExpiryReminderEmailProps = ExpiryReminderEmailData;
+
+function copy(
+  kind: ExpiryReminderKind,
+  daysRemaining: ExpiryDaysRemaining,
+  tierName: string,
+) {
+  const noun = kind === 'trial' ? 'trial' : 'promotion';
+
+  if (daysRemaining === -1) {
+    return {
+      preview: `You're back on the free tier — resubscribe to keep ${tierName} access`,
+      heading: `Your ${noun} has ended`,
+      body: `Your ${noun} has ended and your account is now on the free tier. Subscribe to ${tierName} to pick up where you left off.`,
+      cta: `Subscribe to ${tierName}`,
+    };
+  }
+
+  if (daysRemaining === 0) {
+    return {
+      preview: `Last chance to keep ${tierName} without interruption`,
+      heading: `Your ${noun} ends today`,
+      body: `Today is the last day of your ${noun}. Subscribe to ${tierName} now to keep full access without interruption.`,
+      cta: `Subscribe to ${tierName}`,
+    };
+  }
+
+  // T-3
+  return {
+    preview: `Subscribe before then to keep ${tierName} access`,
+    heading: `Your ${noun} ends in 3 days`,
+    body: `Your ${noun} ends in 3 days. Subscribe to ${tierName} before then to keep full access without a gap. After that your account moves to the free tier.`,
+    cta: `Subscribe to ${tierName}`,
+  };
+}
+
+export function ExpiryReminderEmail(props: ExpiryReminderEmailProps) {
+  const { recipientName, appUrl, appName, tierName, kind, daysRemaining } = props;
+  const c = copy(kind, daysRemaining, tierName);
+  const subscribeUrl = `${appUrl}/subscriptions`;
+
+  return (
+    <EmailLayout
+      previewText={c.preview}
+      appUrl={appUrl}
+      brandName={appName}
+      includePreferencesLink
+    >
+      <EmailHeading>{c.heading}</EmailHeading>
+      <EmailText>{safeGreeting(recipientName)}</EmailText>
+      <EmailText>{c.body}</EmailText>
+      <EmailButton href={subscribeUrl}>{c.cta}</EmailButton>
+    </EmailLayout>
+  );
+}
+
+ExpiryReminderEmail.PreviewProps = {
+  recipientEmail: 'preview@example.com',
+  recipientName: 'Alex',
+  appName: 'VT SaaS Template',
+  appUrl: 'https://example.com',
+  tierName: 'Pro',
+  kind: 'trial',
+  daysRemaining: 3,
+} satisfies ExpiryReminderEmailProps;
+
+export default ExpiryReminderEmail;

--- a/src/libs/email/templates/PromotionGrantedEmail.tsx
+++ b/src/libs/email/templates/PromotionGrantedEmail.tsx
@@ -1,0 +1,80 @@
+import type { PromotionGrantedEmailData } from '../types';
+import {
+  EmailButton,
+  EmailHeading,
+  EmailLayout,
+  EmailMutedText,
+  EmailText,
+} from './EmailLayout';
+import { safeGreeting } from './helpers';
+
+type PromotionGrantedEmailProps = PromotionGrantedEmailData;
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+export function PromotionGrantedEmail({
+  recipientName,
+  appUrl,
+  appName,
+  tierName,
+  expiresAt,
+}: PromotionGrantedEmailProps) {
+  const dashboardUrl = `${appUrl}/dashboard`;
+
+  return (
+    <EmailLayout
+      previewText={`You've been granted ${tierName} access`}
+      appUrl={appUrl}
+      brandName={appName}
+      includePreferencesLink
+    >
+      <EmailHeading>
+        You've been granted
+        {' '}
+        {tierName}
+        {' '}
+        access
+      </EmailHeading>
+      <EmailText>{safeGreeting(recipientName)}</EmailText>
+      <EmailText>
+        Your account now has full
+        {' '}
+        {tierName}
+        {' '}
+        access through
+        {' '}
+        <strong>{formatDate(expiresAt)}</strong>
+        .
+      </EmailText>
+      <EmailText>
+        After that, your account will move to the free tier. We'll send a
+        reminder 3 days before so it doesn't catch you off guard.
+      </EmailText>
+      <EmailButton href={dashboardUrl}>
+        Open
+        {' '}
+        {appName}
+      </EmailButton>
+      <EmailMutedText>
+        If you have any questions, reply to this email.
+      </EmailMutedText>
+    </EmailLayout>
+  );
+}
+
+PromotionGrantedEmail.PreviewProps = {
+  recipientEmail: 'preview@example.com',
+  recipientName: 'Alex',
+  appName: 'VT SaaS Template',
+  appUrl: 'https://example.com',
+  tierName: 'Pro',
+  expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+} satisfies PromotionGrantedEmailProps;
+
+export default PromotionGrantedEmail;

--- a/src/libs/email/templates/SubscriptionEndedEmail.tsx
+++ b/src/libs/email/templates/SubscriptionEndedEmail.tsx
@@ -1,0 +1,59 @@
+import type { SubscriptionEndedEmailData } from '../types';
+import {
+  EmailButton,
+  EmailHeading,
+  EmailLayout,
+  EmailText,
+} from './EmailLayout';
+import { safeGreeting } from './helpers';
+
+type SubscriptionEndedEmailProps = SubscriptionEndedEmailData;
+
+export function SubscriptionEndedEmail({
+  recipientName,
+  appUrl,
+  appName,
+  tierName,
+}: SubscriptionEndedEmailProps) {
+  const subscribeUrl = `${appUrl}/subscriptions`;
+
+  return (
+    <EmailLayout
+      previewText={`Your ${tierName} subscription has ended — resubscribe anytime`}
+      appUrl={appUrl}
+      brandName={appName}
+      includePreferencesLink
+    >
+      <EmailHeading>
+        Your
+        {' '}
+        {tierName}
+        {' '}
+        subscription has ended
+      </EmailHeading>
+      <EmailText>{safeGreeting(recipientName)}</EmailText>
+      <EmailText>
+        Your
+        {' '}
+        {tierName}
+        {' '}
+        subscription has ended and your account is now on the free tier.
+      </EmailText>
+      <EmailText>
+        If this was unintentional, you can resume any time — your data is still
+        here.
+      </EmailText>
+      <EmailButton href={subscribeUrl}>Resubscribe</EmailButton>
+    </EmailLayout>
+  );
+}
+
+SubscriptionEndedEmail.PreviewProps = {
+  recipientEmail: 'preview@example.com',
+  recipientName: 'Alex',
+  appName: 'VT SaaS Template',
+  appUrl: 'https://example.com',
+  tierName: 'Pro',
+} satisfies SubscriptionEndedEmailProps;
+
+export default SubscriptionEndedEmail;

--- a/src/libs/email/templates/SubscriptionStartedEmail.tsx
+++ b/src/libs/email/templates/SubscriptionStartedEmail.tsx
@@ -1,0 +1,67 @@
+import type { SubscriptionStartedEmailData } from '../types';
+import {
+  EmailButton,
+  EmailHeading,
+  EmailLayout,
+  EmailMutedText,
+  EmailText,
+} from './EmailLayout';
+import { safeGreeting } from './helpers';
+
+type SubscriptionStartedEmailProps = SubscriptionStartedEmailData;
+
+export function SubscriptionStartedEmail({
+  recipientName,
+  appUrl,
+  appName,
+  tierName,
+  billingInterval,
+}: SubscriptionStartedEmailProps) {
+  const dashboardUrl = `${appUrl}/dashboard`;
+  const intervalLabel = billingInterval === 'yearly' ? 'yearly' : 'monthly';
+
+  return (
+    <EmailLayout
+      previewText={`Your ${tierName} subscription is now active`}
+      appUrl={appUrl}
+      brandName={appName}
+      includePreferencesLink
+    >
+      <EmailHeading>
+        You're on
+        {' '}
+        {tierName}
+      </EmailHeading>
+      <EmailText>{safeGreeting(recipientName)}</EmailText>
+      <EmailText>
+        Your
+        {' '}
+        {intervalLabel}
+        {' '}
+        {tierName}
+        {' '}
+        subscription is active. You now have full access.
+      </EmailText>
+      <EmailButton href={dashboardUrl}>
+        Open
+        {' '}
+        {appName}
+      </EmailButton>
+      <EmailMutedText>
+        Stripe will email you a separate receipt. You can manage billing or
+        cancel anytime from the subscriptions page.
+      </EmailMutedText>
+    </EmailLayout>
+  );
+}
+
+SubscriptionStartedEmail.PreviewProps = {
+  recipientEmail: 'preview@example.com',
+  recipientName: 'Alex',
+  appName: 'VT SaaS Template',
+  appUrl: 'https://example.com',
+  tierName: 'Pro',
+  billingInterval: 'monthly',
+} satisfies SubscriptionStartedEmailProps;
+
+export default SubscriptionStartedEmail;

--- a/src/libs/email/templates/subscription-emails.test.tsx
+++ b/src/libs/email/templates/subscription-emails.test.tsx
@@ -1,0 +1,82 @@
+/* eslint-disable testing-library/render-result-naming-convention -- uses @react-email/render, not @testing-library */
+import { render } from '@react-email/render';
+import { describe, expect, it } from 'vitest';
+
+import { ExpiryReminderEmail } from './ExpiryReminderEmail';
+import { PromotionGrantedEmail } from './PromotionGrantedEmail';
+import { SubscriptionEndedEmail } from './SubscriptionEndedEmail';
+import { SubscriptionStartedEmail } from './SubscriptionStartedEmail';
+
+// Render to plain text so JSX whitespace expressions ({' '}) collapse into real
+// spaces. The plain-text renderer uppercases headings, so heading assertions are
+// case-insensitive. These templates carry no hardcoded product copy — all brand
+// strings (appName, tierName) come from props.
+
+describe('Subscription lifecycle email templates', () => {
+  it('SubscriptionStartedEmail renders tier name and app name from props', async () => {
+    const text = await render(
+      <SubscriptionStartedEmail {...SubscriptionStartedEmail.PreviewProps} />,
+      { plainText: true },
+    );
+
+    expect(text).toMatch(/You're on Pro/i);
+    expect(text).toContain('VT SaaS Template');
+    expect(text).toContain('monthly');
+  });
+
+  it('SubscriptionEndedEmail renders the tier name and a resubscribe CTA', async () => {
+    const text = await render(
+      <SubscriptionEndedEmail {...SubscriptionEndedEmail.PreviewProps} />,
+      { plainText: true },
+    );
+
+    expect(text).toMatch(/Your Pro subscription has ended/i);
+    expect(text).toMatch(/Resubscribe/i);
+  });
+
+  it('PromotionGrantedEmail renders the tier name and expiry date', async () => {
+    const text = await render(
+      <PromotionGrantedEmail {...PromotionGrantedEmail.PreviewProps} />,
+      { plainText: true },
+    );
+
+    expect(text).toMatch(/granted Pro access/i);
+  });
+
+  it('ExpiryReminderEmail (T-3) renders the 3-day countdown', async () => {
+    const text = await render(
+      <ExpiryReminderEmail {...ExpiryReminderEmail.PreviewProps} daysRemaining={3} />,
+      { plainText: true },
+    );
+
+    expect(text).toMatch(/ends in 3 days/i);
+    expect(text).toMatch(/Subscribe to Pro/i);
+  });
+
+  it('ExpiryReminderEmail (day-of) renders the today copy', async () => {
+    const text = await render(
+      <ExpiryReminderEmail {...ExpiryReminderEmail.PreviewProps} daysRemaining={0} />,
+      { plainText: true },
+    );
+
+    expect(text).toMatch(/ends today/i);
+  });
+
+  it('ExpiryReminderEmail (T+1) renders the already-ended copy', async () => {
+    const text = await render(
+      <ExpiryReminderEmail {...ExpiryReminderEmail.PreviewProps} daysRemaining={-1} />,
+      { plainText: true },
+    );
+
+    expect(text).toMatch(/has ended/i);
+  });
+
+  it('ExpiryReminderEmail renders promotion copy when kind is promotion', async () => {
+    const text = await render(
+      <ExpiryReminderEmail {...ExpiryReminderEmail.PreviewProps} kind="promotion" daysRemaining={3} />,
+      { plainText: true },
+    );
+
+    expect(text).toMatch(/promotion ends in 3 days/i);
+  });
+});

--- a/src/libs/email/types.ts
+++ b/src/libs/email/types.ts
@@ -77,3 +77,48 @@ export type WelcomeEmailData = BaseTemplateData & {
   appUrl: string;
   appName: string;
 };
+
+/**
+ * Subscription-lifecycle email template data. All product copy lives in props
+ * (`appName`, `tierName`, `billingInterval`, …) so these templates carry no
+ * brand or feature copy — a fork passes its own.
+ */
+
+/**
+ * 3  = T-3 reminder (3 days remaining)
+ * 0  = day-of expiry (last day of access)
+ * -1 = T+1 follow-up (the day after expiry)
+ */
+export type ExpiryDaysRemaining = 3 | 0 | -1;
+
+export type ExpiryReminderKind = 'trial' | 'promotion';
+
+export type ExpiryReminderEmailData = BaseTemplateData & {
+  appUrl: string;
+  appName: string;
+  /** Paid tier the user can upgrade to (e.g. 'Pro'). */
+  tierName: string;
+  kind: ExpiryReminderKind;
+  daysRemaining: ExpiryDaysRemaining;
+};
+
+export type SubscriptionStartedEmailData = BaseTemplateData & {
+  appUrl: string;
+  appName: string;
+  tierName: string;
+  billingInterval: 'monthly' | 'yearly';
+};
+
+export type SubscriptionEndedEmailData = BaseTemplateData & {
+  appUrl: string;
+  appName: string;
+  tierName: string;
+};
+
+export type PromotionGrantedEmailData = BaseTemplateData & {
+  appUrl: string;
+  appName: string;
+  tierName: string;
+  /** ISO date string for when the promotional access ends. */
+  expiresAt: string;
+};

--- a/src/libs/hooks/use-subscription-usage.ts
+++ b/src/libs/hooks/use-subscription-usage.ts
@@ -1,0 +1,33 @@
+'use client';
+
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+
+import {
+  fetchSubscriptionUsage,
+  subscriptionUsageQueryKey,
+} from '@/libs/queries/subscription-usage';
+
+export type { SubscriptionUsageResponse } from '@/libs/queries/subscription-usage';
+
+/**
+ * Reads the current user's subscription + tier + quota + usage. Powers the
+ * expiry banner, trial pill, and plan cards. Reuses the same query key as the
+ * fetch function so any invalidation (e.g. after Stripe checkout returns) is
+ * typo-proof.
+ */
+export function useSubscriptionUsage() {
+  return useQuery({
+    queryKey: subscriptionUsageQueryKey,
+    queryFn: fetchSubscriptionUsage,
+  });
+}
+
+/**
+ * Returns a callback that invalidates the subscription-usage cache — call it
+ * after a billing action (checkout success, portal return) so the UI re-reads
+ * the freshest plan state.
+ */
+export function useInvalidateSubscriptionUsage() {
+  const queryClient = useQueryClient();
+  return () => queryClient.invalidateQueries({ queryKey: subscriptionUsageQueryKey });
+}

--- a/src/libs/inngest/functions/force-expire-trials-and-promotions.ts
+++ b/src/libs/inngest/functions/force-expire-trials-and-promotions.ts
@@ -1,0 +1,150 @@
+import { and, eq, isNotNull, lt } from 'drizzle-orm';
+
+import { trackEventServer } from '@/libs/analytics/server';
+import { db } from '@/libs/DB';
+import { Env } from '@/libs/Env';
+import { blockScheduledTasksForUser } from '@/libs/jobs/blocking';
+import { invalidateQuotaCache } from '@/libs/subscriptions/quota';
+import { subscriptionTiers, tierQuotas, userSubscriptions } from '@/models/Schema';
+
+import { inngest } from '../client';
+
+type Logger = { info: (...args: unknown[]) => void; error: (...args: unknown[]) => void };
+
+/**
+ * Invalidates every cached quota state for a user — iterates the resource types
+ * defined across all tiers (the cache is keyed by user+resourceType).
+ */
+async function invalidateAllQuotaCaches(userId: string): Promise<void> {
+  const rows = await db
+    .selectDistinct({ resourceType: tierQuotas.resourceType })
+    .from(tierQuotas);
+  for (const { resourceType } of rows) {
+    invalidateQuotaCache(userId, resourceType);
+  }
+}
+
+async function transitionToFree(
+  userId: string,
+  freeTierId: string,
+  reason: string,
+): Promise<void> {
+  // Deliberately keep trial_expires_at / expires_at populated so the T+1 expiry
+  // email cron can still find these rows. The banner skips them because it gates
+  // on status='trial' or tier='promotion', which both flip below.
+  await db
+    .update(userSubscriptions)
+    .set({
+      status: 'expired',
+      tierId: freeTierId,
+      currentPeriodAnchorAt: new Date(),
+      updatedAt: new Date(),
+    })
+    .where(eq(userSubscriptions.userId, userId));
+
+  await blockScheduledTasksForUser(userId, reason);
+  await invalidateAllQuotaCaches(userId);
+}
+
+/**
+ * Cron body — extracted as a named export so tests can exercise it directly with
+ * a plain logger double (matches the template's scheduled-tasks.ts pattern).
+ *
+ * @internal
+ */
+export async function forceExpireTrialsAndPromotions(logger: Logger): Promise<{
+  expiredTrials: number;
+  expiredPromotions: number;
+}> {
+  const now = new Date();
+
+  // Resolve free + promotion tier IDs once.
+  const tiers = await db
+    .select({ id: subscriptionTiers.id, name: subscriptionTiers.name })
+    .from(subscriptionTiers);
+
+  const freeTierId = tiers.find(t => t.name === 'free')?.id;
+  const promotionTierId = tiers.find(t => t.name === 'promotion')?.id;
+
+  if (!freeTierId) {
+    logger.error('force-expire: free tier not found in DB');
+    return { expiredTrials: 0, expiredPromotions: 0 };
+  }
+
+  // 1. Trials whose trial_expires_at has passed.
+  const expiredTrialRows = await db
+    .select({ userId: userSubscriptions.userId })
+    .from(userSubscriptions)
+    .where(
+      and(
+        eq(userSubscriptions.status, 'trial'),
+        isNotNull(userSubscriptions.trialExpiresAt),
+        lt(userSubscriptions.trialExpiresAt, now),
+      ),
+    );
+
+  let expiredTrials = 0;
+  for (const row of expiredTrialRows) {
+    try {
+      await transitionToFree(row.userId, freeTierId, 'trial_expired');
+      expiredTrials++;
+
+      trackEventServer(
+        'trial_expired',
+        { trigger_source: 'cron' },
+        row.userId,
+      ).catch(err => logger.error('trial_expired tracking failed', { userId: row.userId, err }));
+    } catch (err) {
+      logger.error('force-expire: trial transition failed', { userId: row.userId, err });
+    }
+  }
+
+  // 2. Promotions whose expires_at has passed.
+  let expiredPromotions = 0;
+  if (promotionTierId) {
+    const expiredPromotionRows = await db
+      .select({ userId: userSubscriptions.userId })
+      .from(userSubscriptions)
+      .where(
+        and(
+          eq(userSubscriptions.tierId, promotionTierId),
+          isNotNull(userSubscriptions.expiresAt),
+          lt(userSubscriptions.expiresAt, now),
+        ),
+      );
+
+    for (const row of expiredPromotionRows) {
+      try {
+        await transitionToFree(row.userId, freeTierId, 'promotion_expired');
+        expiredPromotions++;
+      } catch (err) {
+        logger.error('force-expire: promotion transition failed', { userId: row.userId, err });
+      }
+    }
+  }
+
+  logger.info('force-expire: done', { expiredTrials, expiredPromotions });
+  return { expiredTrials, expiredPromotions };
+}
+
+/**
+ * Daily cron: demotes expired trials + promotions to the free tier, blocks their
+ * pending scheduled tasks, and invalidates their quota caches.
+ *
+ * Gated by ENABLE_REVERSE_TRIAL — reverse-trial is opt-in, so this no-ops when
+ * the flag is off. Runs at 10:00 UTC, after the expiry-warning cron (09:00).
+ */
+export const forceExpireTrialsAndPromotionsFunction = inngest.createFunction(
+  {
+    id: 'force-expire-trials-and-promotions',
+    name: 'Force Expire Trials & Promotions',
+    triggers: [{ cron: '0 10 * * *' }],
+  },
+  async ({ logger }) => {
+    if (Env.ENABLE_REVERSE_TRIAL !== 'true') {
+      logger.info('force-expire: skipped (ENABLE_REVERSE_TRIAL is off)');
+      return { expiredTrials: 0, expiredPromotions: 0 };
+    }
+    return forceExpireTrialsAndPromotions(logger);
+  },
+);

--- a/src/libs/inngest/functions/trial-promotion-expiry-warnings.ts
+++ b/src/libs/inngest/functions/trial-promotion-expiry-warnings.ts
@@ -1,0 +1,255 @@
+import { and, eq, gte, isNotNull, lt } from 'drizzle-orm';
+
+import { db } from '@/libs/DB';
+import { sendExpiryReminderEmail } from '@/libs/email/sendSubscriptionEmails';
+import type { ExpiryDaysRemaining } from '@/libs/email/types';
+import { Env } from '@/libs/Env';
+import { logger } from '@/libs/Logger';
+import { createAdminClient } from '@/libs/supabase/admin';
+import { subscriptionTiers, userSubscriptions } from '@/models/Schema';
+
+import { inngest } from '../client';
+
+type CronLogger = { info: (...args: unknown[]) => void; error: (...args: unknown[]) => void };
+
+type WindowKind = 't_minus_3' | 'day_of' | 't_plus_1';
+
+function windowBounds(kind: WindowKind, now: Date): { start: Date; end: Date } {
+  const startOfDay = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  const dayMs = 24 * 60 * 60 * 1000;
+  if (kind === 't_minus_3') {
+    // expiry falls 3 days from today (UTC)
+    return {
+      start: new Date(startOfDay.getTime() + 3 * dayMs),
+      end: new Date(startOfDay.getTime() + 4 * dayMs),
+    };
+  }
+  if (kind === 't_plus_1') {
+    // expiry was yesterday — user has been demoted by the force-expire cron
+    return {
+      start: new Date(startOfDay.getTime() - dayMs),
+      end: startOfDay,
+    };
+  }
+  // day_of: expiry in [today, tomorrow)
+  return {
+    start: startOfDay,
+    end: new Date(startOfDay.getTime() + dayMs),
+  };
+}
+
+/**
+ * For T-3 / day-of we look at users still in the trial window (status='trial').
+ * For T+1 we look at users demoted yesterday (status='expired') — the
+ * force-expire cron flipped status but kept trial_expires_at populated.
+ */
+function trialStatusForWindow(kind: WindowKind): 'trial' | 'expired' {
+  return kind === 't_plus_1' ? 'expired' : 'trial';
+}
+
+async function fetchUserEmail(userId: string): Promise<{ email: string; name?: string } | null> {
+  try {
+    const admin = createAdminClient();
+    const { data, error } = await admin.auth.admin.getUserById(userId);
+    if (error || !data?.user?.email) {
+      return null;
+    }
+    const meta = data.user.user_metadata as Record<string, unknown> | undefined;
+    const name = typeof meta?.display_name === 'string'
+      ? meta.display_name
+      : typeof meta?.full_name === 'string'
+        ? meta.full_name
+        : undefined;
+    return { email: data.user.email, name };
+  } catch (err) {
+    logger.error({ err, userId }, 'expiry-warnings: failed to fetch user');
+    return null;
+  }
+}
+
+/** Display name of the paid tier users can upgrade to (for email copy). */
+async function getPaidTierName(): Promise<string> {
+  const [tier] = await db
+    .select({ displayName: subscriptionTiers.displayName, name: subscriptionTiers.name })
+    .from(subscriptionTiers)
+    .where(eq(subscriptionTiers.name, 'pro'))
+    .limit(1);
+  return tier?.displayName ?? tier?.name ?? 'Pro';
+}
+
+async function processTrials(
+  windowKind: WindowKind,
+  daysRemaining: ExpiryDaysRemaining,
+  now: Date,
+  tierName: string,
+): Promise<number> {
+  const { start, end } = windowBounds(windowKind, now);
+
+  const rows = await db
+    .select({
+      userId: userSubscriptions.userId,
+      lastSentAt: userSubscriptions.lastTrialWarningSentAt,
+    })
+    .from(userSubscriptions)
+    .where(
+      and(
+        eq(userSubscriptions.status, trialStatusForWindow(windowKind)),
+        isNotNull(userSubscriptions.trialExpiresAt),
+        gte(userSubscriptions.trialExpiresAt, start),
+        lt(userSubscriptions.trialExpiresAt, end),
+      ),
+    );
+
+  let sent = 0;
+  for (const row of rows) {
+    // Idempotency: skip if we've already sent a warning in the last 12h.
+    if (row.lastSentAt && row.lastSentAt > new Date(now.getTime() - 12 * 60 * 60 * 1000)) {
+      continue;
+    }
+    const userInfo = await fetchUserEmail(row.userId);
+    if (!userInfo) {
+      continue;
+    }
+    sendExpiryReminderEmail({
+      email: userInfo.email,
+      name: userInfo.name,
+      tierName,
+      kind: 'trial',
+      daysRemaining,
+    });
+    await db
+      .update(userSubscriptions)
+      .set({ lastTrialWarningSentAt: new Date(), updatedAt: new Date() })
+      .where(eq(userSubscriptions.userId, row.userId));
+    sent++;
+  }
+  return sent;
+}
+
+async function processPromotions(
+  windowKind: WindowKind,
+  daysRemaining: ExpiryDaysRemaining,
+  now: Date,
+  tierName: string,
+): Promise<number> {
+  const { start, end } = windowBounds(windowKind, now);
+
+  // Tier filter:
+  //   T-3 / day-of: user is still on the promotion tier (active)
+  //   T+1: force-expire cron has flipped tier to free; expires_at remains
+  //        populated so we can still find them. Match by free tier id +
+  //        status='expired' (paid cancellation uses status='cancelled' and nulls
+  //        expires_at, so there's no overlap).
+  const tierName2 = windowKind === 't_plus_1' ? 'free' : 'promotion';
+  const [tier] = await db
+    .select({ id: subscriptionTiers.id })
+    .from(subscriptionTiers)
+    .where(eq(subscriptionTiers.name, tierName2))
+    .limit(1);
+
+  if (!tier) {
+    return 0;
+  }
+
+  const tierFilter = windowKind === 't_plus_1'
+    ? and(
+        eq(userSubscriptions.tierId, tier.id),
+        eq(userSubscriptions.status, 'expired'),
+      )
+    : eq(userSubscriptions.tierId, tier.id);
+
+  const rows = await db
+    .select({
+      userId: userSubscriptions.userId,
+      lastSentAt: userSubscriptions.lastPromotionWarningSentAt,
+    })
+    .from(userSubscriptions)
+    .where(
+      and(
+        tierFilter,
+        isNotNull(userSubscriptions.expiresAt),
+        gte(userSubscriptions.expiresAt, start),
+        lt(userSubscriptions.expiresAt, end),
+      ),
+    );
+
+  let sent = 0;
+  for (const row of rows) {
+    if (row.lastSentAt && row.lastSentAt > new Date(now.getTime() - 12 * 60 * 60 * 1000)) {
+      continue;
+    }
+    const userInfo = await fetchUserEmail(row.userId);
+    if (!userInfo) {
+      continue;
+    }
+    sendExpiryReminderEmail({
+      email: userInfo.email,
+      name: userInfo.name,
+      tierName,
+      kind: 'promotion',
+      daysRemaining,
+    });
+    await db
+      .update(userSubscriptions)
+      .set({ lastPromotionWarningSentAt: new Date(), updatedAt: new Date() })
+      .where(eq(userSubscriptions.userId, row.userId));
+    sent++;
+  }
+  return sent;
+}
+
+/**
+ * Cron body — extracted as a named export so tests can exercise it directly.
+ *
+ * @internal
+ */
+export async function sendExpiryWarnings(cronLogger: CronLogger): Promise<{
+  trialsT3: number;
+  trialsDay0: number;
+  trialsT1: number;
+  promotionsT3: number;
+  promotionsDay0: number;
+  promotionsT1: number;
+}> {
+  const now = new Date();
+  const tierName = await getPaidTierName();
+  const trialsT3 = await processTrials('t_minus_3', 3, now, tierName);
+  const trialsDay0 = await processTrials('day_of', 0, now, tierName);
+  const trialsT1 = await processTrials('t_plus_1', -1, now, tierName);
+  const promotionsT3 = await processPromotions('t_minus_3', 3, now, tierName);
+  const promotionsDay0 = await processPromotions('day_of', 0, now, tierName);
+  const promotionsT1 = await processPromotions('t_plus_1', -1, now, tierName);
+
+  const result = { trialsT3, trialsDay0, trialsT1, promotionsT3, promotionsDay0, promotionsT1 };
+  cronLogger.info('expiry-warnings: done', result);
+  return result;
+}
+
+/**
+ * Daily cron: sends T-3 / day-of / T+1 expiry-warning emails for trials and
+ * promotions, with a 12h idempotency guard per user.
+ *
+ * Gated by ENABLE_REVERSE_TRIAL (opt-in). Runs at 09:00 UTC, BEFORE the
+ * force-expire cron (10:00) so the warning lands before the demotion.
+ */
+export const trialPromotionExpiryWarningsFunction = inngest.createFunction(
+  {
+    id: 'trial-promotion-expiry-warnings',
+    name: 'Trial & Promotion Expiry Warnings',
+    triggers: [{ cron: '0 9 * * *' }],
+  },
+  async ({ logger: cronLogger }) => {
+    if (Env.ENABLE_REVERSE_TRIAL !== 'true') {
+      cronLogger.info('expiry-warnings: skipped (ENABLE_REVERSE_TRIAL is off)');
+      return {
+        trialsT3: 0,
+        trialsDay0: 0,
+        trialsT1: 0,
+        promotionsT3: 0,
+        promotionsDay0: 0,
+        promotionsT1: 0,
+      };
+    }
+    return sendExpiryWarnings(cronLogger);
+  },
+);

--- a/src/libs/jobs/blocking.test.ts
+++ b/src/libs/jobs/blocking.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockReturning = vi.fn();
+const mockWhere = vi.fn(() => ({ returning: mockReturning }));
+const mockSet = vi.fn(() => ({ where: mockWhere }));
+const mockUpdate = vi.fn((_table: unknown) => ({ set: mockSet }));
+
+vi.mock('@/libs/DB', () => ({
+  db: { update: (table: unknown) => mockUpdate(table) },
+}));
+
+vi.mock('@/libs/Logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
+}));
+
+vi.mock('@/models/Schema', () => ({
+  scheduledTasks: { id: 'id', userId: 'user_id', status: 'status' },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn((...args: unknown[]) => args),
+  eq: vi.fn((...args: unknown[]) => args),
+}));
+
+const { scheduledTasks } = await import('@/models/Schema');
+const { blockScheduledTasksForUser } = await import('./blocking');
+
+describe('blockScheduledTasksForUser', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('marks scheduled tasks as blocked with the given reason', async () => {
+    mockReturning.mockResolvedValueOnce([
+      { id: 'task-1' },
+      { id: 'task-2' },
+    ]);
+
+    const count = await blockScheduledTasksForUser('user-123', 'trial_expired');
+
+    expect(count).toBe(2);
+    expect(mockUpdate).toHaveBeenCalledWith(scheduledTasks);
+    expect(mockSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'blocked',
+        blockedReason: 'trial_expired',
+      }),
+    );
+  });
+
+  it('returns 0 when there are no scheduled tasks', async () => {
+    mockReturning.mockResolvedValueOnce([]);
+
+    const count = await blockScheduledTasksForUser('user-123', 'subscription_cancelled');
+
+    expect(count).toBe(0);
+  });
+});

--- a/src/libs/jobs/blocking.ts
+++ b/src/libs/jobs/blocking.ts
@@ -1,0 +1,41 @@
+import { and, eq } from 'drizzle-orm';
+
+import { db } from '@/libs/DB';
+import { logger } from '@/libs/Logger';
+import { scheduledTasks } from '@/models/Schema';
+
+/**
+ * Transitions all of a user's currently-`scheduled` tasks to `blocked`.
+ *
+ * Called when a user is demoted (trial expiry, promotion expiry, paid
+ * cancellation) so their queued background tasks don't run without an active
+ * subscription. This is the documented use of the `scheduled_tasks.blocked`
+ * status (see `src/models/schema/scheduled-tasks.ts`). `reason` is free text —
+ * the `blocked_reason` column carries no subscription/product enum so this
+ * helper stays decoupled from any specific policy.
+ *
+ * Returns the number of rows affected.
+ */
+export async function blockScheduledTasksForUser(
+  userId: string,
+  reason: string,
+): Promise<number> {
+  const updated = await db
+    .update(scheduledTasks)
+    .set({
+      status: 'blocked',
+      blockedReason: reason,
+      updatedAt: new Date(),
+    })
+    .where(and(eq(scheduledTasks.userId, userId), eq(scheduledTasks.status, 'scheduled')))
+    .returning();
+
+  if (updated.length > 0) {
+    logger.info(
+      { userId, reason, count: updated.length },
+      'blockScheduledTasksForUser: blocked scheduled tasks',
+    );
+  }
+
+  return updated.length;
+}

--- a/src/libs/queries/keys.ts
+++ b/src/libs/queries/keys.ts
@@ -23,4 +23,8 @@ export const queryKeys = {
     /** Single record. See `useItem`. */
     detail: (id: string) => ['item', id] as const,
   },
+  subscription: {
+    /** Current user's subscription + tier + quota + usage. See `useSubscriptionUsage`. */
+    usage: ['subscription', 'usage'] as const,
+  },
 } as const;

--- a/src/libs/queries/subscription-usage.ts
+++ b/src/libs/queries/subscription-usage.ts
@@ -1,0 +1,23 @@
+import { queryKeys } from '@/libs/queries/keys';
+import type { SubscriptionUsageResponse } from '@/libs/subscriptions/get-subscription-usage';
+
+/**
+ * Client fetch function for the subscription usage payload, paired with the
+ * `useSubscriptionUsage` hook (same key from the query-keys factory). The data
+ * itself is assembled server-side by `getSubscriptionUsage` (it reads via the
+ * Drizzle `db` client) and exposed over `GET /api/subscriptions/usage`.
+ */
+
+export type { SubscriptionUsageResponse } from '@/libs/subscriptions/get-subscription-usage';
+
+export const subscriptionUsageQueryKey = queryKeys.subscription.usage;
+
+export async function fetchSubscriptionUsage(): Promise<SubscriptionUsageResponse> {
+  const res = await fetch('/api/subscriptions/usage', {
+    headers: { Accept: 'application/json' },
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to load subscription usage (${res.status})`);
+  }
+  return res.json() as Promise<SubscriptionUsageResponse>;
+}

--- a/src/libs/stripe/client.ts
+++ b/src/libs/stripe/client.ts
@@ -1,0 +1,24 @@
+import Stripe from 'stripe';
+
+import { Env } from '@/libs/Env';
+
+// Lazy singleton — avoids a build-time crash when STRIPE_SECRET_KEY is unset
+// (e.g. CI, or a fork that hasn't enabled billing). Mirrors the cached-singleton
+// + Env pattern used by src/libs/supabase/admin.ts.
+let _stripe: Stripe | null = null;
+
+export function getStripe(): Stripe {
+  if (!_stripe) {
+    const key = Env.STRIPE_SECRET_KEY;
+    if (!key) {
+      throw new Error('STRIPE_SECRET_KEY is not configured');
+    }
+    _stripe = new Stripe(key, {
+      // Pinned to the API version this SDK ships with. Bump it (and re-test the
+      // webhook) when you upgrade the `stripe` package across a major API change.
+      apiVersion: '2026-05-27.dahlia',
+      typescript: true,
+    });
+  }
+  return _stripe;
+}

--- a/src/libs/subscriptions/get-subscription-usage.ts
+++ b/src/libs/subscriptions/get-subscription-usage.ts
@@ -1,0 +1,271 @@
+import { and, asc, eq, ne } from 'drizzle-orm';
+
+import { db } from '@/libs/DB';
+import { logger } from '@/libs/Logger';
+import { getCurrentPeriod, toDateString } from '@/libs/subscriptions/period';
+import { getUsageBatch } from '@/libs/subscriptions/usage';
+import { subscriptionTiers, tierQuotas, userSubscriptions } from '@/models/Schema';
+
+/** Per-(tier, resource) quota config — the two-pool shape from `tier_quotas`. */
+export type QuotaInfo = {
+  resourceType: string;
+  premiumUnitKey: string | null;
+  premiumPeriodLimit: number;
+  fallbackUnitKey: string;
+  fallbackPeriodLimit: number;
+  warningThresholdPct: number;
+};
+
+/** Units consumed this period for one resource type. */
+export type UsageInfo = {
+  premiumUnitsUsed: number;
+  fallbackUnitsUsed: number;
+};
+
+/** Quota config for a tier in the public catalogue (no usage). */
+export type TierQuotaInfo = {
+  resourceType: string;
+  premiumUnitKey: string | null;
+  premiumPeriodLimit: number;
+  fallbackUnitKey: string;
+  fallbackPeriodLimit: number;
+};
+
+export type SubscriptionUsageResponse = {
+  tier: {
+    id: string;
+    name: string;
+    displayName: string;
+    description: string | null;
+    priceCents: number | null;
+  };
+  subscription: {
+    status: 'active' | 'trial' | 'expired' | 'cancelled';
+    trialExpiresAt: string | null;
+    /**
+     * Tier-end date — used for promotion expiry AND for paid users who set
+     * cancel_at_period_end (they stay status='active' until this date, then get
+     * downgraded by the deletion webhook).
+     */
+    expiresAt: string | null;
+    hasTrialed: boolean;
+    billingInterval: 'monthly' | 'yearly' | null;
+  };
+  /**
+   * Per-resource quota + usage for the user's current tier, keyed by
+   * resource_type. Generic: whatever resource types the tier defines appear here
+   * (vs a fixed set of named quota fields).
+   */
+  resources: Record<string, { quota: QuotaInfo; usage: UsageInfo }>;
+  period: {
+    start: string;
+    end: string;
+  };
+  /** Public plan catalogue (active, non-promotion tiers) with their quota config. */
+  allTiers: Array<{
+    id: string;
+    name: string;
+    displayName: string;
+    description: string | null;
+    priceCents: number | null;
+    quotas: Record<string, TierQuotaInfo>;
+  }>;
+};
+
+/**
+ * Fetch the subscription + tier + quota + usage payload for a user. The single
+ * read powering every subscription UI surface.
+ *
+ * Returns null on a fatal data-integrity issue (the free tier is missing).
+ * Callers treat null as a 5xx-equivalent and surface a generic error.
+ */
+export async function getSubscriptionUsage(
+  userId: string,
+): Promise<SubscriptionUsageResponse | null> {
+  if (!db) {
+    logger.error('getSubscriptionUsage: db client not available');
+    return null;
+  }
+
+  // --- Round-trip level 1 ---------------------------------------------------
+  // The user's subscription (+tier) and the public plan catalogue are
+  // independent reads; fetch together. The catalogue also serves the free-tier
+  // fallback below (free is always an active, non-promotion tier).
+  const subQuery = db
+    .select({
+      tierId: userSubscriptions.tierId,
+      status: userSubscriptions.status,
+      trialExpiresAt: userSubscriptions.trialExpiresAt,
+      currentPeriodAnchorAt: userSubscriptions.currentPeriodAnchorAt,
+      startedAt: userSubscriptions.startedAt,
+      expiresAt: userSubscriptions.expiresAt,
+      hasTrialed: userSubscriptions.hasTrialed,
+      billingInterval: userSubscriptions.billingInterval,
+      tierName: subscriptionTiers.name,
+      tierDisplayName: subscriptionTiers.displayName,
+      tierDescription: subscriptionTiers.description,
+      tierPriceCents: subscriptionTiers.priceCents,
+    })
+    .from(userSubscriptions)
+    .innerJoin(subscriptionTiers, eq(userSubscriptions.tierId, subscriptionTiers.id))
+    .where(eq(userSubscriptions.userId, userId))
+    .limit(1);
+
+  const allTiersQuery = db
+    .select({
+      id: subscriptionTiers.id,
+      name: subscriptionTiers.name,
+      displayName: subscriptionTiers.displayName,
+      description: subscriptionTiers.description,
+      priceCents: subscriptionTiers.priceCents,
+      resourceType: tierQuotas.resourceType,
+      premiumUnitKey: tierQuotas.premiumUnitKey,
+      premiumPeriodLimit: tierQuotas.premiumPeriodLimit,
+      fallbackUnitKey: tierQuotas.fallbackUnitKey,
+      fallbackPeriodLimit: tierQuotas.fallbackPeriodLimit,
+    })
+    .from(subscriptionTiers)
+    .innerJoin(tierQuotas, eq(tierQuotas.tierId, subscriptionTiers.id))
+    .where(
+      and(
+        eq(subscriptionTiers.isActive, true),
+        ne(subscriptionTiers.name, 'promotion'),
+      ),
+    )
+    .orderBy(asc(subscriptionTiers.sortOrder));
+
+  const [subRows, allTierRows] = await Promise.all([subQuery, allTiersQuery]);
+
+  // Build the plan-catalogue map up-front so it can also serve the free-tier
+  // fallback.
+  type AllTier = SubscriptionUsageResponse['allTiers'][number];
+  const tierMap = new Map<string, AllTier>();
+
+  for (const row of allTierRows) {
+    let tier = tierMap.get(row.id);
+    if (!tier) {
+      tier = {
+        id: row.id,
+        name: row.name,
+        displayName: row.displayName,
+        description: row.description,
+        priceCents: row.priceCents,
+        quotas: {},
+      };
+      tierMap.set(row.id, tier);
+    }
+    tier.quotas[row.resourceType] = {
+      resourceType: row.resourceType,
+      premiumUnitKey: row.premiumUnitKey,
+      premiumPeriodLimit: row.premiumPeriodLimit,
+      fallbackUnitKey: row.fallbackUnitKey,
+      fallbackPeriodLimit: row.fallbackPeriodLimit,
+    };
+  }
+
+  // Resolve the user's tier — from their subscription, or the free tier from the
+  // catalogue map when they have none.
+  let tierData: {
+    tierId: string;
+    status: string;
+    trialExpiresAt: Date | null;
+    currentPeriodAnchorAt: Date | null;
+    startedAt: Date;
+    expiresAt: Date | null;
+    hasTrialed: boolean;
+    billingInterval: 'monthly' | 'yearly' | null;
+    tierName: string;
+    tierDisplayName: string;
+    tierDescription: string | null;
+    tierPriceCents: number | null;
+  };
+
+  if (subRows.length === 0 || !subRows[0]) {
+    const freeTier = [...tierMap.values()].find(t => t.name === 'free');
+    if (!freeTier) {
+      logger.error('getSubscriptionUsage: free tier not found in DB');
+      return null;
+    }
+    const now = new Date();
+    tierData = {
+      tierId: freeTier.id,
+      status: 'active',
+      trialExpiresAt: null,
+      currentPeriodAnchorAt: now,
+      startedAt: now,
+      expiresAt: null,
+      hasTrialed: false,
+      billingInterval: null,
+      tierName: freeTier.name,
+      tierDisplayName: freeTier.displayName,
+      tierDescription: freeTier.description,
+      tierPriceCents: freeTier.priceCents,
+    };
+  } else {
+    tierData = subRows[0];
+  }
+
+  // --- Round-trip level 2 ---------------------------------------------------
+  // The user-tier quota rows (queried directly — a 'promotion' tier is excluded
+  // from the public catalogue above) and the current-period usage are
+  // independent, so run them together.
+  const anchor = tierData.currentPeriodAnchorAt ?? tierData.startedAt;
+  const period = getCurrentPeriod(anchor);
+
+  const quotaRows = await db
+    .select({
+      resourceType: tierQuotas.resourceType,
+      premiumUnitKey: tierQuotas.premiumUnitKey,
+      premiumPeriodLimit: tierQuotas.premiumPeriodLimit,
+      fallbackUnitKey: tierQuotas.fallbackUnitKey,
+      fallbackPeriodLimit: tierQuotas.fallbackPeriodLimit,
+      warningThresholdPct: tierQuotas.warningThresholdPct,
+    })
+    .from(tierQuotas)
+    .where(eq(tierQuotas.tierId, tierData.tierId));
+
+  const resourceTypes = quotaRows.map(r => r.resourceType);
+  const usageMap = await getUsageBatch(userId, resourceTypes, anchor);
+
+  const resources: SubscriptionUsageResponse['resources'] = {};
+  for (const q of quotaRows) {
+    const usage = usageMap.get(q.resourceType);
+    resources[q.resourceType] = {
+      quota: {
+        resourceType: q.resourceType,
+        premiumUnitKey: q.premiumUnitKey,
+        premiumPeriodLimit: q.premiumPeriodLimit,
+        fallbackUnitKey: q.fallbackUnitKey,
+        fallbackPeriodLimit: q.fallbackPeriodLimit,
+        warningThresholdPct: q.warningThresholdPct,
+      },
+      usage: {
+        premiumUnitsUsed: usage?.premiumUnitsUsed ?? 0,
+        fallbackUnitsUsed: usage?.fallbackUnitsUsed ?? 0,
+      },
+    };
+  }
+
+  return {
+    tier: {
+      id: tierData.tierId,
+      name: tierData.tierName,
+      displayName: tierData.tierDisplayName,
+      description: tierData.tierDescription,
+      priceCents: tierData.tierPriceCents,
+    },
+    subscription: {
+      status: tierData.status as SubscriptionUsageResponse['subscription']['status'],
+      trialExpiresAt: tierData.trialExpiresAt?.toISOString() ?? null,
+      expiresAt: tierData.expiresAt?.toISOString() ?? null,
+      hasTrialed: tierData.hasTrialed,
+      billingInterval: tierData.billingInterval,
+    },
+    resources,
+    period: {
+      start: toDateString(period.start),
+      end: toDateString(period.end),
+    },
+    allTiers: [...tierMap.values()],
+  };
+}

--- a/src/libs/subscriptions/period.test.ts
+++ b/src/libs/subscriptions/period.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+
+import { getCurrentPeriod, PERIOD_MS, toDateString } from './period';
+
+describe('getCurrentPeriod (rolling period)', () => {
+  it('returns [anchor, anchor+PERIOD) when called at the anchor instant', () => {
+    const anchor = new Date('2026-04-30T12:00:00Z');
+    const period = getCurrentPeriod(anchor, anchor);
+
+    expect(period.start.toISOString()).toBe(anchor.toISOString());
+    expect(period.end.getTime() - period.start.getTime()).toBe(PERIOD_MS);
+  });
+
+  it('keeps the same period when called mid-window (3 days in)', () => {
+    const anchor = new Date('2026-04-30T12:00:00Z');
+    const now = new Date(anchor.getTime() + 3 * 24 * 60 * 60 * 1000);
+    const period = getCurrentPeriod(anchor, now);
+
+    expect(period.start.toISOString()).toBe(anchor.toISOString());
+    expect(period.end.toISOString()).toBe(new Date(anchor.getTime() + PERIOD_MS).toISOString());
+  });
+
+  it('returns the next window once the previous one has elapsed', () => {
+    const anchor = new Date('2026-04-30T12:00:00Z');
+    const now = new Date(anchor.getTime() + PERIOD_MS + 60_000); // 1 period + 1 minute later
+    const period = getCurrentPeriod(anchor, now);
+
+    expect(period.start.getTime()).toBe(anchor.getTime() + PERIOD_MS);
+    expect(period.end.getTime()).toBe(anchor.getTime() + 2 * PERIOD_MS);
+  });
+
+  it('returns the Nth window after N periods', () => {
+    const anchor = new Date('2026-01-01T00:00:00Z');
+    const now = new Date(anchor.getTime() + 5 * PERIOD_MS + 60_000);
+    const period = getCurrentPeriod(anchor, now);
+
+    expect(period.start.getTime()).toBe(anchor.getTime() + 5 * PERIOD_MS);
+    expect(period.end.getTime()).toBe(anchor.getTime() + 6 * PERIOD_MS);
+  });
+
+  it('end is exactly one period after start', () => {
+    const anchor = new Date('2026-06-15T08:30:00Z');
+    const now = new Date(anchor.getTime() + 10 * 24 * 60 * 60 * 1000);
+    const period = getCurrentPeriod(anchor, now);
+
+    expect(period.end.getTime() - period.start.getTime()).toBe(PERIOD_MS);
+  });
+
+  it('floors negative elapsed time to the anchor (clock skew defense)', () => {
+    const anchor = new Date('2026-05-01T00:00:00Z');
+    const now = new Date(anchor.getTime() - 1000); // before anchor
+    const period = getCurrentPeriod(anchor, now);
+
+    expect(period.start.toISOString()).toBe(anchor.toISOString());
+  });
+
+  it('a fresh anchor mid-window resets the period (tier-transition scenario)', () => {
+    const originalAnchor = new Date('2026-01-01T00:00:00Z');
+    const now = new Date('2026-01-04T12:00:00Z'); // 3.5 days into period 0
+
+    const before = getCurrentPeriod(originalAnchor, now);
+
+    expect(before.start.toISOString()).toBe(originalAnchor.toISOString());
+
+    // Tier transition resets the anchor to NOW; new period starts now.
+    const resetAnchor = now;
+    const after = getCurrentPeriod(resetAnchor, now);
+
+    expect(after.start.toISOString()).toBe(now.toISOString());
+    expect(after.end.getTime() - after.start.getTime()).toBe(PERIOD_MS);
+  });
+});
+
+describe('toDateString', () => {
+  it('formats date as YYYY-MM-DD', () => {
+    const date = new Date(Date.UTC(2026, 1, 15));
+
+    expect(toDateString(date)).toBe('2026-02-15');
+  });
+
+  it('pads single-digit months and days', () => {
+    const date = new Date(Date.UTC(2026, 0, 5));
+
+    expect(toDateString(date)).toBe('2026-01-05');
+  });
+
+  it('handles December 31', () => {
+    const date = new Date(Date.UTC(2026, 11, 31));
+
+    expect(toDateString(date)).toBe('2026-12-31');
+  });
+});

--- a/src/libs/subscriptions/period.ts
+++ b/src/libs/subscriptions/period.ts
@@ -1,0 +1,34 @@
+export type Period = {
+  start: Date;
+  end: Date;
+};
+
+/**
+ * Length of the rolling quota window. Default is 7 days; a fork can change the
+ * cadence (e.g. 30 days for a monthly meter) in one place.
+ */
+export const PERIOD_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Returns the current rolling quota period for a user, anchored at `anchorAt`
+ * (the user's `current_period_anchor_at`, or `started_at` as a fallback).
+ *
+ * The anchor is reset on every tier transition (free→trial, trial→pro,
+ * promotion→free, etc.) so a user's first window after upgrading begins at the
+ * moment of upgrade — not at original signup.
+ */
+export function getCurrentPeriod(anchorAt: Date, now: Date = new Date()): Period {
+  const elapsedMs = now.getTime() - anchorAt.getTime();
+  const periodsSinceAnchor = Math.max(0, Math.floor(elapsedMs / PERIOD_MS));
+  const start = new Date(anchorAt.getTime() + periodsSinceAnchor * PERIOD_MS);
+  const end = new Date(start.getTime() + PERIOD_MS);
+  return { start, end };
+}
+
+/**
+ * Formats a Date as a YYYY-MM-DD string in UTC.
+ * Used for SQL DATE comparisons and storage.
+ */
+export function toDateString(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}

--- a/src/libs/subscriptions/quota-cache-invalidation.test.ts
+++ b/src/libs/subscriptions/quota-cache-invalidation.test.ts
@@ -1,0 +1,158 @@
+// @vitest-environment node
+//
+// Integration test for the quota-cache invalidation contract between recordUsage
+// (usage.ts) and checkQuota (quota.ts):
+//
+//   checkQuota → recordUsage → checkQuota
+//
+// must reflect the newly-recorded usage on the SECOND checkQuota, even though
+// quota state is cached for CACHE_TTL_MS (60s). Without recordUsage invalidating
+// the cache, the second checkQuota would read the stale pre-write counts for the
+// rest of the window — a stale-window over-spend.
+//
+// This exercises the REAL recordUsage, getUsage, and checkQuota against a tiny
+// in-memory usage ledger driven through the mocked db, so the cache + invalidation
+// path is genuinely wired (not mocked away).
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── In-memory usage ledger the mocked db reads/writes ──────────────────────────
+const ledger = { premiumUsed: 0, fallbackUsed: 0 };
+
+const PREMIUM_KEY = 'premium-pool';
+const FALLBACK_KEY = 'fallback-pool';
+const PREMIUM_LIMIT = 1000;
+const FALLBACK_LIMIT = 1000;
+const ANCHOR = new Date('2026-04-30T00:00:00Z');
+
+// The mocked db dispatches based on which select-shape / insert is requested.
+// We can't see the table from the chain, so we disambiguate by call order within
+// each public call:
+//   - loadUserQuotaState issues ONE joined select (innerJoin present) → tier row.
+//   - getUsage issues ONE select (no innerJoin) → usage row.
+//   - getPeriodAnchor (inside recordUsage) issues ONE select (no innerJoin) → anchor.
+// We tag the chain by whether innerJoin was called.
+
+function makeSelectChain() {
+  let usedInnerJoin = false;
+  const chain: Record<string, unknown> = {
+    select: vi.fn(() => chain),
+    from: vi.fn(() => chain),
+    innerJoin: vi.fn(() => {
+      usedInnerJoin = true;
+      return chain;
+    }),
+    where: vi.fn(() => chain),
+    limit: vi.fn(() => {
+      if (usedInnerJoin) {
+        // Joined tier+quota row for loadUserQuotaState.
+        return Promise.resolve([{
+          status: 'active',
+          trialExpiresAt: null,
+          expiresAt: null,
+          currentPeriodAnchorAt: ANCHOR,
+          startedAt: ANCHOR,
+          tierName: 'pro',
+          premiumUnitKey: PREMIUM_KEY,
+          premiumPeriodLimit: PREMIUM_LIMIT,
+          fallbackUnitKey: FALLBACK_KEY,
+          fallbackPeriodLimit: FALLBACK_LIMIT,
+          warningThresholdPct: 90,
+        }]);
+      }
+      // Non-joined select. Two callers:
+      //   getPeriodAnchor selects currentPeriodAnchorAt/startedAt.
+      //   getUsage selects premiumUnitsUsed/fallbackUnitsUsed.
+      // Returning a row carrying BOTH satisfies whichever asked.
+      return Promise.resolve([{
+        currentPeriodAnchorAt: ANCHOR,
+        startedAt: ANCHOR,
+        premiumUnitsUsed: ledger.premiumUsed,
+        fallbackUnitsUsed: ledger.fallbackUsed,
+        periodStart: '2026-04-30',
+        periodEnd: '2026-05-07',
+      }]);
+    }),
+  };
+  return chain;
+}
+
+const mockInsert = vi.fn(() => ({
+  values: (vals: { premiumUnitsUsed?: number; fallbackUnitsUsed?: number }) => ({
+    onConflictDoUpdate: () => {
+      // Apply the write to the in-memory ledger so the next getUsage sees it.
+      ledger.premiumUsed += vals.premiumUnitsUsed ?? 0;
+      ledger.fallbackUsed += vals.fallbackUnitsUsed ?? 0;
+      return Promise.resolve(undefined);
+    },
+  }),
+}));
+
+vi.mock('@/libs/DB', () => ({
+  db: {
+    select: () => makeSelectChain(),
+    insert: () => mockInsert(),
+  },
+}));
+
+vi.mock('@/libs/Logger', () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('@/libs/analytics/server', () => ({
+  trackEventServer: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/libs/jobs/blocking', () => ({
+  blockScheduledTasksForUser: vi.fn().mockResolvedValue(0),
+}));
+
+vi.mock('@sentry/nextjs', () => ({ captureMessage: vi.fn() }));
+
+const { checkQuotaByUserId, clearQuotaCache } = await import('./quota');
+const { recordUsage } = await import('./usage');
+
+describe('recordUsage invalidates the quota cache (no stale-window over-spend)', () => {
+  beforeEach(() => {
+    clearQuotaCache();
+    ledger.premiumUsed = 0;
+    ledger.fallbackUsed = 0;
+    vi.clearAllMocks();
+  });
+
+  it('checkQuota → recordUsage → checkQuota reflects the updated usage', async () => {
+    // 1. First read: zero usage, premium pool, ~0%.
+    const before = await checkQuotaByUserId('user-cache', 'generation');
+
+    expect(before.allowed).toBe(true);
+    expect(before.unitKey).toBe(PREMIUM_KEY);
+    expect(before.usagePct.premium).toBe(0);
+
+    // 2. Record premium usage. This must invalidate the cached state.
+    await recordUsage('user-cache', 'generation', PREMIUM_KEY, 500, PREMIUM_KEY);
+
+    expect(ledger.premiumUsed).toBe(500);
+
+    // 3. Second read: WITHOUT cache invalidation this would still report 0%.
+    //    With the fix it re-reads the ledger and reports 50%.
+    const after = await checkQuotaByUserId('user-cache', 'generation');
+
+    expect(after.usagePct.premium).toBe(50);
+  });
+
+  it('without invalidation a stale read would mask exhaustion — fix lets the gate fire', async () => {
+    // Prime cache at 0 usage.
+    const first = await checkQuotaByUserId('user-cache-2', 'generation');
+
+    expect(first.allowed).toBe(true);
+
+    // Consume the entire premium + fallback budget.
+    await recordUsage('user-cache-2', 'generation', PREMIUM_KEY, PREMIUM_LIMIT, PREMIUM_KEY);
+    await recordUsage('user-cache-2', 'generation', FALLBACK_KEY, FALLBACK_LIMIT, PREMIUM_KEY);
+
+    // The fresh read must now block (both pools exhausted) — only possible because
+    // each recordUsage invalidated the cached state.
+    const after = await checkQuotaByUserId('user-cache-2', 'generation');
+
+    expect(after.allowed).toBe(false);
+  });
+});

--- a/src/libs/subscriptions/quota.test.ts
+++ b/src/libs/subscriptions/quota.test.ts
@@ -1,0 +1,451 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { QuotaDecision } from './quota';
+
+// Mock DB module before imports.
+vi.mock('@/libs/DB', () => ({
+  db: {
+    select: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+// Mock Logger to suppress output.
+vi.mock('@/libs/Logger', () => ({
+  logger: {
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+// Mock analytics server (checkQuota emits quota_limit_reached / trial_expired).
+vi.mock('@/libs/analytics/server', () => ({
+  trackEventServer: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock usage module.
+vi.mock('./usage', () => ({
+  getUsage: vi.fn(),
+}));
+
+// Mock blocking helper (called from the lazy-expiry path).
+vi.mock('@/libs/jobs/blocking', () => ({
+  blockScheduledTasksForUser: vi.fn().mockResolvedValue(0),
+}));
+
+// Import after mocks.
+const { db } = await import('@/libs/DB');
+const { getUsage } = await import('./usage');
+const { checkQuotaByUserId, clearQuotaCache, invalidateQuotaCache } = await import('./quota');
+
+// Generic two-pool unit keys (a product maps these to its own meter — model ids,
+// rate-limit buckets, …).
+const PREMIUM_KEY = 'premium-pool';
+const FALLBACK_KEY = 'fallback-pool';
+
+function mockSubscriptionQuery(rows: unknown[]) {
+  const chain = {
+    select: vi.fn().mockReturnThis(),
+    from: vi.fn().mockReturnThis(),
+    innerJoin: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue(rows),
+  };
+  (db.select as ReturnType<typeof vi.fn>).mockReturnValue(chain);
+  return chain;
+}
+
+function mockTierRow(overrides: Record<string, unknown> = {}) {
+  return {
+    status: 'active',
+    trialExpiresAt: null,
+    expiresAt: null,
+    currentPeriodAnchorAt: new Date('2026-04-30T00:00:00Z'),
+    startedAt: new Date('2026-04-30T00:00:00Z'),
+    tierName: 'pro',
+    premiumUnitKey: PREMIUM_KEY,
+    premiumPeriodLimit: 150000,
+    fallbackUnitKey: FALLBACK_KEY,
+    fallbackPeriodLimit: 250000,
+    warningThresholdPct: 90,
+    ...overrides,
+  };
+}
+
+describe('checkQuotaByUserId', () => {
+  beforeEach(() => {
+    clearQuotaCache();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    clearQuotaCache();
+  });
+
+  it('returns premium pool when usage is below threshold (Pro tier)', async () => {
+    mockSubscriptionQuery([mockTierRow()]);
+    vi.mocked(getUsage).mockResolvedValue({
+      premiumUnitsUsed: 100000,
+      fallbackUnitsUsed: 0,
+      periodStart: '2026-03-01',
+      periodEnd: '2026-03-15',
+    });
+
+    const result = await checkQuotaByUserId('user-1', 'generation');
+
+    expect(result.allowed).toBe(true);
+    expect(result.unitKey).toBe(PREMIUM_KEY);
+    expect(result.premiumUnitKey).toBe(PREMIUM_KEY);
+    expect(result.usagePct.premium).toBeCloseTo(66.67, 1);
+    expect(result.warning).toBeUndefined();
+    expect(result.downgrade).toBeUndefined();
+  });
+
+  it('returns warning when premium usage exceeds threshold (90%)', async () => {
+    mockSubscriptionQuery([mockTierRow()]);
+    vi.mocked(getUsage).mockResolvedValue({
+      premiumUnitsUsed: 140000,
+      fallbackUnitsUsed: 0,
+      periodStart: '2026-03-01',
+      periodEnd: '2026-03-15',
+    });
+
+    const result = await checkQuotaByUserId('user-2', 'generation');
+
+    expect(result.allowed).toBe(true);
+    expect(result.unitKey).toBe(PREMIUM_KEY);
+    expect(result.warning).toBeDefined();
+    expect(result.warning?.type).toBe('approaching_premium_limit');
+    expect(result.warning?.usage_pct).toBeCloseTo(93.33, 1);
+    expect(result.downgrade).toBeUndefined();
+  });
+
+  it('returns fallback pool with downgrade when premium is exhausted', async () => {
+    mockSubscriptionQuery([mockTierRow()]);
+    vi.mocked(getUsage).mockResolvedValue({
+      premiumUnitsUsed: 160000,
+      fallbackUnitsUsed: 50000,
+      periodStart: '2026-03-01',
+      periodEnd: '2026-03-15',
+    });
+
+    const result = await checkQuotaByUserId('user-3', 'generation');
+
+    expect(result.allowed).toBe(true);
+    expect(result.unitKey).toBe(FALLBACK_KEY);
+    expect(result.downgrade).toBeDefined();
+    expect(result.downgrade?.reason).toBe('premium_exhausted');
+    expect(result.downgrade?.current_unit_key).toBe(FALLBACK_KEY);
+    expect(result.warning).toBeUndefined();
+  });
+
+  it('returns allowed: false when both limits are exhausted', async () => {
+    mockSubscriptionQuery([mockTierRow()]);
+    vi.mocked(getUsage).mockResolvedValue({
+      premiumUnitsUsed: 165000,
+      fallbackUnitsUsed: 260000,
+      periodStart: '2026-03-01',
+      periodEnd: '2026-03-15',
+    });
+
+    const result = await checkQuotaByUserId('user-4', 'generation');
+
+    expect(result.allowed).toBe(false);
+    expect(result.unitKey).toBe(FALLBACK_KEY);
+    expect(result.usagePct.premium).toBeGreaterThan(100);
+    expect(result.usagePct.fallback).toBeGreaterThan(100);
+  });
+
+  it('returns fallback pool for free tier (premium limit = 0)', async () => {
+    mockSubscriptionQuery([mockTierRow({
+      tierName: 'free',
+      premiumUnitKey: null,
+      premiumPeriodLimit: 0,
+      fallbackUnitKey: FALLBACK_KEY,
+      fallbackPeriodLimit: 25000,
+    })]);
+    vi.mocked(getUsage).mockResolvedValue({
+      premiumUnitsUsed: 0,
+      fallbackUnitsUsed: 0,
+      periodStart: '2026-03-01',
+      periodEnd: '2026-03-15',
+    });
+
+    const result = await checkQuotaByUserId('user-5', 'generation');
+
+    expect(result.allowed).toBe(true);
+    expect(result.unitKey).toBe(FALLBACK_KEY);
+    expect(result.premiumUnitKey).toBeNull();
+    expect(result.downgrade).toBeUndefined();
+  });
+
+  it('returns allowed: false for free tier when fallback is exhausted', async () => {
+    mockSubscriptionQuery([mockTierRow({
+      tierName: 'free',
+      premiumUnitKey: null,
+      premiumPeriodLimit: 0,
+      fallbackUnitKey: FALLBACK_KEY,
+      fallbackPeriodLimit: 25000,
+    })]);
+    vi.mocked(getUsage).mockResolvedValue({
+      premiumUnitsUsed: 0,
+      fallbackUnitsUsed: 26000,
+      periodStart: '2026-03-01',
+      periodEnd: '2026-03-15',
+    });
+
+    const result = await checkQuotaByUserId('user-6', 'generation');
+
+    expect(result.allowed).toBe(false);
+  });
+
+  // Zero-limit pools must block: a tier disables a resource entirely by setting
+  // both period limits to 0. Treating that as "non-exhaustible" would silently
+  // allow unlimited usage.
+  it('returns allowed: false when both pools have zero period limit (blocked-tier pattern)', async () => {
+    mockSubscriptionQuery([mockTierRow({
+      tierName: 'free',
+      premiumUnitKey: null,
+      premiumPeriodLimit: 0,
+      fallbackUnitKey: FALLBACK_KEY,
+      fallbackPeriodLimit: 0,
+    })]);
+    vi.mocked(getUsage).mockResolvedValue({
+      premiumUnitsUsed: 0,
+      fallbackUnitsUsed: 0,
+      periodStart: '2026-03-01',
+      periodEnd: '2026-03-15',
+    });
+
+    const result = await checkQuotaByUserId('user-zero-limit', 'restricted_resource');
+
+    expect(result.allowed).toBe(false);
+  });
+
+  it('handles expired trial by updating tier_id to free tier and returning free-tier quota', async () => {
+    const expiredTrialRow = mockTierRow({
+      status: 'trial',
+      trialExpiresAt: new Date('2026-01-01T00:00:00Z'), // well in the past
+    });
+
+    const FREE_TIER_ID = 'tier-free-id';
+
+    // db.select is called multiple times:
+    //   1. subscription query (returns expired trial)
+    //   2. free tier lookup (returns free tier row with id)
+    //   3. subscription query again on recursion (returns free tier)
+    let selectCallCount = 0;
+    const chain = {
+      select: vi.fn().mockReturnThis(),
+      from: vi.fn().mockReturnThis(),
+      innerJoin: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockImplementation(() => {
+        selectCallCount++;
+        if (selectCallCount === 1) {
+          return Promise.resolve([expiredTrialRow]);
+        }
+        if (selectCallCount === 2) {
+          return Promise.resolve([{ id: FREE_TIER_ID }]);
+        }
+        return Promise.resolve([mockTierRow({
+          status: 'expired',
+          tierName: 'free',
+          premiumUnitKey: null,
+          premiumPeriodLimit: 0,
+          fallbackUnitKey: FALLBACK_KEY,
+          fallbackPeriodLimit: 25000,
+        })]);
+      }),
+    };
+    (db.select as ReturnType<typeof vi.fn>).mockReturnValue(chain);
+
+    const updateChain = {
+      set: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue(undefined),
+    };
+    (db.update as ReturnType<typeof vi.fn>).mockReturnValue(updateChain);
+
+    vi.mocked(getUsage).mockResolvedValue({
+      premiumUnitsUsed: 0,
+      fallbackUnitsUsed: 0,
+      periodStart: '2026-03-01',
+      periodEnd: '2026-03-15',
+    });
+
+    const result = await checkQuotaByUserId('user-7', 'generation');
+
+    expect(db.update).toHaveBeenCalled();
+    expect(updateChain.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'expired',
+        tierId: FREE_TIER_ID,
+      }),
+    );
+    expect(result.allowed).toBe(true);
+    expect(result.unitKey).toBe(FALLBACK_KEY);
+  });
+
+  // Regression: an expired trial whose 'free' tier is missing from the DB (fresh
+  // install without seed.sql) must throw a recoverable error rather than recurse
+  // forever. expireTrialToFree returns false (no row mutation), so loadUserQuotaState
+  // must NOT re-enter the same expiry branch.
+  it('throws (does NOT infinite-loop) on expired trial when free tier is missing', async () => {
+    const expiredTrialRow = mockTierRow({
+      status: 'trial',
+      trialExpiresAt: new Date('2026-01-01T00:00:00Z'),
+    });
+
+    // db.select call sequence:
+    //   1. subscription query → expired trial
+    //   2. getTierIdByName('free') → [] (free tier missing)
+    // After (2) returns empty, expireTrialToFree returns false and the caller
+    // throws. There must be NO third select (no recursion).
+    let selectCallCount = 0;
+    const chain = {
+      select: vi.fn().mockReturnThis(),
+      from: vi.fn().mockReturnThis(),
+      innerJoin: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockImplementation(() => {
+        selectCallCount++;
+        if (selectCallCount === 1) {
+          return Promise.resolve([expiredTrialRow]);
+        }
+        // Free-tier lookup (and any further call) returns empty.
+        return Promise.resolve([]);
+      }),
+    };
+    (db.select as ReturnType<typeof vi.fn>).mockReturnValue(chain);
+
+    // db.update is never reached (free tier missing → no demotion write).
+    const updateChain = {
+      set: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue(undefined),
+    };
+    (db.update as ReturnType<typeof vi.fn>).mockReturnValue(updateChain);
+
+    await expect(checkQuotaByUserId('user-no-free', 'generation')).rejects.toThrow(
+      /free tier is missing from DB/,
+    );
+
+    // Exactly 2 selects: the subscription read + the free-tier lookup. A third
+    // would mean we recursed (the bug).
+    expect(selectCallCount).toBe(2);
+    expect(db.update).not.toHaveBeenCalled();
+  });
+
+  it('degrades to free tier row when no subscription found', async () => {
+    let selectCallCount = 0;
+    const chain = {
+      select: vi.fn().mockReturnThis(),
+      from: vi.fn().mockReturnThis(),
+      innerJoin: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockImplementation(() => {
+        selectCallCount++;
+        if (selectCallCount === 1) {
+          return Promise.resolve([]);
+        }
+        return Promise.resolve([{
+          tierName: 'free',
+          premiumUnitKey: null,
+          premiumPeriodLimit: 0,
+          fallbackUnitKey: FALLBACK_KEY,
+          fallbackPeriodLimit: 25000,
+          warningThresholdPct: 90,
+        }]);
+      }),
+    };
+    (db.select as ReturnType<typeof vi.fn>).mockReturnValue(chain);
+
+    const result = await checkQuotaByUserId('user-8', 'generation');
+
+    expect(result.allowed).toBe(true);
+    expect(result.unitKey).toBe(FALLBACK_KEY);
+    expect(result.premiumUnitKey).toBeNull();
+  });
+
+  it('returns cached result on cache hit without making DB calls', async () => {
+    mockSubscriptionQuery([mockTierRow()]);
+    vi.mocked(getUsage).mockResolvedValue({
+      premiumUnitsUsed: 50000,
+      fallbackUnitsUsed: 0,
+      periodStart: '2026-03-01',
+      periodEnd: '2026-03-15',
+    });
+
+    const first = await checkQuotaByUserId('user-9', 'generation');
+
+    expect(first.allowed).toBe(true);
+
+    vi.clearAllMocks();
+
+    const second = await checkQuotaByUserId('user-9', 'generation');
+
+    expect(second.allowed).toBe(first.allowed);
+    expect(second.unitKey).toBe(first.unitKey);
+    expect(db.select).not.toHaveBeenCalled();
+    expect(getUsage).not.toHaveBeenCalled();
+  });
+
+  it('invalidateQuotaCache clears the cache for a user+resource', async () => {
+    mockSubscriptionQuery([mockTierRow()]);
+    vi.mocked(getUsage).mockResolvedValue({
+      premiumUnitsUsed: 50000,
+      fallbackUnitsUsed: 0,
+      periodStart: '2026-03-01',
+      periodEnd: '2026-03-15',
+    });
+
+    await checkQuotaByUserId('user-10', 'generation');
+    vi.clearAllMocks();
+
+    invalidateQuotaCache('user-10', 'generation');
+
+    mockSubscriptionQuery([mockTierRow()]);
+    vi.mocked(getUsage).mockResolvedValue({
+      premiumUnitsUsed: 50000,
+      fallbackUnitsUsed: 0,
+      periodStart: '2026-03-01',
+      periodEnd: '2026-03-15',
+    });
+
+    await checkQuotaByUserId('user-10', 'generation');
+
+    expect(db.select).toHaveBeenCalled();
+  });
+
+  it('includes resetsAt in all results', async () => {
+    mockSubscriptionQuery([mockTierRow()]);
+    vi.mocked(getUsage).mockResolvedValue({
+      premiumUnitsUsed: 50000,
+      fallbackUnitsUsed: 0,
+      periodStart: '2026-03-01',
+      periodEnd: '2026-03-15',
+    });
+
+    const result: QuotaDecision = await checkQuotaByUserId('user-11', 'generation');
+
+    expect(result.resetsAt).toBeInstanceOf(Date);
+  });
+
+  it('enforce:false returns allowed:true even when both pools are exhausted', async () => {
+    mockSubscriptionQuery([mockTierRow()]);
+    vi.mocked(getUsage).mockResolvedValue({
+      premiumUnitsUsed: 165000,
+      fallbackUnitsUsed: 260000,
+      periodStart: '2026-03-01',
+      periodEnd: '2026-03-15',
+    });
+
+    const result = await checkQuotaByUserId('user-12', 'generation', { enforce: false });
+
+    expect(result.allowed).toBe(true);
+    // Even though allowed is forced true, pool selection still surfaces fallback
+    // because premium is exhausted.
+    expect(result.unitKey).toBe(FALLBACK_KEY);
+    expect(result.usagePct.premium).toBeGreaterThan(100);
+  });
+});

--- a/src/libs/subscriptions/quota.ts
+++ b/src/libs/subscriptions/quota.ts
@@ -1,0 +1,452 @@
+import type { User } from '@supabase/supabase-js';
+import { and, eq } from 'drizzle-orm';
+
+import { trackEventServer } from '@/libs/analytics/server';
+import { db } from '@/libs/DB';
+import { blockScheduledTasksForUser } from '@/libs/jobs/blocking';
+import { logger } from '@/libs/Logger';
+import { subscriptionTiers, tierQuotas, userSubscriptions } from '@/models/Schema';
+
+import { getCurrentPeriod } from './period';
+import { getUsage } from './usage';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+// UsageWarning + Downgrade describe the telemetry a caller can surface (a
+// usage-approaching banner, a pool-downgrade notice). snake_case fields are kept
+// so they serialize cleanly if a product forwards them over a wire boundary.
+export type UsageWarning = {
+  type: 'approaching_premium_limit';
+  usage_pct: number;
+  resets_at: Date;
+};
+
+export type Downgrade = {
+  reason: 'premium_exhausted';
+  current_unit_key: string;
+  resets_at: Date;
+};
+
+/**
+ * Result of resolving which pool a user should draw from for a resource type,
+ * plus the gate decision (when `enforce: true`).
+ *
+ * The two-pool model is generic: a product maps `unitKey` to whatever it meters
+ * (an AI model id, a rate-limit bucket, …). See `tier_quotas` for the model.
+ */
+export type QuotaDecision = {
+  /** True when the user can make this call. Always true under enforce:false. */
+  allowed: boolean;
+  /** The pool the user should draw from (premium while budget remains, else fallback). */
+  unitKey: string;
+  /** The tier's premium pool key — needed by recordUsage for usage tagging. */
+  premiumUnitKey: string | null;
+  usagePct: { premium: number; fallback: number };
+  warning?: UsageWarning;
+  downgrade?: Downgrade;
+  resetsAt: Date;
+};
+
+// ---------------------------------------------------------------------------
+// In-memory cache
+// ---------------------------------------------------------------------------
+
+type CacheEntry = {
+  state: QuotaState;
+  expiresAt: number;
+};
+
+const CACHE_TTL_MS = 60_000; // 60 seconds — accepts staleness, avoids per-call DB hit on hot paths.
+const stateCache = new Map<string, CacheEntry>();
+
+function getCacheKey(userId: string, resourceType: string): string {
+  return `${userId}:${resourceType}`;
+}
+
+function getCachedState(key: string): QuotaState | null {
+  const entry = stateCache.get(key);
+  if (!entry) {
+    return null;
+  }
+  if (Date.now() > entry.expiresAt) {
+    stateCache.delete(key);
+    return null;
+  }
+  return entry.state;
+}
+
+function setCachedState(key: string, state: QuotaState): void {
+  stateCache.set(key, { state, expiresAt: Date.now() + CACHE_TTL_MS });
+}
+
+/** Invalidates the cached quota state for a user+resource after usage is recorded. */
+export function invalidateQuotaCache(userId: string, resourceType: string): void {
+  stateCache.delete(getCacheKey(userId, resourceType));
+}
+
+/** Clears the entire cache. Test-only — do NOT call in production code. @internal */
+export function clearQuotaCache(): void {
+  stateCache.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Private: loadUserQuotaState — single source of joined tier+usage data
+// ---------------------------------------------------------------------------
+
+type QuotaState = {
+  tierName: string;
+  premiumUnitKey: string | null;
+  premiumLimit: number;
+  fallbackUnitKey: string;
+  fallbackLimit: number;
+  warningThresholdPct: number;
+  premiumUsed: number;
+  fallbackUsed: number;
+  resetsAt: Date;
+};
+
+/**
+ * Loads the joined subscription + tier + tier_quotas row + current-period usage
+ * for a user. Handles lazy trial / promotion expiry along the way.
+ *
+ * Falls back to the 'free' tier row when the user has no subscription — should
+ * not happen (the signup trigger ensures every user has a row), but we degrade
+ * gracefully rather than throw.
+ *
+ * Throws only when the 'free' tier itself is missing from the DB (a broken env)
+ * — callers convert this into a 5xx.
+ */
+async function loadUserQuotaState(
+  userId: string,
+  resourceType: string,
+): Promise<QuotaState> {
+  const cacheKey = getCacheKey(userId, resourceType);
+  const cached = getCachedState(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  const rows = await db
+    .select({
+      status: userSubscriptions.status,
+      trialExpiresAt: userSubscriptions.trialExpiresAt,
+      expiresAt: userSubscriptions.expiresAt,
+      currentPeriodAnchorAt: userSubscriptions.currentPeriodAnchorAt,
+      startedAt: userSubscriptions.startedAt,
+      tierName: subscriptionTiers.name,
+      premiumUnitKey: tierQuotas.premiumUnitKey,
+      premiumPeriodLimit: tierQuotas.premiumPeriodLimit,
+      fallbackUnitKey: tierQuotas.fallbackUnitKey,
+      fallbackPeriodLimit: tierQuotas.fallbackPeriodLimit,
+      warningThresholdPct: tierQuotas.warningThresholdPct,
+    })
+    .from(userSubscriptions)
+    .innerJoin(subscriptionTiers, eq(userSubscriptions.tierId, subscriptionTiers.id))
+    .innerJoin(
+      tierQuotas,
+      and(
+        eq(tierQuotas.tierId, subscriptionTiers.id),
+        eq(tierQuotas.resourceType, resourceType),
+      ),
+    )
+    .where(eq(userSubscriptions.userId, userId))
+    .limit(1);
+
+  if (rows.length === 0 || !rows[0]) {
+    // No subscription row — degrade to the 'free' tier so the call still
+    // resolves a sensible pool rather than failing.
+    logger.warn({ userId }, 'loadUserQuotaState: no subscription found — using free tier');
+    return loadFreeTierState(resourceType);
+  }
+
+  const row = rows[0];
+
+  // Lazy trial expiry: trial flipped past its expiry between the cron tick and now.
+  // Recurse ONLY if the demotion actually mutated the row. If the 'free' tier is
+  // missing (broken env — no seed.sql), the helper can't demote and returns
+  // false; recursing would re-enter this exact branch forever, hammering the DB.
+  // Degrade to the same recoverable error loadFreeTierState throws instead.
+  if (row.status === 'trial' && row.trialExpiresAt && row.trialExpiresAt < new Date()) {
+    const demoted = await expireTrialToFree(userId);
+    if (!demoted) {
+      throw new Error(`loadUserQuotaState: cannot expire trial — free tier is missing from DB`);
+    }
+    stateCache.delete(cacheKey);
+    return loadUserQuotaState(userId, resourceType);
+  }
+
+  // Lazy promotion expiry: same idea (and same guard) for admin-granted promotions.
+  if (row.tierName === 'promotion' && row.expiresAt && row.expiresAt < new Date()) {
+    const demoted = await expirePromotionToFree(userId);
+    if (!demoted) {
+      throw new Error(`loadUserQuotaState: cannot expire promotion — free tier is missing from DB`);
+    }
+    stateCache.delete(cacheKey);
+    return loadUserQuotaState(userId, resourceType);
+  }
+
+  const usage = await getUsage(userId, resourceType);
+  const period = getCurrentPeriod(row.currentPeriodAnchorAt ?? row.startedAt);
+
+  const state: QuotaState = {
+    tierName: row.tierName,
+    premiumUnitKey: row.premiumUnitKey,
+    premiumLimit: row.premiumPeriodLimit,
+    fallbackUnitKey: row.fallbackUnitKey,
+    fallbackLimit: row.fallbackPeriodLimit,
+    warningThresholdPct: row.warningThresholdPct,
+    premiumUsed: usage.premiumUnitsUsed,
+    fallbackUsed: usage.fallbackUnitsUsed,
+    resetsAt: period.end,
+  };
+
+  setCachedState(cacheKey, state);
+  return state;
+}
+
+/**
+ * Loads a synthetic QuotaState seeded from the 'free' tier's row, with zero
+ * usage. Used as the missing-subscription safety net so a call still resolves a
+ * sensible pool rather than failing.
+ *
+ * Throws if the 'free' tier or its tier_quotas row for the resource type is
+ * missing — that's a broken environment, not a runtime condition we can recover
+ * from. (Run supabase/seed.sql to seed the default tiers + quota rows.)
+ */
+async function loadFreeTierState(resourceType: string): Promise<QuotaState> {
+  const rows = await db
+    .select({
+      tierName: subscriptionTiers.name,
+      premiumUnitKey: tierQuotas.premiumUnitKey,
+      premiumPeriodLimit: tierQuotas.premiumPeriodLimit,
+      fallbackUnitKey: tierQuotas.fallbackUnitKey,
+      fallbackPeriodLimit: tierQuotas.fallbackPeriodLimit,
+      warningThresholdPct: tierQuotas.warningThresholdPct,
+    })
+    .from(subscriptionTiers)
+    .innerJoin(
+      tierQuotas,
+      and(
+        eq(tierQuotas.tierId, subscriptionTiers.id),
+        eq(tierQuotas.resourceType, resourceType),
+      ),
+    )
+    .where(eq(subscriptionTiers.name, 'free'))
+    .limit(1);
+
+  if (rows.length === 0 || !rows[0]) {
+    throw new Error(`loadFreeTierState: free tier or its ${resourceType} quota row is missing from DB`);
+  }
+
+  const row = rows[0];
+  // Synthetic: pretend the user is fresh into their period.
+  const farFuture = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000);
+
+  return {
+    tierName: row.tierName,
+    premiumUnitKey: row.premiumUnitKey,
+    premiumLimit: row.premiumPeriodLimit,
+    fallbackUnitKey: row.fallbackUnitKey,
+    fallbackLimit: row.fallbackPeriodLimit,
+    warningThresholdPct: row.warningThresholdPct,
+    premiumUsed: 0,
+    fallbackUsed: 0,
+    resetsAt: farFuture,
+  };
+}
+
+/**
+ * Demotes an expired trial to the 'free' tier.
+ *
+ * Returns `true` once the row has been mutated. Returns `false` when the 'free'
+ * tier is missing from the DB (broken env) — the caller must NOT recurse in that
+ * case, since the row is unchanged and would re-trigger the same expiry branch.
+ */
+async function expireTrialToFree(userId: string): Promise<boolean> {
+  const freeTierId = await getTierIdByName('free');
+  if (!freeTierId) {
+    logger.error({ userId }, 'expireTrialToFree: free tier not found in DB');
+    return false;
+  }
+
+  await db
+    .update(userSubscriptions)
+    .set({
+      status: 'expired',
+      tierId: freeTierId,
+      currentPeriodAnchorAt: new Date(),
+      updatedAt: new Date(),
+    })
+    .where(eq(userSubscriptions.userId, userId));
+
+  await blockScheduledTasksForUser(userId, 'trial_expired');
+
+  trackEventServer(
+    'trial_expired',
+    { trigger_source: 'lazy_quota_check' },
+    userId,
+  ).catch(err => logger.warn({ error: err, userId }, '[quota] trial_expired tracking failed'));
+
+  return true;
+}
+
+/**
+ * Demotes an expired promotion to the 'free' tier. Same contract as
+ * {@link expireTrialToFree}: returns `false` (without mutating the row) when the
+ * 'free' tier is missing, so the caller can avoid an infinite recursion.
+ */
+async function expirePromotionToFree(userId: string): Promise<boolean> {
+  const freeTierId = await getTierIdByName('free');
+  if (!freeTierId) {
+    logger.error({ userId }, 'expirePromotionToFree: free tier not found in DB');
+    return false;
+  }
+
+  logger.info({ userId }, 'quota: promotion period expired — downgrading to free');
+  await db
+    .update(userSubscriptions)
+    .set({
+      status: 'expired',
+      tierId: freeTierId,
+      currentPeriodAnchorAt: new Date(),
+      updatedAt: new Date(),
+    })
+    .where(eq(userSubscriptions.userId, userId));
+
+  await blockScheduledTasksForUser(userId, 'promotion_expired');
+
+  return true;
+}
+
+async function getTierIdByName(name: string): Promise<string | null> {
+  const rows = await db
+    .select({ id: subscriptionTiers.id })
+    .from(subscriptionTiers)
+    .where(eq(subscriptionTiers.name, name))
+    .limit(1);
+  return rows[0]?.id ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// decideQuota — pure: state + mode → QuotaDecision
+// ---------------------------------------------------------------------------
+
+function decideQuota(state: QuotaState, enforce: boolean): QuotaDecision {
+  const premiumPct = state.premiumLimit > 0 ? (state.premiumUsed / state.premiumLimit) * 100 : 0;
+  const fallbackPct = state.fallbackLimit > 0 ? (state.fallbackUsed / state.fallbackLimit) * 100 : 0;
+  const usagePct = {
+    premium: Math.round(premiumPct * 100) / 100,
+    fallback: Math.round(fallbackPct * 100) / 100,
+  };
+
+  // A pool is "usable" iff it has a positive period limit AND budget remains.
+  // A zero limit means the tier explicitly disables that pool — never treat that
+  // as "infinite budget available".
+  const premiumUsable
+    = state.premiumLimit > 0
+      && state.premiumUsed < state.premiumLimit
+      && state.premiumUnitKey !== null;
+  const fallbackUsable
+    = state.fallbackLimit > 0
+      && state.fallbackUsed < state.fallbackLimit;
+
+  // enforce:false short-circuits the gate but keeps premium-aware pool selection
+  // so background callers automatically downgrade to fallback when premium is
+  // exhausted.
+  const allowed = enforce ? (premiumUsable || fallbackUsable) : true;
+  const premiumExhausted = state.premiumLimit > 0 && state.premiumUsed >= state.premiumLimit;
+
+  if (!allowed) {
+    return {
+      allowed: false,
+      unitKey: state.fallbackUnitKey,
+      premiumUnitKey: state.premiumUnitKey,
+      usagePct,
+      resetsAt: state.resetsAt,
+    };
+  }
+
+  // Premium available — re-check premiumUnitKey !== null for TS narrowing.
+  if (premiumUsable && state.premiumUnitKey !== null) {
+    const warning: UsageWarning | undefined = premiumPct >= state.warningThresholdPct
+      ? { type: 'approaching_premium_limit', usage_pct: usagePct.premium, resets_at: state.resetsAt }
+      : undefined;
+    return {
+      allowed,
+      unitKey: state.premiumUnitKey,
+      premiumUnitKey: state.premiumUnitKey,
+      usagePct,
+      warning,
+      resetsAt: state.resetsAt,
+    };
+  }
+
+  // Premium exhausted (or tier has no premium pool) → fallback.
+  const downgrade: Downgrade | undefined
+    = (state.premiumLimit > 0 && premiumExhausted)
+      ? { reason: 'premium_exhausted', current_unit_key: state.fallbackUnitKey, resets_at: state.resetsAt }
+      : undefined;
+
+  return {
+    allowed,
+    unitKey: state.fallbackUnitKey,
+    premiumUnitKey: state.premiumUnitKey,
+    usagePct,
+    downgrade,
+    resetsAt: state.resetsAt,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolves which pool a user should draw from for a given resource type, and
+ * gates the call when `enforce: true`.
+ *
+ * - `enforce: true` (default) — full quota gate. `allowed` reflects actual
+ *   usage; emits a `quota_limit_reached` event when both pools are exhausted.
+ * - `enforce: false` — selection only. `allowed` is always `true`, no event is
+ *   emitted, but `unitKey` is still premium-aware (premium while budget remains,
+ *   fallback once exhausted, with `downgrade` populated). Use for best-effort
+ *   background calls.
+ *
+ * Missing subscription (should not happen — the signup trigger creates one) →
+ * falls back to the 'free' tier row. Reads `tier_quotas + resource_usage`,
+ * cached for 60s. Handles lazy trial / promotion expiry.
+ */
+export async function checkQuota(
+  user: User,
+  resourceType: string,
+  options?: { enforce?: boolean },
+): Promise<QuotaDecision> {
+  return checkQuotaByUserId(user.id, resourceType, options);
+}
+
+/**
+ * `checkQuota` variant for background callers (Inngest jobs, pipelines) that
+ * only have a `userId` string and not the full Supabase `User`.
+ */
+export async function checkQuotaByUserId(
+  userId: string,
+  resourceType: string,
+  options?: { enforce?: boolean },
+): Promise<QuotaDecision> {
+  const enforce = options?.enforce ?? true;
+  const state = await loadUserQuotaState(userId, resourceType);
+  const result = decideQuota(state, enforce);
+
+  // Only emit quota_limit_reached in enforce mode and only when the gate fires.
+  if (enforce && !result.allowed) {
+    trackEventServer(
+      'quota_limit_reached',
+      { resource_type: resourceType, tier_name: state.tierName },
+      userId,
+    ).catch(err => logger.warn({ error: err, userId }, '[quota] quota_limit_reached tracking failed'));
+  }
+
+  return result;
+}

--- a/src/libs/subscriptions/tier-display.ts
+++ b/src/libs/subscriptions/tier-display.ts
@@ -1,0 +1,20 @@
+/**
+ * Display-only tier constants — the SHAPE, not real product copy.
+ *
+ * This is a documented placeholder so the subscription UI's imports resolve.
+ * Each product REPLACES these values with its own pricing + feature copy.
+ *
+ * Prices here are DISPLAY-ONLY: the actual charge always uses the Stripe price id
+ * resolved server-side (see `subscription_tiers.stripe_price_id_*` and
+ * `createCheckoutSession`). Keeping a price constant here just lets the pricing
+ * grid render a number without an extra round-trip.
+ */
+
+export const PRO_MONTHLY_PRICE_CENTS = 0;
+export const PRO_YEARLY_PRICE_CENTS = 0;
+
+export const PRO_FEATURES = [
+  'Feature one',
+  'Feature two',
+  'Feature three',
+] as const;

--- a/src/libs/subscriptions/usage.test.ts
+++ b/src/libs/subscriptions/usage.test.ts
@@ -1,0 +1,171 @@
+// @vitest-environment node
+import * as Sentry from '@sentry/nextjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('@sentry/nextjs', () => ({
+  captureMessage: vi.fn(),
+}));
+
+vi.mock('@/libs/Logger', () => ({
+  logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// The recordUsage path runs:
+//   1. db.select(...).from(userSubscriptions).where(...).limit(1)   ← anchor lookup
+//   2. db.insert(resourceUsage).values(...).onConflictDoUpdate(...) ← the upsert we retry
+const mockInsertOnConflict = vi.fn();
+const mockInsertValues = vi.fn((..._a: unknown[]) => ({ onConflictDoUpdate: mockInsertOnConflict }));
+const mockInsert = vi.fn((..._a: unknown[]) => ({ values: mockInsertValues }));
+
+const mockSelectLimit = vi.fn();
+const mockSelectWhere = vi.fn((..._a: unknown[]) => ({ limit: mockSelectLimit }));
+const mockSelectFrom = vi.fn((..._a: unknown[]) => ({ where: mockSelectWhere }));
+const mockSelect = vi.fn((..._a: unknown[]) => ({ from: mockSelectFrom }));
+
+vi.mock('@/libs/DB', () => ({
+  db: {
+    select: (...args: unknown[]) => mockSelect(...args),
+    insert: (...args: unknown[]) => mockInsert(...args),
+  },
+}));
+
+vi.mock('@/models/Schema', () => ({
+  resourceUsage: {
+    userId: 'user_id',
+    resourceType: 'resource_type',
+    periodStart: 'period_start',
+    premiumUnitsUsed: 'premium_units_used',
+    fallbackUnitsUsed: 'fallback_units_used',
+  },
+  userSubscriptions: {
+    userId: 'user_id',
+    currentPeriodAnchorAt: 'current_period_anchor_at',
+    startedAt: 'started_at',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn((...args: unknown[]) => args),
+  eq: vi.fn((...args: unknown[]) => args),
+  inArray: vi.fn((...args: unknown[]) => args),
+  sql: Object.assign(
+    (strings: TemplateStringsArray, ...values: unknown[]) => ({ strings, values }),
+    {},
+  ),
+}));
+
+// Import after mocks
+const { recordUsage } = await import('./usage');
+
+const PREMIUM_KEY = 'premium-pool';
+
+function pgError(code: string): Error & { code: string } {
+  const err = new Error(`pg error ${code}`) as Error & { code: string };
+  err.code = code;
+  return err;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default: anchor lookup returns a usable date
+  mockSelectLimit.mockResolvedValue([{ currentPeriodAnchorAt: new Date('2026-01-01'), startedAt: new Date('2026-01-01') }]);
+});
+
+describe('recordUsage retry behavior', () => {
+  it('returns early without inserting when units <= 0', async () => {
+    await recordUsage('u1', 'generation', PREMIUM_KEY, 0, PREMIUM_KEY);
+
+    expect(mockInsert).not.toHaveBeenCalled();
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('succeeds on first attempt when upsert resolves', async () => {
+    mockInsertOnConflict.mockResolvedValueOnce(undefined);
+
+    await recordUsage('u1', 'generation', PREMIUM_KEY, 100, PREMIUM_KEY);
+
+    expect(mockInsertOnConflict).toHaveBeenCalledOnce();
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('retries once on transient 40P01 (deadlock_detected) and succeeds', async () => {
+    mockInsertOnConflict
+      .mockRejectedValueOnce(pgError('40P01'))
+      .mockResolvedValueOnce(undefined);
+
+    await recordUsage('u1', 'generation', PREMIUM_KEY, 100, PREMIUM_KEY);
+
+    expect(mockInsertOnConflict).toHaveBeenCalledTimes(2);
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('retries once on transient 40001 (serialization_failure) and succeeds', async () => {
+    mockInsertOnConflict
+      .mockRejectedValueOnce(pgError('40001'))
+      .mockResolvedValueOnce(undefined);
+
+    await recordUsage('u1', 'generation', PREMIUM_KEY, 100, PREMIUM_KEY);
+
+    expect(mockInsertOnConflict).toHaveBeenCalledTimes(2);
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('captures Sentry warning when transient errors persist across both attempts', async () => {
+    mockInsertOnConflict
+      .mockRejectedValueOnce(pgError('40P01'))
+      .mockRejectedValueOnce(pgError('40P01'));
+
+    // Must NOT throw — recordUsage swallows to keep the user request alive.
+    await expect(
+      recordUsage('u1', 'generation', PREMIUM_KEY, 100, PREMIUM_KEY),
+    ).resolves.toBeUndefined();
+
+    expect(mockInsertOnConflict).toHaveBeenCalledTimes(2);
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      'recordUsage failed after retry',
+      expect.objectContaining({
+        level: 'warning',
+        extra: expect.objectContaining({
+          userId: 'u1',
+          resourceType: 'generation',
+          errorCode: '40P01',
+        }),
+      }),
+    );
+  });
+
+  it('does NOT retry on non-transient errors (e.g. 23505 unique_violation) and emits Sentry warning', async () => {
+    mockInsertOnConflict.mockRejectedValueOnce(pgError('23505'));
+
+    await expect(
+      recordUsage('u1', 'generation', PREMIUM_KEY, 100, PREMIUM_KEY),
+    ).resolves.toBeUndefined();
+
+    expect(mockInsertOnConflict).toHaveBeenCalledTimes(1);
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      'recordUsage failed after retry',
+      expect.objectContaining({
+        level: 'warning',
+        extra: expect.objectContaining({ errorCode: '23505' }),
+      }),
+    );
+  });
+
+  it('does NOT retry on errors without a pg code (generic JS Error) and emits Sentry warning', async () => {
+    mockInsertOnConflict.mockRejectedValueOnce(new Error('boom'));
+
+    await expect(
+      recordUsage('u1', 'generation', PREMIUM_KEY, 100, PREMIUM_KEY),
+    ).resolves.toBeUndefined();
+
+    expect(mockInsertOnConflict).toHaveBeenCalledTimes(1);
+    expect(Sentry.captureMessage).toHaveBeenCalledOnce();
+  });
+});

--- a/src/libs/subscriptions/usage.ts
+++ b/src/libs/subscriptions/usage.ts
@@ -1,0 +1,230 @@
+import * as Sentry from '@sentry/nextjs';
+import { and, eq, inArray, sql } from 'drizzle-orm';
+
+import { db } from '@/libs/DB';
+import { logger } from '@/libs/Logger';
+import { resourceUsage, userSubscriptions } from '@/models/Schema';
+
+import { getCurrentPeriod, toDateString } from './period';
+import { invalidateQuotaCache } from './quota';
+
+// pg error codes treated as transient (worth one retry).
+//   40P01 = deadlock_detected
+//   40001 = serialization_failure
+const TRANSIENT_PG_CODES = new Set(['40P01', '40001']);
+
+async function withTransientRetry<T>(op: () => Promise<T>, attempts = 2): Promise<T> {
+  let lastErr: unknown;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return await op();
+    } catch (err) {
+      lastErr = err;
+      const code = (err as { code?: string } | null)?.code;
+      if (!code || !TRANSIENT_PG_CODES.has(code)) {
+        // Non-transient: stop immediately.
+        throw err;
+      }
+      // Transient: loop will retry up to `attempts` total times.
+    }
+  }
+  throw lastErr;
+}
+
+export type UsageRecord = {
+  premiumUnitsUsed: number;
+  fallbackUnitsUsed: number;
+  periodStart: string;
+  periodEnd: string;
+};
+
+/**
+ * Fetches the rolling-period anchor for a user. Falls back to NOW() if the row
+ * is missing (should be impossible — the signup trigger creates one).
+ */
+async function getPeriodAnchor(userId: string): Promise<Date> {
+  const rows = await db
+    .select({
+      currentPeriodAnchorAt: userSubscriptions.currentPeriodAnchorAt,
+      startedAt: userSubscriptions.startedAt,
+    })
+    .from(userSubscriptions)
+    .where(eq(userSubscriptions.userId, userId))
+    .limit(1);
+
+  return rows[0]?.currentPeriodAnchorAt ?? rows[0]?.startedAt ?? new Date();
+}
+
+/**
+ * Gets usage for a user+resource in the current rolling period.
+ * Returns a zeroed record if no row exists yet (first use this period).
+ */
+export async function getUsage(userId: string, resourceType: string): Promise<UsageRecord> {
+  const anchor = await getPeriodAnchor(userId);
+  const period = getCurrentPeriod(anchor);
+  const periodStartStr = toDateString(period.start);
+
+  const rows = await db
+    .select({
+      premiumUnitsUsed: resourceUsage.premiumUnitsUsed,
+      fallbackUnitsUsed: resourceUsage.fallbackUnitsUsed,
+      periodStart: resourceUsage.periodStart,
+      periodEnd: resourceUsage.periodEnd,
+    })
+    .from(resourceUsage)
+    .where(
+      and(
+        eq(resourceUsage.userId, userId),
+        eq(resourceUsage.resourceType, resourceType),
+        eq(resourceUsage.periodStart, periodStartStr),
+      ),
+    )
+    .limit(1);
+
+  if (rows.length === 0 || !rows[0]) {
+    return {
+      premiumUnitsUsed: 0,
+      fallbackUnitsUsed: 0,
+      periodStart: periodStartStr,
+      periodEnd: toDateString(period.end),
+    };
+  }
+
+  return rows[0];
+}
+
+/**
+ * Batched variant of {@link getUsage}: fetches usage for several resource types
+ * in a SINGLE query, and takes the period anchor as an argument instead of
+ * re-fetching it from `user_subscriptions`.
+ *
+ * Used by `getSubscriptionUsage`, which already holds the anchor and would
+ * otherwise issue one `getUsage` call per resource — each doing its own anchor
+ * lookup + its own usage select. This collapses those to 1. Resource types with
+ * no row this period are returned zeroed.
+ */
+export async function getUsageBatch(
+  userId: string,
+  resourceTypes: string[],
+  anchor: Date,
+): Promise<Map<string, UsageRecord>> {
+  const period = getCurrentPeriod(anchor);
+  const periodStartStr = toDateString(period.start);
+  const periodEndStr = toDateString(period.end);
+
+  const rows = await db
+    .select({
+      resourceType: resourceUsage.resourceType,
+      premiumUnitsUsed: resourceUsage.premiumUnitsUsed,
+      fallbackUnitsUsed: resourceUsage.fallbackUnitsUsed,
+      periodStart: resourceUsage.periodStart,
+      periodEnd: resourceUsage.periodEnd,
+    })
+    .from(resourceUsage)
+    .where(
+      and(
+        eq(resourceUsage.userId, userId),
+        inArray(resourceUsage.resourceType, resourceTypes),
+        eq(resourceUsage.periodStart, periodStartStr),
+      ),
+    );
+
+  const result = new Map<string, UsageRecord>();
+  for (const resourceType of resourceTypes) {
+    const row = rows.find(r => r.resourceType === resourceType);
+    result.set(resourceType, row
+      ? {
+          premiumUnitsUsed: row.premiumUnitsUsed,
+          fallbackUnitsUsed: row.fallbackUnitsUsed,
+          periodStart: row.periodStart,
+          periodEnd: row.periodEnd,
+        }
+      : {
+          premiumUnitsUsed: 0,
+          fallbackUnitsUsed: 0,
+          periodStart: periodStartStr,
+          periodEnd: periodEndStr,
+        });
+  }
+  return result;
+}
+
+/**
+ * Records units consumed after a quota-gated operation completes.
+ *
+ * Determines whether the consumed pool is premium or fallback by comparing
+ * `unitKey` against `premiumUnitKey` (passed from the checkQuota result).
+ * Uses an atomic upsert to avoid race conditions.
+ *
+ * @param userId - The authenticated user's ID
+ * @param resourceType - e.g. 'generation', 'api_call'
+ * @param unitKey - The pool that was actually used (from quotaResult.unitKey)
+ * @param units - The number of units consumed
+ * @param premiumUnitKey - The tier's premium pool key (null if the tier has none)
+ */
+export async function recordUsage(
+  userId: string,
+  resourceType: string,
+  unitKey: string,
+  units: number,
+  premiumUnitKey: string | null,
+): Promise<void> {
+  if (units <= 0) {
+    return;
+  }
+
+  const anchor = await getPeriodAnchor(userId);
+  const period = getCurrentPeriod(anchor);
+  const periodStartStr = toDateString(period.start);
+  const periodEndStr = toDateString(period.end);
+
+  const isPremium = premiumUnitKey !== null && unitKey === premiumUnitKey;
+
+  try {
+    await withTransientRetry(() =>
+      db
+        .insert(resourceUsage)
+        .values({
+          userId,
+          resourceType,
+          periodStart: periodStartStr,
+          periodEnd: periodEndStr,
+          premiumUnitsUsed: isPremium ? units : 0,
+          fallbackUnitsUsed: isPremium ? 0 : units,
+        })
+        .onConflictDoUpdate({
+          target: [resourceUsage.userId, resourceUsage.resourceType, resourceUsage.periodStart],
+          set: {
+            premiumUnitsUsed: isPremium
+              ? sql`${resourceUsage.premiumUnitsUsed} + ${units}`
+              : resourceUsage.premiumUnitsUsed,
+            fallbackUnitsUsed: isPremium
+              ? resourceUsage.fallbackUnitsUsed
+              : sql`${resourceUsage.fallbackUnitsUsed} + ${units}`,
+            updatedAt: sql`NOW()`,
+          },
+        }),
+    );
+
+    // The quota cache is keyed by (user, resourceType) and holds usage counts for
+    // up to CACHE_TTL_MS (60s). Without this, a checkQuota immediately after a
+    // recordUsage would read the stale pre-write counts for the rest of that
+    // window — a stale-window over-spend. Invalidate only on a successful write
+    // (on failure the cached counts are still accurate — nothing was recorded).
+    invalidateQuotaCache(userId, resourceType);
+  } catch (error) {
+    // Usage recording is best-effort — log but don't throw (don't fail the
+    // user's request). We still warn Sentry so we can spot if transient pg
+    // errors become persistent.
+    const errorCode = (error as { code?: string } | null)?.code;
+    logger.error(
+      { error, userId, resourceType, unitKey, units, errorCode },
+      'recordUsage: failed to record usage after retry',
+    );
+    Sentry.captureMessage('recordUsage failed after retry', {
+      level: 'warning',
+      user: { id: userId },
+      extra: { userId, resourceType, unitKey, units, errorCode },
+    });
+  }
+}

--- a/src/models/Schema.test.ts
+++ b/src/models/Schema.test.ts
@@ -615,4 +615,156 @@ describe('Database Schema Tests', () => {
       expect(job1Index).toBeLessThan(job2Index);
     });
   });
+
+  describe('subscription tables', () => {
+    // Helper: seed a tier and return its id.
+    async function createTier(
+      name: string,
+      overrides: Partial<typeof schema.subscriptionTiers.$inferInsert> = {},
+    ): Promise<string> {
+      const [tier] = await testDb
+        .insert(schema.subscriptionTiers)
+        .values({ name, displayName: name.toUpperCase(), ...overrides })
+        .returning();
+      return tier!.id;
+    }
+
+    it('creates a subscription_tiers row with the documented column shape', async () => {
+      const [tier] = await testDb
+        .insert(schema.subscriptionTiers)
+        .values({
+          name: 'free-shape',
+          displayName: 'Free',
+          description: 'Starter plan',
+          priceCents: null,
+          stripePriceIdMonthly: null,
+          stripePriceIdYearly: null,
+        })
+        .returning();
+
+      expect(tier).toBeDefined();
+      expect(tier!.name).toBe('free-shape');
+      expect(tier!.isActive).toBe(true);
+      expect(tier!.sortOrder).toBe(0);
+      expect(tier!.priceCents).toBeNull();
+      expect(tier!.createdAt).toBeInstanceOf(Date);
+    });
+
+    it('enforces the unique tier name constraint', async () => {
+      await createTier('dup-tier');
+
+      await expect(createTier('dup-tier')).rejects.toThrow();
+    });
+
+    it('stores the user_subscriptions status + billing_interval text unions', async () => {
+      const tierId = await createTier('pro-subs');
+      const userId = '550e8400-e29b-41d4-a716-446655440100';
+
+      const [sub] = await testDb
+        .insert(schema.userSubscriptions)
+        .values({
+          userId,
+          tierId,
+          status: 'trial',
+          billingInterval: 'monthly',
+          hasTrialed: true,
+        })
+        .returning();
+
+      expect(sub).toBeDefined();
+      expect(sub!.status).toBe('trial');
+      expect(sub!.billingInterval).toBe('monthly');
+      expect(sub!.hasTrialed).toBe(true);
+      // The union values are exported for the CHECK guard in prod-setup.sql.
+      expect(schema.userSubscriptionStatusEnum).toContain('trial');
+      expect(schema.billingIntervalEnum).toContain('yearly');
+    });
+
+    it('enforces the unique user_id constraint on user_subscriptions', async () => {
+      const tierId = await createTier('uniq-user-tier');
+      const userId = '550e8400-e29b-41d4-a716-446655440101';
+
+      await testDb.insert(schema.userSubscriptions).values({ userId, tierId });
+
+      await expect(
+        testDb.insert(schema.userSubscriptions).values({ userId, tierId }),
+      ).rejects.toThrow();
+    });
+
+    it('stores tier_quotas as a two-pool config with generic unit keys', async () => {
+      const tierId = await createTier('quota-tier');
+
+      const [quota] = await testDb
+        .insert(schema.tierQuotas)
+        .values({
+          tierId,
+          resourceType: 'generation',
+          premiumUnitKey: 'premium-pool',
+          premiumPeriodLimit: 1000,
+          fallbackUnitKey: 'fallback-pool',
+          fallbackPeriodLimit: 500,
+        })
+        .returning();
+
+      expect(quota).toBeDefined();
+      expect(quota!.premiumUnitKey).toBe('premium-pool');
+      expect(quota!.fallbackUnitKey).toBe('fallback-pool');
+      expect(quota!.warningThresholdPct).toBe(90);
+    });
+
+    it('cascade-deletes tier_quotas when the tier is removed', async () => {
+      const tierId = await createTier('cascade-tier');
+      await testDb.insert(schema.tierQuotas).values({
+        tierId,
+        resourceType: 'generation',
+        fallbackUnitKey: 'fallback-pool',
+        fallbackPeriodLimit: 100,
+      });
+
+      await testDb.delete(schema.subscriptionTiers).where(eq(schema.subscriptionTiers.id, tierId));
+
+      const remaining = await testDb
+        .select()
+        .from(schema.tierQuotas)
+        .where(eq(schema.tierQuotas.tierId, tierId));
+
+      expect(remaining).toHaveLength(0);
+    });
+
+    it('tracks resource_usage units per (user, resource, period)', async () => {
+      const userId = '550e8400-e29b-41d4-a716-446655440102';
+
+      const [usage] = await testDb
+        .insert(schema.resourceUsage)
+        .values({
+          userId,
+          resourceType: 'generation',
+          periodStart: '2026-06-01',
+          periodEnd: '2026-06-08',
+          premiumUnitsUsed: 10,
+          fallbackUnitsUsed: 5,
+        })
+        .returning();
+
+      expect(usage).toBeDefined();
+      expect(usage!.premiumUnitsUsed).toBe(10);
+      expect(usage!.fallbackUnitsUsed).toBe(5);
+    });
+
+    it('enforces the unique (user, resource, period_start) constraint on resource_usage', async () => {
+      const userId = '550e8400-e29b-41d4-a716-446655440103';
+      const row = {
+        userId,
+        resourceType: 'generation',
+        periodStart: '2026-06-01',
+        periodEnd: '2026-06-08',
+      };
+
+      await testDb.insert(schema.resourceUsage).values(row);
+
+      await expect(
+        testDb.insert(schema.resourceUsage).values(row),
+      ).rejects.toThrow();
+    });
+  });
 });

--- a/src/models/schema/index.ts
+++ b/src/models/schema/index.ts
@@ -6,10 +6,29 @@ export { adminAuditLog } from './audit';
 export { feedback, feedbackStatusEnum, feedbackTypeEnum } from './feedback';
 export { platformConnections } from './platform-connections';
 export { userPreferences } from './preferences';
+export type { InsertResourceUsage, ResourceUsage } from './resource-usage';
+export { resourceUsage } from './resource-usage';
 export type { InsertScheduledTask, ScheduledTaskRow } from './scheduled-tasks';
 export { scheduledTasks, scheduledTaskStatusEnum } from './scheduled-tasks';
 export { shareableLinks } from './share-links';
+export type { InsertStripeWebhookEvent, StripeWebhookEvent } from './stripe-webhook-events';
+export { stripeWebhookEvents } from './stripe-webhook-events';
+export type { InsertSubscriptionTier, SubscriptionTier } from './subscription-tiers';
+export { subscriptionTiers } from './subscription-tiers';
 export { threads } from './threads';
+export type { InsertTierQuota, TierQuota } from './tier-quotas';
+export { tierQuotas } from './tier-quotas';
+export type {
+  BillingInterval,
+  InsertUserSubscription,
+  UserSubscription,
+  UserSubscriptionStatus,
+} from './user-subscriptions';
+export {
+  billingIntervalEnum,
+  userSubscriptions,
+  userSubscriptionStatusEnum,
+} from './user-subscriptions';
 export {
   mem0Memories,
   memoryExtractionJobs,

--- a/src/models/schema/resource-usage.ts
+++ b/src/models/schema/resource-usage.ts
@@ -1,0 +1,40 @@
+import { bigint, date, index, text, timestamp, unique, uuid } from 'drizzle-orm/pg-core';
+
+import { vtSaasSchema } from './_db-schema';
+
+/**
+ * Rolling-period usage ledger for the quota framework. One row per
+ * `(user, resource_type, period_start)`, tracking units drawn from each of the
+ * two pools defined in `tier_quotas` (see that table for the two-pool model).
+ *
+ * Units are generic integers (tokens, API calls, generations, …) — the column
+ * names are pool-agnostic on purpose. Server-only: usage is recorded by trusted
+ * server code, so this table has RLS ON with no policy in prod-setup.sql. The
+ * cross-schema FK (user_id -> auth.users) is added in prod-setup.sql.
+ */
+export const resourceUsage = vtSaasSchema.table(
+  'resource_usage',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    // user_id references auth.users(id) ON DELETE CASCADE — cross-schema FK added
+    // in supabase/prod-setup.sql.
+    userId: uuid('user_id').notNull(),
+    resourceType: text('resource_type').notNull(), // e.g. 'generation', 'api_call'
+    periodStart: date('period_start').notNull(),
+    periodEnd: date('period_end').notNull(),
+    premiumUnitsUsed: bigint('premium_units_used', { mode: 'number' }).notNull().default(0),
+    fallbackUnitsUsed: bigint('fallback_units_used', { mode: 'number' }).notNull().default(0),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  table => ({
+    userResourcePeriodUnique: unique('resource_usage_user_resource_period_unique')
+      .on(table.userId, table.resourceType, table.periodStart),
+    userIdIdx: index('idx_resource_usage_user_id').on(table.userId),
+    userResourcePeriodIdx: index('idx_resource_usage_user_resource_period')
+      .on(table.userId, table.resourceType, table.periodStart),
+  }),
+);
+
+export type ResourceUsage = typeof resourceUsage.$inferSelect;
+export type InsertResourceUsage = typeof resourceUsage.$inferInsert;

--- a/src/models/schema/stripe-webhook-events.ts
+++ b/src/models/schema/stripe-webhook-events.ts
@@ -1,0 +1,32 @@
+import { text, timestamp } from 'drizzle-orm/pg-core';
+
+import { vtSaasSchema } from './_db-schema';
+
+/**
+ * Idempotency ledger for the Stripe webhook (`/api/stripe/webhook`).
+ *
+ * On a non-2xx response Stripe retries the SAME `event.id`. The DB status writes
+ * the webhook performs are idempotent, but its side effects are NOT — the
+ * `subscription_converted` analytics event and the started/ended lifecycle emails
+ * would double-fire on every retry. The webhook records each `event.id` here
+ * exactly once (insert ... ON CONFLICT DO NOTHING) before doing anything else,
+ * and short-circuits when the row already existed, so side effects fire only on
+ * the first-seen delivery.
+ *
+ * Server-only: written by the trusted webhook handler. RLS is ON with no policy
+ * in prod-setup.sql (service role bypasses RLS), so it is not reachable over the
+ * REST API. No FK to auth.users — keyed solely by Stripe's event id.
+ */
+export const stripeWebhookEvents = vtSaasSchema.table(
+  'stripe_webhook_events',
+  {
+    // Stripe's `event.id` (e.g. "evt_..."), globally unique — used as the PK so a
+    // retried delivery conflicts on insert.
+    eventId: text('event_id').primaryKey(),
+    eventType: text('event_type').notNull(),
+    processedAt: timestamp('processed_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+);
+
+export type StripeWebhookEvent = typeof stripeWebhookEvents.$inferSelect;
+export type InsertStripeWebhookEvent = typeof stripeWebhookEvents.$inferInsert;

--- a/src/models/schema/subscription-tiers.ts
+++ b/src/models/schema/subscription-tiers.ts
@@ -1,0 +1,37 @@
+import { boolean, index, integer, text, timestamp, unique, uuid } from 'drizzle-orm/pg-core';
+
+import { vtSaasSchema } from './_db-schema';
+
+/**
+ * Per-tier plan catalogue. A lookup table read by every signed-in user (the
+ * pricing grid + the quota resolver), so it gets a read-only RLS policy in
+ * prod-setup.sql.
+ *
+ * `name` is a stable slug used in code branches (e.g. the free-tier safety net
+ * and the trial trigger). Generic placeholders: `'free'`, `'pro'`, and the
+ * optional admin-granted `'promotion'`. A product keeps these slugs and fills in
+ * its own `display_name` / `description` / Stripe price ids via seed.sql.
+ */
+export const subscriptionTiers = vtSaasSchema.table(
+  'subscription_tiers',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    name: text('name').notNull(), // slug: 'free' | 'pro' | 'promotion'
+    displayName: text('display_name').notNull(),
+    description: text('description'),
+    priceCents: integer('price_cents'), // nullable — free/promotion have no listed price
+    stripePriceIdMonthly: text('stripe_price_id_monthly'), // nullable — free/promotion have no Stripe product
+    stripePriceIdYearly: text('stripe_price_id_yearly'), // nullable — free/promotion have no Stripe product
+    isActive: boolean('is_active').notNull().default(true),
+    sortOrder: integer('sort_order').notNull().default(0),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  table => ({
+    nameIdx: unique('subscription_tiers_name_unique').on(table.name),
+    sortOrderIdx: index('idx_subscription_tiers_sort_order').on(table.sortOrder),
+  }),
+);
+
+export type SubscriptionTier = typeof subscriptionTiers.$inferSelect;
+export type InsertSubscriptionTier = typeof subscriptionTiers.$inferInsert;

--- a/src/models/schema/tier-quotas.ts
+++ b/src/models/schema/tier-quotas.ts
@@ -1,0 +1,50 @@
+import { bigint, index, integer, text, timestamp, unique, uuid } from 'drizzle-orm/pg-core';
+
+import { vtSaasSchema } from './_db-schema';
+import { subscriptionTiers } from './subscription-tiers';
+
+/**
+ * Per-tier resource limits backing the quota framework.
+ *
+ * GENERIC TWO-POOL METERING MODEL. Each `(tier, resource_type)` row defines two
+ * pools that a request draws from in order:
+ *   - `premium`  — the preferred pool, used while budget remains
+ *     (`premium_units_used < premium_period_limit`).
+ *   - `fallback` — the always-configured pool used once premium is exhausted.
+ *
+ * `premiumUnitKey` / `fallbackUnitKey` are opaque labels for what each pool
+ * meters — the framework never interprets them. A product mapping this to AI
+ * models simply sets the keys to model ids (e.g. premium = `gpt-4o`,
+ * fallback = `gpt-4o-mini`); a product metering API calls sets them to
+ * `metered` / `rate_limited`, etc. Units are generic integers (tokens, calls,
+ * generations, …) — see `resource_usage`.
+ *
+ * A pool with a zero `period_limit` is explicitly disabled for that tier (never
+ * "infinite budget"); `premiumUnitKey` is nullable so a tier can omit the
+ * premium pool entirely and run fallback-only.
+ */
+export const tierQuotas = vtSaasSchema.table(
+  'tier_quotas',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    tierId: uuid('tier_id')
+      .notNull()
+      .references(() => subscriptionTiers.id, { onDelete: 'cascade' }),
+    resourceType: text('resource_type').notNull(), // e.g. 'generation', 'api_call'
+    premiumUnitKey: text('premium_unit_key'), // null = no premium pool for this tier
+    premiumPeriodLimit: bigint('premium_period_limit', { mode: 'number' }).notNull().default(0),
+    fallbackUnitKey: text('fallback_unit_key').notNull(),
+    fallbackPeriodLimit: bigint('fallback_period_limit', { mode: 'number' }).notNull(),
+    warningThresholdPct: integer('warning_threshold_pct').notNull().default(90),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  table => ({
+    tierResourceUnique: unique('tier_quotas_tier_resource_unique').on(table.tierId, table.resourceType),
+    tierIdIdx: index('idx_tier_quotas_tier_id').on(table.tierId),
+    tierResourceIdx: index('idx_tier_quotas_tier_resource').on(table.tierId, table.resourceType),
+  }),
+);
+
+export type TierQuota = typeof tierQuotas.$inferSelect;
+export type InsertTierQuota = typeof tierQuotas.$inferInsert;

--- a/src/models/schema/user-subscriptions.ts
+++ b/src/models/schema/user-subscriptions.ts
@@ -1,0 +1,60 @@
+import { boolean, index, text, timestamp, unique, uuid } from 'drizzle-orm/pg-core';
+
+import { vtSaasSchema } from './_db-schema';
+import { subscriptionTiers } from './subscription-tiers';
+
+// Status + billing-interval unions are stored as plain `text` (TS-side $type<>),
+// NOT pg enums — prod-setup.sql adds a CHECK guard for each. This keeps the table
+// migration-portable without an `ALTER TYPE ... ADD VALUE` dance when a fork adds
+// a status. The cross-schema FK (user_id -> auth.users) is added in prod-setup.sql.
+export const userSubscriptionStatusEnum = ['active', 'trial', 'expired', 'cancelled'] as const;
+export type UserSubscriptionStatus = typeof userSubscriptionStatusEnum[number];
+
+export const billingIntervalEnum = ['monthly', 'yearly'] as const;
+export type BillingInterval = typeof billingIntervalEnum[number];
+
+/**
+ * Per-user subscription state + lifecycle anchors. One row per user (created by
+ * the signup trigger in prod-setup.sql). The spine the quota/Stripe/cron code
+ * reads and writes.
+ */
+export const userSubscriptions = vtSaasSchema.table(
+  'user_subscriptions',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    // user_id references auth.users(id) ON DELETE CASCADE — cross-schema FK added
+    // in supabase/prod-setup.sql (Drizzle can't express it).
+    userId: uuid('user_id').notNull(),
+    tierId: uuid('tier_id')
+      .notNull()
+      .references(() => subscriptionTiers.id),
+    status: text('status')
+      .$type<UserSubscriptionStatus>()
+      .notNull()
+      .default('active'),
+    billingInterval: text('billing_interval').$type<BillingInterval>(),
+    hasTrialed: boolean('has_trialed').notNull().default(false),
+    trialExpiresAt: timestamp('trial_expires_at', { withTimezone: true }),
+    stripeSubscriptionId: text('stripe_subscription_id'),
+    stripeCustomerId: text('stripe_customer_id'),
+    startedAt: timestamp('started_at', { withTimezone: true }).defaultNow().notNull(),
+    // Anchor for the rolling quota window — reset on every tier transition so a
+    // user's first period after upgrading begins at the moment of upgrade.
+    currentPeriodAnchorAt: timestamp('current_period_anchor_at', { withTimezone: true }),
+    expiresAt: timestamp('expires_at', { withTimezone: true }),
+    // 12h-idempotency markers for the expiry-warning cron (trial vs promotion).
+    lastTrialWarningSentAt: timestamp('last_trial_warning_sent_at', { withTimezone: true }),
+    lastPromotionWarningSentAt: timestamp('last_promotion_warning_sent_at', { withTimezone: true }),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  table => ({
+    userIdUnique: unique('user_subscriptions_user_id_unique').on(table.userId),
+    userIdIdx: index('idx_user_subscriptions_user_id').on(table.userId),
+    tierIdIdx: index('idx_user_subscriptions_tier_id').on(table.tierId),
+    statusIdx: index('idx_user_subscriptions_status').on(table.status),
+  }),
+);
+
+export type UserSubscription = typeof userSubscriptions.$inferSelect;
+export type InsertUserSubscription = typeof userSubscriptions.$inferInsert;

--- a/supabase/prod-setup.sql
+++ b/supabase/prod-setup.sql
@@ -3,7 +3,11 @@
 --
 -- Execution order for a fresh environment:
 --   1. npm run db:migrate            (creates the schema + tables)
---   2. psql -f supabase/seed.sql     (optional dev/lookup seed data)
+--   2. psql -f supabase/seed.sql     (lookup seed data — REQUIRED before step 3
+--                                     if you enable the reverse-trial trigger:
+--                                     it RAISEs without the seeded subscription
+--                                     tiers; the quota framework also needs the
+--                                     'free' tier + its quota row)
 --   3. psql -f supabase/prod-setup.sql  (this file — grants, trigger, FKs, RLS, CHECKs, updated_at)
 --
 -- This file contains Supabase-specific constructs that Drizzle ORM cannot manage:
@@ -68,6 +72,72 @@ DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
 CREATE TRIGGER on_auth_user_created
   AFTER INSERT ON auth.users
   FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();
+
+-- ---- subscription enrollment (one row per user) ----
+-- Auto-create a user_subscriptions row on signup so the quota framework always
+-- finds one. REQUIRES supabase/seed.sql to have inserted the subscription tiers
+-- first (this function RAISEs otherwise). Two coexisting AFTER INSERT triggers on
+-- auth.users (this + on_auth_user_created above) is fine.
+--
+-- DEFAULT (safe-by-default): enroll every new user on the FREE tier — no trial,
+-- no card. This is what ships uncommented.
+CREATE OR REPLACE FUNCTION public.handle_new_user_subscription()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER SET search_path = ''
+AS $$
+DECLARE
+  free_tier_id uuid;
+BEGIN
+  SELECT id INTO free_tier_id FROM "vt_saas"."subscription_tiers" WHERE name = 'free';
+  IF free_tier_id IS NULL THEN
+    RAISE EXCEPTION 'handle_new_user_subscription: free tier not seeded (run supabase/seed.sql first)';
+  END IF;
+
+  INSERT INTO "vt_saas"."user_subscriptions" (user_id, tier_id, status, started_at, current_period_anchor_at, created_at, updated_at)
+  VALUES (NEW.id, free_tier_id, 'active', NOW(), NOW(), NOW(), NOW())
+  ON CONFLICT (user_id) DO NOTHING;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS on_auth_user_created_subscription ON auth.users;
+CREATE TRIGGER on_auth_user_created_subscription
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION public.handle_new_user_subscription();
+
+-- ---- OPT-IN reverse-trial variant ----
+-- To enroll every new user in an N-day trial on the PRO tier (no card),
+-- REPLACE the function body above with the version below, then re-run this file.
+-- This changes product behaviour (every signup gets Pro for free), so it is
+-- opt-in and ships commented out.
+--
+-- ⚠️ DUAL-SOURCE CAVEAT: the trial length lives in TWO places — the
+-- `INTERVAL '14 days'` literal below AND the TS `TRIAL_DAYS` env var (which gates
+-- the expiry crons). Keep them in sync. Also flip `ENABLE_REVERSE_TRIAL=true` so
+-- the force-expire + expiry-warning crons run. See docs/subscriptions.md.
+--
+-- CREATE OR REPLACE FUNCTION public.handle_new_user_subscription()
+-- RETURNS TRIGGER
+-- LANGUAGE plpgsql
+-- SECURITY DEFINER SET search_path = ''
+-- AS $$
+-- DECLARE
+--   pro_tier_id uuid;
+-- BEGIN
+--   SELECT id INTO pro_tier_id FROM "vt_saas"."subscription_tiers" WHERE name = 'pro';
+--   IF pro_tier_id IS NULL THEN
+--     RAISE EXCEPTION 'handle_new_user_subscription: pro tier not seeded (run supabase/seed.sql first)';
+--   END IF;
+--
+--   INSERT INTO "vt_saas"."user_subscriptions"
+--     (user_id, tier_id, status, has_trialed, trial_expires_at, started_at, current_period_anchor_at, created_at, updated_at)
+--   VALUES
+--     (NEW.id, pro_tier_id, 'trial', true, NOW() + INTERVAL '14 days', NOW(), NOW(), NOW(), NOW())  -- set 14 to TRIAL_DAYS
+--   ON CONFLICT (user_id) DO NOTHING;
+--   RETURN NEW;
+-- END;
+-- $$;
 
 -- ============================================================
 -- 3. CROSS-SCHEMA FOREIGN KEYS
@@ -200,6 +270,33 @@ DO $$ BEGIN
   ) THEN
     ALTER TABLE "vt_saas"."scheduled_tasks"
       ADD CONSTRAINT fk_scheduled_tasks_auth_users
+      FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+  END IF;
+END $$;
+
+-- user_subscriptions: one row per user. CASCADE so a deleted user's subscription
+-- row is removed. (tier_id -> subscription_tiers is an intra-schema FK Drizzle
+-- already created in the migration.)
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_schema = 'vt_saas' AND constraint_name = 'fk_user_subscriptions_auth_users'
+  ) THEN
+    ALTER TABLE "vt_saas"."user_subscriptions"
+      ADD CONSTRAINT fk_user_subscriptions_auth_users
+      FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+  END IF;
+END $$;
+
+-- resource_usage: per-user usage ledger. CASCADE so a deleted user's usage rows
+-- don't linger.
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_schema = 'vt_saas' AND constraint_name = 'fk_resource_usage_auth_users'
+  ) THEN
+    ALTER TABLE "vt_saas"."resource_usage"
+      ADD CONSTRAINT fk_resource_usage_auth_users
       FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
   END IF;
 END $$;
@@ -348,8 +445,46 @@ ALTER TABLE "vt_saas"."memory_extraction_jobs" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "vt_saas"."scheduled_tasks" ENABLE ROW LEVEL SECURITY;
 -- (intentionally no CREATE POLICY — server-only)
 
+-- ---- subscription_tiers ----
+-- Lookup/catalogue table every signed-in user may read but not write (the
+-- pricing grid + quota resolver read it). Writes are server-only.
+ALTER TABLE "vt_saas"."subscription_tiers" ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "subscription_tiers_select_authenticated" ON "vt_saas"."subscription_tiers";
+CREATE POLICY "subscription_tiers_select_authenticated" ON "vt_saas"."subscription_tiers"
+  FOR SELECT USING (auth.role() = 'authenticated');
+
+-- ---- tier_quotas ----
+-- Lookup table (per-tier quota config). Same read-only-for-authenticated rule.
+ALTER TABLE "vt_saas"."tier_quotas" ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "tier_quotas_select_authenticated" ON "vt_saas"."tier_quotas";
+CREATE POLICY "tier_quotas_select_authenticated" ON "vt_saas"."tier_quotas"
+  FOR SELECT USING (auth.role() = 'authenticated');
+
+-- ---- user_subscriptions ----
+-- Users read their own row. No INSERT/UPDATE policy: rows are created by the
+-- signup trigger above and only ever mutated by server code (the Stripe webhook,
+-- the expiry crons, the lazy-expiry path) via the service role.
+ALTER TABLE "vt_saas"."user_subscriptions" ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "user_subscriptions_select_own" ON "vt_saas"."user_subscriptions";
+CREATE POLICY "user_subscriptions_select_own" ON "vt_saas"."user_subscriptions"
+  FOR SELECT USING (auth.uid() = user_id);
+
+-- ---- resource_usage ----
+-- Server-only usage ledger: recorded by trusted server code only. RLS ON + no
+-- policy denies all anon/authenticated REST access (service role bypasses RLS).
+ALTER TABLE "vt_saas"."resource_usage" ENABLE ROW LEVEL SECURITY;
+-- (intentionally no CREATE POLICY — server-only)
+
+-- ---- stripe_webhook_events ----
+-- Server-only Stripe webhook idempotency ledger: written only by the webhook
+-- handler. RLS ON + no policy denies all anon/authenticated REST access (service
+-- role bypasses RLS).
+ALTER TABLE "vt_saas"."stripe_webhook_events" ENABLE ROW LEVEL SECURITY;
+-- (intentionally no CREATE POLICY — server-only)
+
 -- Variant — authenticated read-only lookup table (uncomment + adapt for a
--- reference table every signed-in user may read but not write):
+-- reference table every signed-in user may read but not write — see the
+-- subscription_tiers / tier_quotas blocks above for a live example):
 -- ALTER TABLE "vt_saas"."<lookup_table>" ENABLE ROW LEVEL SECURITY;
 -- DROP POLICY IF EXISTS "<lookup_table>_select_authenticated" ON "vt_saas"."<lookup_table>";
 -- CREATE POLICY "<lookup_table>_select_authenticated" ON "vt_saas"."<lookup_table>"
@@ -379,6 +514,32 @@ ALTER TABLE "vt_saas"."scheduled_tasks" ENABLE ROW LEVEL SECURITY;
 --       CHECK (my_status IN ('pending', 'reviewed', 'archived'));
 --   END IF;
 -- END $$;
+
+-- LIVE EXAMPLE: user_subscriptions.status and .billing_interval are text columns
+-- with TS-side $type<> unions only (NOT pg enums — see
+-- src/models/schema/user-subscriptions.ts), so the DB needs CHECKs to enforce them.
+-- Keep the value lists in sync with userSubscriptionStatusEnum / billingIntervalEnum.
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_schema = 'vt_saas' AND constraint_name = 'user_subscriptions_status_check'
+  ) THEN
+    ALTER TABLE "vt_saas"."user_subscriptions"
+      ADD CONSTRAINT user_subscriptions_status_check
+      CHECK (status IN ('active', 'trial', 'expired', 'cancelled'));
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_schema = 'vt_saas' AND constraint_name = 'user_subscriptions_billing_interval_check'
+  ) THEN
+    ALTER TABLE "vt_saas"."user_subscriptions"
+      ADD CONSTRAINT user_subscriptions_billing_interval_check
+      CHECK (billing_interval IS NULL OR billing_interval IN ('monthly', 'yearly'));
+  END IF;
+END $$;
 
 -- ============================================================
 -- 6. UPDATED_AT TRIGGER

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,16 +1,57 @@
 -- Seed data
 -- Runs after `db:migrate` on a fresh environment, or via `supabase db reset`.
 --
--- This file is intentionally empty in the template. Add dev fixtures or lookup
--- rows (reference tables, default plans, etc.) here. Keep every insert idempotent
--- with `ON CONFLICT ... DO NOTHING` so the file is safe to re-run.
+-- Keep every insert idempotent with `ON CONFLICT ... DO NOTHING` so the file is
+-- safe to re-run.
 --
--- See docs/database-workflow.md for the fresh-environment application order and
--- where each kind of change belongs (the "three-home" model).
+-- ⚠️ EXECUTION ORDER: this file MUST run BEFORE supabase/prod-setup.sql. The
+-- reverse-trial signup trigger (in prod-setup.sql, opt-in) RAISEs if the tiers
+-- below aren't seeded, and the quota framework's free-tier safety net throws if
+-- the 'free' tier + its quota row is missing. See docs/database-workflow.md for
+-- the fresh-environment application order.
+--
+-- See docs/subscriptions.md for the subscription subsystem these rows back.
 
--- Example (uncomment + adapt to a real table):
---
--- INSERT INTO "vt_saas"."<lookup_table>" (id, name)
--- VALUES
---   (gen_random_uuid(), 'example')
--- ON CONFLICT (name) DO NOTHING;
+-- ============================================================
+-- Subscription tiers (generic catalogue — replace copy + Stripe ids per product)
+-- ============================================================
+-- Slugs ('free' / 'pro' / 'promotion') are stable and referenced in code; the
+-- display_name / description / price_cents / stripe_price_id_* values are
+-- placeholders a product fills in. Prices here are display-only — the real charge
+-- uses the Stripe price id resolved server-side.
+
+INSERT INTO "vt_saas"."subscription_tiers"
+  (name, display_name, description, price_cents, stripe_price_id_monthly, stripe_price_id_yearly, is_active, sort_order)
+VALUES
+  ('free',      'Free',      'Starter plan',           0,    NULL, NULL, true, 0),
+  ('pro',       'Pro',       'Full-access paid plan',  0,    NULL, NULL, true, 1),
+  ('promotion', 'Promotion', 'Admin-granted access',   NULL, NULL, NULL, true, 2)
+ON CONFLICT (name) DO NOTHING;
+
+-- ============================================================
+-- Tier quotas (one generic 'generation' resource per tier)
+-- ============================================================
+-- The two-pool model (premium-then-fallback). Unit keys are opaque labels —
+-- a product maps them to whatever it meters (AI model ids, rate-limit buckets).
+-- A zero period limit disables a pool for that tier.
+--   free:      no premium pool, modest fallback budget
+--   pro:       generous premium pool + larger fallback budget
+--   promotion: mirrors pro (admin-granted full access)
+
+INSERT INTO "vt_saas"."tier_quotas"
+  (tier_id, resource_type, premium_unit_key, premium_period_limit, fallback_unit_key, fallback_period_limit, warning_threshold_pct)
+SELECT id, 'generation', NULL, 0, 'fallback', 100, 90
+FROM "vt_saas"."subscription_tiers" WHERE name = 'free'
+ON CONFLICT (tier_id, resource_type) DO NOTHING;
+
+INSERT INTO "vt_saas"."tier_quotas"
+  (tier_id, resource_type, premium_unit_key, premium_period_limit, fallback_unit_key, fallback_period_limit, warning_threshold_pct)
+SELECT id, 'generation', 'premium', 1000, 'fallback', 2000, 90
+FROM "vt_saas"."subscription_tiers" WHERE name = 'pro'
+ON CONFLICT (tier_id, resource_type) DO NOTHING;
+
+INSERT INTO "vt_saas"."tier_quotas"
+  (tier_id, resource_type, premium_unit_key, premium_period_limit, fallback_unit_key, fallback_period_limit, warning_threshold_pct)
+SELECT id, 'generation', 'premium', 1000, 'fallback', 2000, 90
+FROM "vt_saas"."subscription_tiers" WHERE name = 'promotion'
+ON CONFLICT (tier_id, resource_type) DO NOTHING;


### PR DESCRIPTION
## What

Adds the entire subscription/billing subsystem to the template — it had **none** (no `stripe` dep, no subscription tables, no billing routes). Ported and generalized from ContentFlow (its reference implementation), stripping all product specifics. Reverse-trial ships as a **config-gated, opt-in policy** layered on top, not a separate feature.

This is a large, coherent subsystem. It is sub-batched for review (see commits): **schema+quota → stripe+billing → reverse-trial crons → UI+emails → docs**.

### Subsystem
- **Schema (4 tables):** `subscription_tiers`, `user_subscriptions`, `tier_quotas`, `resource_usage` as new `src/models/schema/*` modules under `vtSaasSchema`. Drizzle-generated migration; cross-schema FKs + RLS + CHECK guards in `prod-setup.sql`; generic free/pro(/promotion) seed rows.
- **Quota framework:** generic two-pool metering (`premium`/`fallback` **units**, not AI tokens), rolling-period anchor math, usage recording with transient-error (deadlock/serialization) retry, 60s cache + invalidation, lazy trial/promotion expiry. AI-model coupling removed — products map unit keys to whatever they meter.
- **Stripe:** lazy client + webhook for `checkout.session.completed`, `invoice.paid`, `customer.subscription.{updated,deleted}` (price→tier mapping, period-anchor reset on trial→active, cancel_at handling, downgrade-to-free). Checkout + billing-portal server actions returning `ActionResult<T>`.
- **Reverse-trial (opt-in):** signup trigger enrolls users in an N-day Pro trial → daily force-expire cron demotes + blocks tasks → lazy-expiry on quota reads. Gated by `ENABLE_REVERSE_TRIAL` (TS) + `TRIAL_DAYS`, with the prod-setup trigger independently opt-in.
- **Blocking helper:** transitions a downgraded user's pending tasks to `blocked` using the template's existing `scheduled_tasks` table (`status`+free-text `blocked_reason`) — the documented use of that status.
- **UI:** pure/tested display logic (expiry-countdown banner, trial pill, plan-gate upsell, current-plan/tier cards) — copy + tier names replaced with props/placeholders.
- **Emails:** lifecycle templates (T-3/day-of/T+1 expiry, Pro started/ended, promotion granted) built on the Wave-2 email system — copy stripped to props (`tierName`, `trialDays`).
- **Docs:** `docs/subscriptions.md` end-to-end reference; `.env.example` + Env keys for Stripe + reverse-trial.

## Integration notes
- Uses the template's `@/libs/DB` Drizzle query client (the template, unlike ContentFlow, has not adopted a supabase-js-only query rule), the existing `withActionAuth` HOF + `ActionResult`, `getStripe()` lazy-singleton style, the Wave-2 email primitives, and the type-safe analytics taxonomy (extended `EventName`/`EventPropertiesMap` with generic subscription events; the template's `trackEventServer` is 3-arg, so CF's `personSet` arg was dropped).
- Stripe webhook uses Stripe's own `constructEvent` signature verification — intentionally **not** routed through `withWebhookSecret` (different mechanism).

## New dependency
- `stripe` (client is lazy + all Env keys optional → unconfigured forks are unaffected).

## Depends on
- `contrib/inngest-job-patterns` (status+blocked_reason convention) on main.
- Wave-2 email system (already on main).

## Policy defaults (confirm before merge)
- `TRIAL_DAYS` value and whether `ENABLE_REVERSE_TRIAL` ships on or off (recommend **off** so a fresh fork is safe-by-default; trial is explicit opt-in).

## Sync-down caveat
ContentFlow is the origin of this code; the template version is intentionally renamed/generalized (`vt_saas` schema, `QuotaDecision`, generic `units`, generic blocking helper). ContentFlow must **not** blindly pull these renames back on its next upstream sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
