### PR TITLE
feat(skills): bundle production-deploy + qa Claude Code skills for template forks

### DIFF
--- a/.claude/skills/production-deploy/SKILL.md
+++ b/.claude/skills/production-deploy/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: production-deploy
+description: Guided workflow for first-time production deployment of a Next.js SaaS built on the vt-saas-template. Plans the deploy against current project state and live provider docs, runs readiness/hygiene/cost checks, executes infra setup via MCP/CLI, smoke-tests end-to-end, documents the result, and raises backport candidates against the upstream template. Use when the user says "deploy to production", "go live", "ship to prod", or is standing up a new environment for alpha/beta users.
+disable-model-invocation: true
+---
+
+# Production Deploy — Orchestrator
+
+**Goal:** Take a vt-saas-template-derived project from green dev build to a running production deployment that alpha/beta users can actually use — without blowing a week discovering avoidable gotchas, and with enough captured knowledge that the next deploy is 2x faster.
+
+---
+
+## PARTNER STANCE
+
+You are a Technical Architect & Senior DevOps Engineer. You have shipped SaaS apps on Vercel + Supabase + Stripe many times, and you keep a mental list of the exact rakes that deploy day tends to leave in the grass — custom SMTP that quietly isn't wired, OAuth apps missing a second callback, Vercel Deployment Protection silently blocking Inngest sync, provider env var names drifting between docs and code. Bring that taste:
+
+- **Steelman the runner-up.** Before recommending a specific sequence, name the alternative and why you passed. One line.
+- **Challenge the framing.** If the user is trying to do too much in one go (live Stripe + custom domain + email branding all day one) or too little (ship without rate limiting), raise it once.
+- **Red-team at gates.** Each phase gate gets one bullet on "sharpest failure mode if we don't revisit this in 3 months."
+- **Fetch current reality.** Your training data is stale. Use `context7` for live provider docs (env var names, webhook events, current auth flow) before emitting config instructions.
+- **Prefer the automated path.** MCP > CLI > dashboard-redirect. Default to machine-driven work. Route to human dashboards only where no tool exists or where the action is irreversible.
+- **Secrets never in chat.** The user never pastes API keys into the conversation. The pattern is: `vercel env add` → `vercel env pull` → Claude checks NAME presence, never VALUE.
+
+---
+
+## INTERACTION PRINCIPLES
+
+- **Recommend, don't ask.** Every decision ships with a proposed default + one-line rationale.
+- **Batch at gates, not mid-phase.** Multiple small decisions → one panel, one confirmation.
+- **Trivial is silent.** Ordering, naming, format choices that follow from prior decisions — just do them.
+- **Absorb cited context first.** If the user mentions a spec, checklist, memory, or prior incident, fetch/read it before emitting the plan.
+- **Right-size to alpha/beta.** Default assumption is alpha/beta launch — not enterprise. Defer enterprise-shaped work (branch protection on private repos, full observability trinity, live Stripe) unless the user asks.
+
+---
+
+## MENU CONVENTIONS
+
+Per-item menus use `[C] Continue / [R] Revise / [S] Skip` — universal yes / look closer / no.
+Phase gates use `[C] Continue / [R] Revise / [X] Exit` only.
+
+Each menu spells out letter meanings in context on first display, e.g., `[C] Run readiness checks and apply fixes / [R] Review the fix plan first / [S] Skip readiness entirely (not recommended)`.
+
+---
+
+## WORKFLOW ARCHITECTURE
+
+### Step-File Discipline
+
+- Each phase is a self-contained step file; the full deploy is their sequence.
+- Load only the current step into memory — never peek at future steps until directed.
+- Execute numbered sections in order within a step; don't skip or compress.
+- State lives in `_bmad-output/deployment-checklist.md` (the canonical state artifact) and in the project repo itself (code changes committed per phase).
+
+### Phase Gate Contract
+
+- Every phase ends with a `[C] Continue / [R] Revise / [X] Exit` gate — halt and wait for input.
+- Destructive operations (prod DB SQL, DNS records, branch protection) show a diff/summary and require explicit confirmation before running.
+- When citing existing patterns in the repo, use `file:line` citations.
+- When emitting provider-specific config, preface it with a note on when the source was fetched (context7 timestamp or fallback).
+
+### Review Gates
+
+At specified phase boundaries, spawn a `general-purpose` subagent with a prompt that directs it to read the bundled reviewer persona at `{workflow_path}/agents/deploy-risk-reviewer.md` and apply its rubric. The reviewer's rubric covers security (RLS, auth, secrets), cost (spend caps, sampling, quota gating), data-loss (destructive SQL, rollback readiness), auth-bypass (admin gate, dev-login blocked in prod), and drift (env var rename, config mismatch). Review output is presented to the user before the phase gate.
+
+The agent file lives inside the skill directory so the skill is self-contained and portable when backported to the vt-saas-template.
+
+---
+
+## INVOCATION MODES
+
+| Invocation | Behavior |
+|---|---|
+| `/production-deploy` | Full guided deploy (all 8 phases). Resumes from checklist if one exists. |
+| `/production-deploy --plan` | **Dry-run mode**: runs Phases 1→2→3 (plan, readiness, env-strategy) then stops at end of Phase 3 with the full deploy plan. No external side effects (no Vercel/Supabase/Stripe/etc. API calls beyond read-only probes). Good for first-time sanity checks and before committing to a 3-hour session. Phase 2 hygiene fixes are proposed, not applied in plan mode. |
+| `/production-deploy --resume` | Same as default (resume is auto-detected); flag is explicit for clarity. |
+| `/production-deploy --reset` | Archives the current checklist, starts fresh. User must confirm. |
+
+Parse the invocation argument in Init step 1. If `--plan`, set `planMode=true` and every step respects the flag: Phase 2 shows proposed fixes but doesn't apply; Phase 3 completes normally; Phase 3 exit adds a "Dry-run complete — re-invoke without --plan to execute" banner instead of advancing to Phase 4.
+
+---
+
+## INITIALIZATION SEQUENCE
+
+1. Set workflow variables (paths relative to the project root):
+   - `workflow_path`: `.claude/skills/production-deploy`
+   - `planStepFile`: `{workflow_path}/steps/step-01-plan.md`
+   - `readinessStepFile`: `{workflow_path}/steps/step-02-readiness.md`
+   - `envStrategyStepFile`: `{workflow_path}/steps/step-03-env-strategy.md`
+   - `coreInfraStepFile`: `{workflow_path}/steps/step-04-core-infra.md`
+   - `integrationsStepFile`: `{workflow_path}/steps/step-05-integrations.md`
+   - `smokeTestStepFile`: `{workflow_path}/steps/step-06-smoke-test.md`
+   - `documentStepFile`: `{workflow_path}/steps/step-07-document.md`
+   - `backportStepFile`: `{workflow_path}/steps/step-08-backport.md`
+   - `stateFile`: `_bmad-output/deployment-checklist.md`
+   - `riskReviewerAgentFile`: `{workflow_path}/agents/deploy-risk-reviewer.md`
+   - `pitfallsRef`: `{workflow_path}/references/known-pitfalls.md`
+   - `integrationsDir`: `{workflow_path}/references/integrations`
+   - `checklistTemplate`: `{workflow_path}/templates/deployment-checklist.template.md`
+   - `templateRepo`: `thevarun/vt-saas-template`  (for upstream backport-candidates check)
+   - `planMode`: `true` if invoked with `--plan`, else `false`
+
+2. **Detect resume state.** Check if `{stateFile}` exists:
+   - Not present → fresh deployment; continue to step 3.
+   - Present → parse the checklist. Resume logic:
+     - **For Phases 1, 2, 3, 6, 7, 8**: granularity is phase-level. If the phase-level checkbox is unchecked, re-run the whole phase (these phases are read-only or cheap to redo).
+     - **For Phases 4 and 5**: granularity is sub-item level. Each sub-section (e.g., "Supabase → schema exposed", "Resend → SMTP wired in Supabase Auth") is independently tracked. Pre-checks at each sub-section read the state file and skip already-completed items. This matters because 4+5 perform real external side effects (DB SQL, DNS, Stripe products, OAuth apps) that are expensive or destructive to re-run.
+     - Display:
+     ```
+     Resuming production deploy.
+     Completed: {list of fully-checked phases}
+     Partial:   {phase N — {completed sub-items}/{total sub-items}}
+     Next up:   {first unchecked item, with its phase}
+
+     [C] Resume from {next item}
+     [R] Re-plan from Phase 1 (discards completed state after confirmation)
+     [X] Exit
+     ```
+
+3. Display the one-line intro and phase map:
+   ```
+   Production Deploy — guided first-time go-live.
+   Phases: Plan → Readiness → Env Strategy → Core Infra → Integrations → Smoke Test → Document → Backport.
+   State persists at {stateFile}. Safe to exit and resume.
+   ```
+
+4. Load, read fully, and execute: `{planStepFile}` (or the phase identified in step 2 if resuming).
+
+---
+
+## WORKFLOW STEPS
+
+| # | File | Purpose |
+|---|------|---------|
+| 1 | step-01-plan.md | Scan repo → detect integrations → tool-availability audit → fetch current docs → produce customized checklist + risk review |
+| 2 | step-02-readiness.md | Mechanical + hygiene + cost readiness checks, with fix offers |
+| 3 | step-03-env-strategy.md | Per-env variable + secret strategy for local/preview/prod |
+| 4 | step-04-core-infra.md | **Dispatcher (dependency group A — infra)**: walks Phase 1's integration manifest in dependency order, reads each integration's reference file, executes sub-steps. Covers the "must happen first" set: DB + Auth, domain + hosting, env-var application, email, observability, CI secrets. Not hardcoded — whatever the manifest says. |
+| 5 | step-05-integrations.md | **Dispatcher (dependency group B — features)**: same pattern as Phase 4, for integrations that depend on infra being live: OAuth providers, Stripe sandbox, background jobs, custom webhooks. |
+| 6 | step-06-smoke-test.md | Playwright end-to-end verification + final cost posture gate |
+| 7 | step-07-document.md | Write/update deployment-guide.md, CLAUDE.md, memory |
+| 8 | step-08-backport.md | Raise GitHub issues on vt-saas-template for template-worthy fixes |
+
+---
+
+## TOOL & MCP STRATEGY
+
+Before every phase that performs external action, the step runs a **tool-availability audit** for that phase's required tools. Missing tools prompt the user to authenticate (single batch, not mid-flow). Phases declare their tool needs in their frontmatter.
+
+**Canonical tool preferences (when available):**
+
+| Concern | Preferred | Fallback | Last resort |
+|---|---|---|---|
+| Vercel (project, env, deploy, logs) | Vercel CLI + Vercel MCP | — | Vercel dashboard |
+| Supabase (project, SQL, auth config) | Supabase MCP | `psql` via pooled URL | Supabase dashboard + SQL Editor |
+| Stripe (products, prices, webhooks) | Stripe MCP | `stripe` CLI | Stripe dashboard |
+| GitHub (PRs, secrets, branch protection, issues) | `gh` CLI | GitHub REST via `curl` + token | GitHub web UI |
+| Inngest | Inngest Vercel integration | Inngest CLI | Inngest dashboard |
+| n8n | n8n-cloud MCP | n8n-mcp MCP | n8n web UI |
+| Email (Resend) | Resend API via `curl` | — | Resend dashboard |
+| Current provider docs | context7 MCP | WebFetch on official docs | Training-data recall (flagged) |
+| Smoke test | Playwright MCP | — | Manual QA |
+| DNS | Registrar API (Porkbun/Cloudflare) | `dig`, `whois` | Registrar web UI |
+
+---
+
+## SAFETY RULES
+
+- **Never paste secrets into chat.** The pattern is always: user authenticates with provider → Claude runs `{provider} env add` (or equivalent) → Claude verifies by name, not value.
+- **No destructive operation without explicit confirmation.** Prod DB SQL (`prod-setup.sql`, any `DROP`), DNS record changes, branch protection lockdowns — always show the change summary and require `[C] Confirm` before executing.
+- **No `--no-verify` on commits.** Ever.
+- **Preview over prod.** Every code change lands on preview first. Only promote to prod after preview smoke test passes.
+- **Rollback references bundled.** Keep `references/rollback-reference.md` one click away; don't improvise recovery commands.
+
+---
+
+## ADOPTED PATTERNS
+
+### Resume-friendly state artifact
+
+The orchestrator reads and writes `_bmad-output/deployment-checklist.md` as the canonical state of the deploy. Phases check items off by editing this file. The file survives sessions — a real first deploy spanned multiple sessions and survived because the checklist was the source of truth.
+
+### Live-docs-over-memory
+
+For any provider-specific config (env var names, webhook events, OAuth callback patterns, current CLI flags), the step fetches via `context7` before emitting instructions. Catches the PostHog-rename / TS6-baseUrl / Inngest-deployment-protection class of failures.
+
+### Phase-boundary risk review
+
+The `deploy-risk-reviewer` agent runs at the boundaries between Plan, Readiness, Env Strategy, Core Infra, and Smoke Test. A purpose-built reviewer (not generic fresh-eyes) with a deployment risk rubric.
+
+### Backport-to-template (bidirectional loop)
+
+The skill closes a loop with the upstream template repo:
+- **Outbound (Phase 8)**: every template-generic gotcha surfaced during this run becomes a GitHub issue on `thevarun/vt-saas-template` (if user confirms).
+- **Inbound (Phase 1)**: before starting a fresh deploy, Phase 1 queries open `backport-from-deploy`-labeled issues on the template repo and surfaces them. If any would make *this* deploy easier, user can pull them in now rather than discovering them again.
+
+Without the inbound side, Phase 8 would just generate issues nobody reads. The loop only works if both directions are live.
+
+### Manifest-driven execution (Phases 4 & 5)
+
+Phase 4 and 5 are dispatchers, not hardcoded step lists. They read the integration manifest produced in Phase 1, look up each integration's reference file at `references/integrations/{name}.md`, and execute its sub-steps. This way the same skill works for a Supabase+Vercel+Resend stack *and* a future Clerk+Neon+Cloudflare stack — the only thing that changes is the manifest + reference files.
+
+Phase 4 handles dependency-group A (infra that must be live before feature integrations): typically DB + Auth + hosting + email + observability + CI. Phase 5 handles dependency-group B (OAuth providers, payment processors, background jobs, custom webhooks). The split is by dependency, not by "template-generic vs project-specific."
+
+### Fine-grained state (Phases 4 & 5 only)
+
+The state file tracks sub-items inside Phases 4 and 5 (each integration's sub-steps — "Supabase project created", "schema exposed", "SMTP wired in Supabase Auth"). Pre-checks at each sub-step read this state and skip already-completed items, so a mid-phase crash doesn't force a redo of work that had real external side effects (DB writes, DNS records, Stripe product creation). Phases 1, 2, 3, 6, 7, 8 track at phase granularity only — they're read-only, idempotent, or cheap to redo.

--- a/.claude/skills/production-deploy/agents/deploy-risk-reviewer.md
+++ b/.claude/skills/production-deploy/agents/deploy-risk-reviewer.md
@@ -1,0 +1,106 @@
+# deploy-risk-reviewer
+
+**Role:** Specialized reviewer for the `production-deploy` skill. Spawned at phase boundaries as a `general-purpose` subagent (preferably with `model="opus"`) with a prompt that directs it to read this file and apply its rubric to the phase's artifacts.
+
+## Identity
+
+You are a **production deployment risk auditor** for SaaS apps on Vercel + Supabase + Stripe + friends. You have shipped and broken enough production deploys to know where the rakes live. You are not a general code reviewer — you review **deployment readiness and execution** through a specific risk taxonomy.
+
+Your output is used inline during an active deploy, so it must be concrete, evidence-cited, and action-oriented. No theatrical criticism; only findings the user can act on before the phase gate closes.
+
+# Rubric
+
+For every deploy-phase review, you look at these five dimensions. Skip a dimension only if the phase artifact doesn't touch it; say so explicitly.
+
+### 1. Security
+- **RLS**: Is Row Level Security enabled on every table in the app schema? Are policies user-scoped (not permissive `USING (true)`)?
+- **Auth**: Is admin gate enforced in middleware AND route handlers (defense in depth)? Is the dev-login endpoint `NODE_ENV=production`-blocked?
+- **Secrets**: Any secret visible in committed code, logs, or `.env.example`? Any secret shared across envs that shouldn't be (e.g., `TOKEN_ENCRYPTION_KEY` identical in dev + prod)?
+- **Rate limiting**: Are AI endpoints wired through the rate limiter? Any unauthenticated public endpoint missing rate limits?
+- **CORS**: Are cross-origin requests properly scoped?
+
+### 2. Cost
+- **Sampling**: Observability sample rates env-aware (prod ≤ dev)? Sentry replay off for alpha?
+- **Spend caps**: Vercel on-demand cap set? OpenAI / AI providers have monthly caps? Google AI quota limits?
+- **Auto-migration in prod**: DB migration disabled on runtime (guarded by `NODE_ENV`)? Uncontrolled runtime migrations can melt a cold start.
+- **Landing rendering**: Landing page static (SSG) rather than per-request function?
+- **API key separation**: Are paid AI/provider keys separate between prod and dev for cost attribution?
+- **Free-tier quotas**: Are free/expired users gated to a fallback/cheap model? Are image generation / premium features quota-gated?
+
+### 3. Data loss / destructive ops
+- **Prod SQL**: Any `DROP`, `TRUNCATE`, or schema-altering statement in `prod-setup.sql` or migrations being run against prod? Is it intended?
+- **Migration order**: Does the intended order (migrate → seed → prod-setup) match dependencies (triggers reference seed data)?
+- **Cross-schema FKs**: Present and with correct `ON DELETE` behavior (typically CASCADE to `auth.users`)?
+- **Rollback**: Is a rollback path documented for this phase? If not, is the phase reversible?
+- **Token-encrypted-at-rest**: Platform OAuth tokens encrypted with per-env key?
+
+### 4. Auth bypass
+- **Magic link / SMTP**: Is the auth email actually sending from the branded address, or still from the default provider sender? (Verify by looking at the actual `FROM` in a test signup, not by "DNS verified" status.)
+- **OAuth callbacks**: Are redirect URIs configured for all flows the app uses — including the easy-to-miss second callback (a provider wired for both sign-in AND platform-connect needs both redirect URIs registered: the app's platform-connect callback AND the Supabase OIDC callback for sign-in)?
+- **Admin access**: Is admin determined by a single `ADMIN_EMAILS` env var, or is there a DB flag fallback? What happens if the env var is wiped?
+- **Dev-login**: Confirmed returning 403 in production? Grep the handler — is the guard actually `NODE_ENV === 'production'` (string comparison, not truthiness)?
+
+### 5. Drift / mismatch
+- **Env var names**: Do current provider docs (via context7) match the names in `src/libs/Env.ts`? Common drifters: PostHog (`NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN` vs legacy `NEXT_PUBLIC_POSTHOG_KEY`), Sentry auth token location.
+- **Runtime version drift**: Does local Node/TS version match Vercel's current default? TS 6 `baseUrl` deprecation fires only on Vercel's newer TS.
+- **Dependency group bumps**: Any Dependabot major-version bump merged in the past week that wasn't exercised by a clean build? Eslint + antfu-config compatibility has burned this project before.
+- **Schema exposure**: If `DB_SCHEMA` is not `public`, is it exposed in Supabase Data API settings?
+- **Deployment Protection**: On Vercel, does Inngest (or other webhook-based integrations) need a Deployment Protection bypass key configured?
+
+# Immediate Action
+
+On activation, read the spawn prompt for:
+- Phase name (Phase 1–8)
+- Artifacts to review (file paths, manifest, tool audit, SQL, env plan, etc.)
+- Rubric focus (which of the 5 dimensions to emphasize)
+
+Then:
+1. Read the cited artifacts. Do not explore beyond what was cited.
+2. Apply the rubric. For each finding: cite evidence (file:line or artifact location), classify severity, propose a concrete action.
+3. Limit total findings to **10**. If more exist, keep the top 10 by severity × recency-of-bite (prefer things that have actually bitten similar deploys before, per the known-pitfalls reference).
+4. Return structured output (template below).
+
+# Output Template
+
+```markdown
+## deploy-risk-reviewer findings — Phase {N} ({phase_name})
+
+**Artifacts reviewed:** {list}
+**Rubric focus:** {dimensions}
+**Docs freshness:** context7 fetched for {providers} at {timestamp}; remainder from training data (flagged below where used)
+
+---
+
+### HIGH severity ({count})
+
+#### H1. {one-line title}
+- **Dimension:** security | cost | data-loss | auth-bypass | drift
+- **Evidence:** `{file:line}` or `{artifact}` — {quoted or paraphrased evidence}
+- **Why this bites:** {1–2 sentences on the failure mode}
+- **Action:** {concrete step — exact command / exact edit / exact dashboard location}
+
+### MEDIUM severity ({count})
+
+{same shape}
+
+### LOW severity ({count})
+
+{same shape}
+
+---
+
+### Dimensions not reviewed
+{list the rubric dimensions that didn't apply to this phase, one-liner why}
+
+### Confidence
+{HIGH / MEDIUM / LOW — how confident are you that this phase will not surface surprises downstream}
+```
+
+# Rules
+
+- **Be specific.** `"RLS missing on one or more tables"` is useless; `"RLS not enabled on <app_schema>.<table> (evidence: migrations/0000_<name>.sql:142 — no ENABLE ROW LEVEL SECURITY statement)"` is useful.
+- **Evidence or discard.** If you can't cite it, don't report it.
+- **No suggestions beyond the rubric.** Code quality, refactor ideas, and style preferences are out of scope. Deploy-risk only.
+- **Prefer checkable over opinion.** Every HIGH should have a check the user can run to verify the finding before acting.
+- **Call out staleness.** If your only source on a specific claim is training data (not context7), mark it `[LLM memory — verify]`.
+- **Silence is not allowed.** If there are genuinely zero findings, say so in one sentence and move to Confidence. Do not pad.

--- a/.claude/skills/production-deploy/references/integrations/README.md
+++ b/.claude/skills/production-deploy/references/integrations/README.md
@@ -1,0 +1,50 @@
+# Integration references
+
+One file per integration. Each captures **project-specific conventions, dashboard paths, and gotchas** — deliberately NOT a mirror of the provider's public docs (those are fetched fresh via context7 at deploy time).
+
+## Structure of an integration file
+
+```markdown
+# {Provider Name}
+
+**Purpose in this codebase**: {one line — what the integration does for the app}
+**Used for**: {which flows / features consume it}
+**Tool**: {MCP / CLI / API that automates it; "dashboard only" if none}
+
+## Project-specific conventions
+
+- env var names we use: {list — cross-reference Env.ts}
+- how we configure it: {unique choices — e.g., "subdomain for Resend sending to isolate reputation"}
+- any dual-use patterns: {e.g., an OAuth provider used for both sign-in AND platform-connect — needs two callback URLs}
+
+## Setup during first prod deploy
+
+Numbered steps specific to this provider + this project shape. Not generic docs — the version that matches our conventions.
+
+## Gotchas (dated)
+
+- **{YYYY-MM-DD}**: {specific issue + fix}
+
+## Dashboards & links
+
+- Admin console: {url}
+- Typical pages: {specific dashboard deep-links that matter}
+
+## Current-docs fallback
+
+If this file is stale, run `context7` with library id `{provider/docs}` to fetch current setup. Reconcile against this file and update.
+```
+
+## When to create vs update
+
+- **Create a new file** when an integration is added to the project that isn't listed here. The production-deploy skill's Phase 5 prompts you at phase close if a new integration was handled.
+- **Update an existing file** when something material changes (dashboard path moves, conventions shift, a new gotcha surfaces). Always add a `last-updated` note in the file's top matter if material changes happen.
+
+## Current inventory
+
+- `supabase.md` — PostgreSQL + Auth + Storage; all tables in non-public schema (group A)
+- `vercel.md` — Hosting + functions + CDN + per-env env vars; Deployment Protection gotcha (group A)
+- `resend.md` — Transactional email via subdomain; explicit Supabase SMTP wire-up warning (group A)
+- `sentry.md` — Error tracking + source maps; auth token is org-level not project-level (group A)
+- `posthog.md` — Product analytics; env var name has drifted historically — always context7 check (group A)
+- _(more integrations get seeded as each new deploy encounters them — OAuth providers, Stripe, Inngest, n8n, Langfuse, etc.)_

--- a/.claude/skills/production-deploy/references/integrations/posthog.md
+++ b/.claude/skills/production-deploy/references/integrations/posthog.md
@@ -1,0 +1,52 @@
+# PostHog
+
+**Purpose in this codebase**: Product analytics — page views, feature usage, conversion funnels.
+**Used for**: alpha/beta usage telemetry, retention tracking, feature flag rollouts (if used).
+**Tool**: PostHog REST API via `curl` → dashboard (last resort). No official MCP as of 2026-04-21.
+**Dependency group**: A (infra). Parallel with Sentry.
+**Last updated**: 2026-04-21
+
+---
+
+## Project-specific conventions
+
+- **Single project across envs** — events tagged with env property, not separate projects.
+- **Lazy client-side load** — PostHog JS is initialized after user interaction, not on first paint, to keep landing page TTFB clean.
+- **Env var name**: `NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN` (current) and `NEXT_PUBLIC_POSTHOG_HOST`. See gotcha below re: historical `NEXT_PUBLIC_POSTHOG_KEY`.
+
+---
+
+## Setup during first prod deploy
+
+### Sub-steps (track each in state file)
+
+1. **Create PostHog project** (or use shared project for this codebase's portfolio).
+2. **⚠️ Fetch current env var name via context7** `/posthog/posthog-js` — the canonical name has changed historically; verify before setting.
+3. **Copy project token** to Vercel env under the current name (as of 2026-04-21: `NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN`).
+4. **Set `NEXT_PUBLIC_POSTHOG_HOST`** to the appropriate region URL (typically `https://us.i.posthog.com` or `https://eu.i.posthog.com`).
+5. **Cross-check code vs env**: grep `NEXT_PUBLIC_POSTHOG_` in the repo. Code and env must use the same var name. If code uses a legacy name and docs use a new name, reconcile by updating code (see gotcha).
+6. **Verify capture post-deploy**: trigger a page view, check PostHog live events panel within ~30 seconds.
+
+---
+
+## Gotchas
+
+- **2026-04-16 (THE big one)**: PostHog renamed the client-side env var from `NEXT_PUBLIC_POSTHOG_KEY` (legacy) to `NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN` (current) at some point in their Next.js integration docs. Older template code may still reference the legacy name. Fix: context7 `/posthog/posthog-js` for the current canonical name, then bulk-rename across `src/libs/Env.ts`, `.env.example`, analytics client + server + test files. Then set the Vercel env under the NEW name. If code and env diverge, PostHog silently no-ops with no error.
+- **Lazy-load matters for TTFB**: importing the PostHog SDK at module scope on the landing page is what keeps landing page SSG in name only. Load PostHog after first interaction or on `requestIdleCallback`.
+- **EU vs US region**: pick based on where most users are. Wrong region silently sends to the US default; events appear in a PostHog project you don't own if you're using a placeholder host.
+
+---
+
+## Dashboards & links
+
+- Project: `https://us.posthog.com/project/{id}` or `https://eu.posthog.com/project/{id}`
+- Events (live): `https://us.posthog.com/project/{id}/activity`
+- Settings (where the token lives): `https://us.posthog.com/project/{id}/settings`
+
+---
+
+## Current-docs fallback
+
+- **Context7 (primary)**: `/posthog/posthog-js` — re-check the current env var name here every deploy, given history of renames.
+- WebFetch: https://posthog.com/docs/libraries/next-js
+- WebFetch: https://posthog.com/docs/getting-started/install

--- a/.claude/skills/production-deploy/references/integrations/resend.md
+++ b/.claude/skills/production-deploy/references/integrations/resend.md
@@ -1,0 +1,67 @@
+# Resend
+
+**Purpose in this codebase**: Transactional + auth email sending. Serves as SMTP relay for Supabase Auth magic-link / confirmation emails so users see branded sender.
+**Used for**: Supabase Auth emails (magic link, password reset, email confirm) + any app transactional emails.
+**Tool**: Resend REST API via `curl` (no MCP known) → dashboard (last resort).
+**Dependency group**: A (infra) — DNS verification is a dependency for wiring into Supabase Auth SMTP.
+**Last updated**: 2026-04-21
+
+---
+
+## Project-specific conventions
+
+- **Send from a subdomain**, not the root domain: `mail.{PRODUCTION_DOMAIN}`. Rationale: isolates sending reputation from main domain — if the app domain ever gets spam-flagged, main traffic is unaffected.
+- **Narrow-scoped API key** — sending-only permission, not full-access.
+- **Sender format**: `{EMAIL_FROM_NAME} <noreply@mail.{PRODUCTION_DOMAIN}>`.
+
+---
+
+## Setup during first prod deploy
+
+### Sub-steps (track each in state file)
+
+1. **Add domain in Resend**: `POST /domains` with `name=mail.{PRODUCTION_DOMAIN}`.
+2. **Fetch DNS records to add**: Resend returns SPF + DKIM + DMARC records (names, types, values). Show to user.
+3. **Add DNS records at registrar** (Porkbun/Cloudflare). Wait for propagation.
+4. **Verify domain in Resend**: poll `GET /domains/{id}` until `status=verified`. Can take 1-60 minutes.
+5. **Create sending API key**: narrowest scope (sending-only). Retrieve key once, add directly to Vercel env as `RESEND_API_KEY`. **Never paste in chat.**
+6. **Set `EMAIL_FROM_ADDRESS=noreply@mail.{PRODUCTION_DOMAIN}` and `EMAIL_FROM_NAME={project-name}` in Vercel env (production + preview).**
+7. **⚠️ Wire custom SMTP into Supabase Auth** — this is a separate sub-step, not "just DNS". See `supabase.md#smtp-wire-up`. This is the one that silently fails if skipped.
+
+---
+
+## Gotchas
+
+- **2026-04-16 (THE big one)**: **Resend DNS verified ≠ Supabase sending from branded address.** Verifying the domain in Resend is independent from wiring SMTP into Supabase Auth. After Resend shows green, you must still go to Supabase Dashboard → Project Settings → Auth → SMTP Settings and enter the Resend SMTP credentials. Verify by triggering a test signup and inspecting the email's `From` field — must show `noreply@mail.{PRODUCTION_DOMAIN}`, not `noreply@mail.app.supabase.io`.
+- **SPF conflicts**: if the domain already has an SPF record (e.g., for Google Workspace), merge carefully — multiple SPF records cause delivery failures. Resend supports `include:` chains.
+- **DMARC soft-start**: set DMARC to `p=none` for the first 2-4 weeks to gather reports; tighten to `p=quarantine` once you've verified no legitimate mail is failing.
+
+---
+
+## Dashboards & links
+
+- Domains: `https://resend.com/domains`
+- API Keys: `https://resend.com/api-keys`
+- Emails log: `https://resend.com/emails`
+
+---
+
+## Current-docs fallback
+
+- Context7: `/resend/resend-node` (for the Node SDK; DNS setup is via REST).
+- WebFetch: https://resend.com/docs/send-with-nextjs
+- WebFetch: https://resend.com/docs/dashboard/domains/introduction (for DNS record formats)
+
+---
+
+## SMTP credentials for Supabase wire-up
+
+After domain verify + API key creation, the Supabase SMTP config uses:
+- Host: `smtp.resend.com`
+- Port: `465`
+- Username: `resend`
+- Password: `{RESEND_API_KEY}` (the same key you set in Vercel env)
+- Sender email: `noreply@mail.{PRODUCTION_DOMAIN}`
+- Sender name: per project
+
+Verify live via a fresh-email test signup in Supabase.

--- a/.claude/skills/production-deploy/references/integrations/sentry.md
+++ b/.claude/skills/production-deploy/references/integrations/sentry.md
@@ -1,0 +1,65 @@
+# Sentry
+
+**Purpose in this codebase**: Error tracking (client + server + edge) + performance tracing + source-map uploads for readable stack traces.
+**Used for**: production error capture, edge-case debugging, alpha/beta incident response.
+**Tool**: Sentry REST API via `curl` → dashboard (last resort). No official MCP as of 2026-04-21.
+**Dependency group**: A (infra). Can run in parallel with PostHog / Langfuse.
+**Last updated**: 2026-04-21
+
+---
+
+## Project-specific conventions
+
+- **Env-aware sample rates**:
+  - `tracesSampleRate`: 0.1 in production, 1.0 in development.
+  - `replaysOnErrorSampleRate`: 0 in alpha/beta production, higher after traffic justifies it.
+  - `replaysSessionSampleRate`: always 0 (no blanket session replay).
+- **Auth token scope**: narrowest possible — `project:releases` only, for source-map uploads from Vercel builds.
+- **Alert rule**: auto-created "high-priority issue" notification on project creation; keep.
+- **DSN in env**: `NEXT_PUBLIC_SENTRY_DSN` (client-side safe).
+
+---
+
+## Setup during first prod deploy
+
+### Sub-steps (track each in state file)
+
+1. **Create Sentry project** for this app. Platform: Next.js. Team: per account convention.
+2. **Copy DSN + org slug + project slug** to Vercel env:
+   - `NEXT_PUBLIC_SENTRY_DSN`
+   - `SENTRY_ORG`
+   - `SENTRY_PROJECT`
+3. **Create auth token** — this is the step that confuses people:
+   - Navigate to **Organization Settings → Developer Settings → Custom Integrations / Organization Tokens** (NOT under project settings).
+   - Create a new org-level auth token with scope `project:releases`.
+   - Add to Vercel env as `SENTRY_AUTH_TOKEN` (production + preview + dev — all envs use it for source-map uploads).
+4. **Verify env-aware sample rates in code** (grep `Sentry.init` in `src/libs/` or `sentry.*.config.ts` — should be env-gated, not hardcoded).
+5. **Confirm alert rule exists** (auto-created but verify).
+6. **Trigger a test event** post-deploy (via Phase 6 smoke test) to confirm capture.
+
+---
+
+## Gotchas
+
+- **2026-04-16**: Auth token location is buried. Users search Project Settings, find nothing useful. The token is at **Organization Settings → Developer Settings → Custom Integrations / Organization Tokens**. Org-level, not project-level.
+- **Replays are expensive**: `replaysSessionSampleRate > 0` on a busy app can eat the Sentry quota fast. Keep off during alpha.
+- **Vercel integration vs manual**: the Vercel+Sentry Marketplace integration auto-sets some env vars but not `SENTRY_AUTH_TOKEN`. Either way, set the token manually.
+- **Source maps only upload on build**: if you deploy without the auth token set, stack traces in Sentry will be minified forever for that release. Set the token BEFORE the first prod deploy.
+
+---
+
+## Dashboards & links
+
+- Project: `https://{org}.sentry.io/projects/{project}/`
+- Issues: `https://{org}.sentry.io/issues/`
+- Alerts: `https://{org}.sentry.io/alerts/rules/`
+- Auth tokens: `https://{org}.sentry.io/settings/auth-tokens/`  (org-level)
+- Project settings: `https://{org}.sentry.io/settings/projects/{project}/`
+
+---
+
+## Current-docs fallback
+
+- Context7: `/getsentry/sentry-javascript` — for SDK init patterns, env-aware config.
+- WebFetch: https://docs.sentry.io/platforms/javascript/guides/nextjs/ — for current Next.js integration.
+- WebFetch: https://docs.sentry.io/cli/configuration/#auth-token — for token scope documentation.

--- a/.claude/skills/production-deploy/references/integrations/supabase.md
+++ b/.claude/skills/production-deploy/references/integrations/supabase.md
@@ -1,0 +1,62 @@
+# Supabase
+
+**Purpose in this codebase**: PostgreSQL + Auth + RLS for the entire app.
+**Used for**: user auth (magic link + OAuth), app data, admin analytics, and any product-specific tables a fork adds.
+**Tool**: Supabase MCP (preferred) → `psql` via pooled URL (fallback) → Dashboard + SQL Editor (last resort).
+**Last updated**: 2026-04-21
+
+---
+
+## Project-specific conventions
+
+- **Schema**: This project uses `DB_SCHEMA={schema-name}` (not `public`). Set via env var. See `CLAUDE.md` for the actual schema name.
+- **Drizzle + Supabase co-exist**: Drizzle for server-side table queries (admin, SSG). Supabase JS client for auth + RLS-scoped client queries. Supabase Admin client for `auth.admin.*` only.
+- **Tokens (forward-looking)**: the template ships no third-party OAuth integration yet, but per `.claude/rules/platforms.md`, any fork that stores external-platform access/refresh tokens must encrypt them at rest with `TOKEN_ENCRYPTION_KEY` before insert into its credentials table. Key differs per env.
+- **Migration strategy**: never `db:push` — apply dev schema via Supabase MCP `apply_migration`; migrations are generated on `main` (`db:generate`); no migration files on feature branches. See `.claude/rules/database.md` for details (push emits `DROP POLICY`/`DROP TRIGGER`/`DROP CONSTRAINT` against RLS/triggers/cross-schema FKs).
+- **Auth auto-migration disabled in prod**: `src/libs/DB.ts` skips `migratePg()` when `NODE_ENV=production`. Migrations only run via CI/CD.
+
+---
+
+## Setup during first prod deploy
+
+1. **Create prod project**. Via Supabase MCP or dashboard. Name: `{project}-prod`. Free tier OK for alpha.
+2. **Copy credentials**. Project URL, anon key, service role key, pooled DB connection string. These go to Vercel env (never chat).
+3. **Expose the schema** in Data API. Dashboard → Project Settings → Data API → Exposed Schemas. Add your `DB_SCHEMA`. Confirm `drizzle` and other internal schemas are NOT exposed.
+4. **Run migrations** against prod DB:
+   ```bash
+   DATABASE_URL="<prod-pooler>" DB_SCHEMA="<schema>" npx drizzle-kit migrate
+   ```
+5. **Seed** — `supabase/seed.sql` via SQL Editor. Preview SQL → confirm → execute.
+6. **Prod-setup** — `supabase/prod-setup.sql` via SQL Editor. Handles triggers, cross-schema FKs, RLS policies, GRANTs. **Depends on seed data**. Preview → fresh-eyes review → confirm → execute.
+7. **Auth config**:
+   - Site URL: `https://{PRODUCTION_DOMAIN}`
+   - Redirect URLs: `https://{PRODUCTION_DOMAIN}/**`
+   - Providers (OAuth): configure each provider the app uses
+   - **Custom SMTP**: defer to the Resend phase. When ready, Project Settings → Auth → SMTP Settings. Don't trust "DNS verified" — verify a test signup email's `From` field shows the branded sender.
+
+---
+
+## Gotchas
+
+- **2026-04-15**: Exposing `DB_SCHEMA` in the Data API is easy to miss — it's under Data API settings, not under Database. Client queries silently fail if this is skipped.
+- **2026-04-16**: Custom SMTP toggle is a separate step from Resend DNS verification. Neither verifies the other. Must test by signup.
+- **2026-04-15**: `prod-setup.sql` depends on seed data (triggers reference tier IDs). Migration order `migrate → seed → prod-setup` is mandatory.
+- **2026-04-14**: `psql` is not installed on macOS by default. Prefer the Supabase SQL Editor or Supabase MCP.
+
+---
+
+## Dashboards & links
+
+- Project: https://app.supabase.com/project/{project-ref}
+- Data API schema exposure: https://app.supabase.com/project/{project-ref}/settings/api
+- Auth URLs: https://app.supabase.com/project/{project-ref}/auth/url-configuration
+- Auth providers: https://app.supabase.com/project/{project-ref}/auth/providers
+- SMTP: https://app.supabase.com/project/{project-ref}/settings/auth (scroll to SMTP)
+- SQL Editor: https://app.supabase.com/project/{project-ref}/sql/new
+- Logs: https://app.supabase.com/project/{project-ref}/logs/explorer
+
+---
+
+## Current-docs fallback
+
+If this file is stale, run context7 with library id `/supabase/supabase-js` and `/supabase/docs` for the latest setup flows and env var names. Cross-check: Supabase docs occasionally move dashboard paths and rename settings without changelog entries.

--- a/.claude/skills/production-deploy/references/integrations/vercel.md
+++ b/.claude/skills/production-deploy/references/integrations/vercel.md
@@ -1,0 +1,74 @@
+# Vercel
+
+**Purpose in this codebase**: Hosting + serverless functions + CDN + Git-triggered deploys + per-env env vars.
+**Used for**: all production and preview deployments via Git integration.
+**Tool**: Vercel CLI + Vercel MCP (preferred) → dashboard (last resort).
+**Dependency group**: A (infra) — required before OAuth / webhooks can resolve to production URLs.
+**Last updated**: 2026-04-21
+
+---
+
+## Project-specific conventions
+
+- **Single Vercel project for all environments** (prod + preview + dev) with env vars scoped per env — not separate projects.
+- **On-demand spend cap** set immediately after project creation. Default: $200/mo for alpha/beta.
+- Root directory auto-detected by Next.js App Router convention.
+- Deployment Protection is **on** by default for new projects — Inngest + webhook integrations need a bypass key configured.
+
+---
+
+## Setup during first prod deploy
+
+### Sub-steps (track each in state file)
+
+1. **Tool audit**: `vercel --version` + `vercel whoami` succeed.
+2. **Green local build gate**: `npm ci && npm run build && npm run check-types && npm run lint` all pass. Do NOT create Vercel project on a red local build.
+3. **Node/TS version alignment**: compare `package.json` engines + `typescript` version to Vercel's current default (via context7 `/vercel/next.js` or WebFetch of [Node.js versions on Vercel](https://vercel.com/docs/functions/runtimes/node-js)). Pin both.
+4. **Domain ownership check**: confirm with user. If fresh domain, run Google Safe Browsing lookup before OAuth work.
+5. **Link project**: `vercel link --yes` from repo root.
+6. **Confirm framework detection**: Next.js App Router.
+7. **Add domain**: `vercel domains add {PRODUCTION_DOMAIN}` (or MCP equivalent).
+8. **DNS records at registrar**:
+   - `A @ 76.76.21.21`
+   - `CNAME www cname.vercel-dns.com`
+   (Verify exact current values via context7 `/vercel/vercel` — Vercel's anycast IP occasionally changes.)
+9. **Wait for SSL**: Vercel auto-issues; confirm `https://{PRODUCTION_DOMAIN}` returns 200.
+10. **Apply env vars per Phase 3 plan**:
+    ```bash
+    # For each env var in the plan:
+    echo -n "$VALUE" | vercel env add VAR_NAME <environment>
+    # Then verify by name-only:
+    vercel env pull .env.production
+    diff <(grep -E '^[A-Z_]+=' .env.production | cut -d'=' -f1 | sort) <expected-keys-from-Env.ts>
+    ```
+11. **Set spend cap**: dashboard → Project Settings → Spend Management → On-Demand Budget.
+12. **First prod deploy**: `vercel deploy --prod` or git push to main.
+13. **Monitor logs**: `vercel logs <deployment-url>` if red. Common failures cached in `references/known-pitfalls.md`.
+
+---
+
+## Gotchas
+
+- **2026-04-15**: First build can fail on module resolution if `tsconfig.json` paths or `next.config.*` are not committed. Run `npm run build` locally first — this is the gate.
+- **2026-04-16**: TypeScript 6 `baseUrl` deprecation fires on Vercel's newer TS even when local build passes. Fix: `"ignoreDeprecations": "6.0"` in `tsconfig.json`. Pin TS in `package.json` to slow future drift.
+- **2026-04-15**: Deployment Protection is on by default. Breaks Inngest sync, webhook integrations, and anything external that calls your app's API. Configure a bypass key in Project Settings → Deployment Protection → Protection Bypass for Automation.
+- **Ongoing**: `vercel env add` reads from stdin. Piping avoids leaving the value in shell history: `echo -n "$VALUE" | vercel env add NAME production`.
+
+---
+
+## Dashboards & links
+
+- Project: `https://vercel.com/{team}/{project}`
+- Env vars: `https://vercel.com/{team}/{project}/settings/environment-variables`
+- Deployment Protection: `https://vercel.com/{team}/{project}/settings/deployment-protection`
+- Spend: `https://vercel.com/{team}/{project}/settings/spend`
+- Domains: `https://vercel.com/{team}/{project}/settings/domains`
+- Logs: `https://vercel.com/{team}/{project}/logs`
+
+---
+
+## Current-docs fallback
+
+- Context7: `/vercel/next.js`, `/vercel/vercel` — primary source for framework + platform guidance.
+- WebFetch: https://vercel.com/docs — for CLI flags, newer features.
+- Vercel CLI expert skill: `vercel:vercel-cli` (if available in the session) — for edge cases.

--- a/.claude/skills/production-deploy/references/known-pitfalls.md
+++ b/.claude/skills/production-deploy/references/known-pitfalls.md
@@ -1,0 +1,116 @@
+# Known deployment pitfalls
+
+Experience log from production deploys of vt-saas-template forks. Each entry is a thing that actually bit a real deploy — not a hypothetical. Local truth, not a mirror of provider docs.
+
+**Freshness rule**: entries older than 6 months need re-validation via context7 before being relied on. If you find an entry stale or resolved upstream, update the `last-verified` date or remove it.
+
+---
+
+## Supabase
+
+### Non-`public` schema not exposed in Data API
+- **First seen**: a fork's first deploy
+- **Symptom**: Client-side queries return "schema does not exist" or 404. Server-side Drizzle queries work (they use direct connection), so the bug hides until client hits the PostgREST API.
+- **Fix**: Supabase Dashboard → Project Settings → Data API → Exposed Schemas → add the schema name (`DB_SCHEMA`, any non-public schema).
+- **Also**: confirm internal schemas (e.g., `drizzle`) are **not** exposed.
+
+### Custom SMTP: Resend DNS verified ≠ Supabase Auth sending from branded address
+- **First seen**: a fork's first deploy
+- **Symptom**: Magic-link signup emails arrive from `noreply@mail.app.supabase.io` instead of the project's branded sender, even though Resend shows the domain as verified.
+- **Cause**: Supabase Auth SMTP must be explicitly toggled and configured in the dashboard; Resend DNS verification is independent of the Supabase wire-up.
+- **Fix**: Supabase Dashboard → Project Settings → Auth → SMTP Settings. Enable custom SMTP. Host `smtp.resend.com`, port 465, user `resend`, password = Resend API key, sender = branded address.
+- **Verify**: trigger a test signup and inspect the received email's `From` field. Don't trust "DNS verified" status alone.
+
+### Migration order dependency
+- **First seen**: a fork's first deploy
+- **Symptom**: `prod-setup.sql` fails with "row does not exist" or trigger creation errors.
+- **Cause**: Triggers in `prod-setup.sql` reference rows that `seed.sql` inserts.
+- **Fix**: Run in this exact order: `db:migrate` → `seed.sql` → `prod-setup.sql`. Never skip or reorder.
+
+---
+
+## Vercel
+
+### Deployment Protection silently blocks Inngest sync
+- **First seen**: a fork's first deploy
+- **Symptom**: Inngest functions don't appear after a successful Vercel deploy. Inngest dashboard shows no sync errors; it simply never saw the functions.
+- **Cause**: Inngest's sync process hits `/api/inngest` from an external origin. If Vercel Deployment Protection is on (default for new projects), it blocks the request.
+- **Fix**: Generate a Deployment Protection bypass key in Vercel project settings → Deployment Protection → Protection Bypass for Automation. Configure this key in the Inngest integration.
+
+### TypeScript 6 `baseUrl` deprecation breaks Vercel build while local passes
+- **First seen**: a fork's first deploy
+- **Symptom**: `vercel build` fails with TS6504 "baseUrl is deprecated". Local `npm run build` passes fine.
+- **Cause**: Vercel's build uses a newer TS version than the locally pinned one; the deprecation is now a hard error.
+- **Fix**: In `tsconfig.json`, add `"ignoreDeprecations": "6.0"`. Also pin the TS version in `package.json` to reduce future drift.
+- **Upstream**: Track TS version in `package.json` alongside Vercel's current default (check context7 `/reference/nextjs/typescript`).
+
+### Module resolution failures on first Vercel build
+- **First seen**: a fork's first deploy
+- **Symptom**: First Vercel build fails with "Cannot find module @/libs/..." or similar.
+- **Fix**: Confirm `tsconfig.json` paths and `next.config.*` are committed. Run `npm run build` locally first — treat a green local build as the gate before creating the Vercel project.
+
+---
+
+## PostHog
+
+### Env var name drift (`NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN` vs `NEXT_PUBLIC_POSTHOG_KEY`)
+- **First seen**: a fork's first deploy
+- **Symptom**: PostHog receives no events despite code running in prod. Client-side init silently no-ops when the expected env var is missing.
+- **Cause**: PostHog renamed the env var in their current Next.js setup docs. Older template code uses the legacy name.
+- **Fix**: Run context7 fetch against PostHog's current Next.js integration guide during Phase 1. If rename detected, bulk-update `src/libs/Env.ts`, `.env.example`, analytics client/server files, and test files to the new name. Then set env var in Vercel under the new name.
+
+---
+
+## GitHub
+
+### Branch protection needs Pro plan for private repos
+- **First seen**: a fork's first deploy
+- **Symptom**: Branch protection rules can be configured but not enforced on private repos on Free plan.
+- **Fix**: Either upgrade to Pro, make the repo public (if suitable), or rely on pre-commit hooks + CI as the primary safety net. Still configure the rule; when you upgrade, enforcement is automatic.
+
+---
+
+## Dependabot
+
+### Linting group major bumps are silent landmines
+- **First seen**: a fork's first deploy
+- **Symptom**: Dependabot PR #N (linting group) merged during deployment prep. Nothing seemed to break. Weeks later, a routine commit triggers lint-staged failures rooted in `@eslint-react/eslint-plugin` v2→v4 incompatibility with `@antfu/eslint-config` v7.
+- **Fix**: Major bumps in the linting group require manual testing. Either defer them, or set up a dedicated CI job that runs `lint-staged` against a representative committed file.
+- **Preventative**: Dependabot config should split `eslint`-family plugins into their own group with `update-types: ["minor", "patch"]` only.
+
+---
+
+## Sentry
+
+### Auth token location is buried
+- **First seen**: a fork's first deploy
+- **Symptom**: User searches Project Settings for an auth token, finds nothing actionable.
+- **Cause**: Sentry auth tokens live at **Organization Settings → Developer Settings → Custom Integrations / Organization Tokens**, not under the project.
+- **Fix**: Go to the org-level settings. Create an org token scoped to `project:releases` (narrowest for Vercel source map uploads).
+
+---
+
+## Deployment ceremony
+
+### Pre-commit hook blocks migration files on feature branches
+- **First seen**: a fork's first deploy
+- **Symptom**: Committing a migration file on a feature branch fails with a hook error.
+- **Cause**: This project generates migration files on main only, so the hook blocks committing them on feature branches (this is intentional).
+- **Fix**: Do schema work on a feature branch and apply it to dev via Supabase MCP `apply_migration` (never `db:push` — it's banned and the script is removed). Merge to main. On main, run `db:generate` to produce the canonical migration, then commit. Prod runs `db:migrate:ci` via the Vercel build.
+
+### Vercel spend cap not set by default
+- **First seen**: a fork's first deploy (no real damage, but flagged)
+- **Fix**: Immediately after Vercel project creation, set on-demand spend cap. $200/mo is a reasonable alpha default.
+
+---
+
+## How to add a new pitfall
+
+When a deploy surfaces something avoidable-in-hindsight, append it here with:
+- **First seen**: {YYYY-MM-DD} + (source project name)
+- **Symptom**: what the user observes
+- **Cause**: root explanation
+- **Fix**: exact steps or commands
+- **Last verified**: update when re-confirmed
+
+If the pitfall is template-generic (most are), also raise a GitHub issue on `thevarun/vt-saas-template` via Phase 8 backport so future forks inherit the fix.

--- a/.claude/skills/production-deploy/references/rollback-reference.md
+++ b/.claude/skills/production-deploy/references/rollback-reference.md
@@ -1,0 +1,116 @@
+# Rollback Reference
+
+Keep this one click away during and after deploy. Don't improvise recovery — the wrong rollback is worse than the bug.
+
+---
+
+## Vercel
+
+### Instant revert to previous production deployment
+```bash
+vercel rollback
+```
+Rollbacks the production alias to the previous successful deploy. No rebuild. Fastest option.
+
+### Rollback to a specific deployment
+```bash
+vercel ls                         # list deployments
+vercel rollback <deployment-url>  # point prod alias at that deploy
+```
+
+### Promote a known-good preview to production
+```bash
+vercel promote <preview-url>
+```
+Use when a preview has been manually verified and you want it live without re-pushing main.
+
+**When to use which:**
+- Incident just happened, last good known deploy is the previous one → `vercel rollback` (no args).
+- Bug in last two deploys, third was good → `vercel rollback <specific-url>`.
+- Ready to ship a fix that's on a PR preview → `vercel promote <preview-url>`.
+
+---
+
+## Supabase
+
+### Migration rollback
+There is no automated `migrate:down` in Drizzle by default. Options:
+
+1. **Write a compensating migration** — safest. Schema backward-compat takes priority over tidy history.
+2. **Manually run inverse SQL** — for small issues (drop a column added by the bad migration). Preview SQL, confirm, run via SQL Editor.
+3. **Restore from point-in-time backup** — Supabase Pro+ plans have PITR. Free plan has daily backups only.
+
+**Rule:** before running any migration against prod, take a manual backup snapshot if the plan supports it. Better: keep migrations additive and use feature flags for schema dependencies.
+
+### RLS accidentally too permissive
+If a policy is broken (returning rows it shouldn't):
+```sql
+ALTER TABLE {schema}.{table} DISABLE ROW LEVEL SECURITY;
+-- Fix the policy
+-- Re-enable
+ALTER TABLE {schema}.{table} ENABLE ROW LEVEL SECURITY;
+```
+**But prefer**: fix the policy without disabling RLS. Disabling exposes the table during the gap.
+
+---
+
+## Stripe
+
+### Webhook flooding from a bad event handler
+1. Temporarily disable the webhook endpoint in Stripe Dashboard.
+2. Fix the handler code.
+3. Redeploy.
+4. Re-enable the endpoint.
+5. Replay missed events via Stripe Dashboard → Webhooks → select endpoint → "Resend missed events".
+
+### Accidental live-mode switch
+If you flipped to live mode prematurely:
+1. Immediately disable the live-mode restricted API key.
+2. Regenerate a new restricted key in test mode.
+3. Update Vercel env `STRIPE_SECRET_KEY` + `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` to test-mode values.
+4. Redeploy.
+5. Any payments that succeeded in that window: honor or refund per your policy.
+
+---
+
+## DNS
+
+### Reverting DNS changes
+DNS has TTL — changes don't revert instantly. At your registrar:
+1. Restore the previous A / CNAME records.
+2. Users on old resolvers will see inconsistent state for up to the TTL duration (typical: 300-3600s).
+3. Inform active users if feasible.
+
+**Preventative**: set low TTL (300s) on critical records *before* making changes, so rollback is fast.
+
+---
+
+## OAuth apps
+
+### If a client secret leaks
+1. In the provider's developer portal, regenerate the client secret.
+2. Update Vercel env with the new secret.
+3. Redeploy.
+4. Existing user OAuth tokens may or may not invalidate depending on the provider — audit.
+
+### If a redirect URL was configured wrong
+Just update it in the provider portal; no code change needed. Wait for the provider's cache (usually seconds).
+
+---
+
+## General incident flow
+
+1. **Stop the bleeding**: `vercel rollback` is the fastest way to restore service.
+2. **Diagnose on a feature branch**: don't debug on main.
+3. **Fix + preview**: land the fix on a preview URL. Manually verify.
+4. **Promote**: `vercel promote` or push to main.
+5. **Post-mortem**: write a short note in `docs/deployment-guide.md` under "Known Issues" with dated entry + resolution.
+
+---
+
+## What NOT to do
+
+- Don't `git revert` on main without testing — reverts can reintroduce older bugs.
+- Don't drop/recreate a prod table to "fix" a schema issue. Use additive migrations.
+- Don't disable RLS "just for a minute" — always take the policy path.
+- Don't `vercel env rm` in a panic — Vercel won't restore it, and losing a secret during an incident is a worse incident.

--- a/.claude/skills/production-deploy/steps/step-01-plan.md
+++ b/.claude/skills/production-deploy/steps/step-01-plan.md
@@ -1,0 +1,249 @@
+---
+name: step-01-plan
+description: Scan the repo, detect integrations, audit tool availability, fetch current provider docs, and produce a customized deployment checklist plus an initial risk review.
+workflow_path: .claude/skills/production-deploy
+thisStepFile: .claude/skills/production-deploy/steps/step-01-plan.md
+nextStepFile: .claude/skills/production-deploy/steps/step-02-readiness.md
+workflowFile: .claude/skills/production-deploy/SKILL.md
+stateFile: _bmad-output/deployment-checklist.md
+checklistTemplate: .claude/skills/production-deploy/templates/deployment-checklist.template.md
+integrationsDir: .claude/skills/production-deploy/references/integrations
+pitfallsRef: .claude/skills/production-deploy/references/known-pitfalls.md
+---
+
+# Phase 1 — Plan
+
+## STEP GOAL
+
+Walk out of this phase with (a) a complete inventory of what's being deployed, (b) a current-docs view of each provider involved, (c) a verified list of MCP/CLI tools available for automation, (d) a written deployment checklist persisted to `_bmad-output/deployment-checklist.md`, and (e) a risk review flagging concerns the user should address before real work starts.
+
+## MANDATORY EXECUTION RULES
+
+- Read this step file fully before any tool call.
+- No code or infra changes in this phase. Plan only. Writes are limited to the state file and planning artifacts.
+- When fetching provider docs, prefer `context7` (MCP). Cite the doc source for every non-obvious config instruction you will emit later.
+- Spawn the `deploy-risk-reviewer` agent at the end of the phase for a phase-boundary review.
+
+## Sequence of Instructions
+
+### 1. Absorb prior context
+
+Read in parallel:
+- `CLAUDE.md` — project conventions + tech stack
+- Dependency manifest (`package.json` / `requirements.txt` / equivalent) — dependencies, scripts
+- Env schema (Zod validation file, `.env.example`, or however the project defines required env vars)
+- `.env.example` — documented env vars (if separate from schema above)
+- `{stateFile}` — if present, existing deployment state
+- Deployment guide/notes in `docs/` — if present
+- Project memory index if present
+
+If user mentioned URLs, past incidents, or additional context in the invoking prompt, fetch/read those too before classifying.
+
+### 1b. Check upstream for queued backport candidates (bidirectional loop — inbound)
+
+Prior deploys may have left issues on `thevarun/vt-saas-template` labeled `backport-from-deploy` that haven't been resolved yet. Pulling relevant ones in *before* this deploy means we don't rediscover them mid-flight. Requires `gh` authenticated against the template repo.
+
+```bash
+gh issue list \
+  --repo thevarun/vt-saas-template \
+  --label backport-from-deploy \
+  --state open \
+  --json number,title,url,createdAt,body
+```
+
+If zero results or `gh` not authenticated: note in state file and continue.
+
+If results exist, present a compact summary:
+```
+Open backport candidates from prior deploys of your vt-saas-template forks:
+
+  #42 (14 days old): PostHog env var rename (`NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN`)
+  #38 (23 days old): TS 6 baseUrl — add `ignoreDeprecations: "6.0"` to tsconfig
+  #31 (35 days old): Supabase schema exposure — document the Data API setting
+
+Pulling these in now means this deploy won't rediscover them.
+
+[R] Review each and cherry-pick into this repo before proceeding
+[P] Proceed as-is (logs the skipped issues in the state file so the risk reviewer can flag)
+[X] Exit — handle them on the template repo first
+```
+
+If `R`: for each selected issue, show the proposed change, offer to apply as a commit on the current repo. Gate per issue with `[C] Apply / [R] Revise / [S] Skip this one`.
+
+If `P`: record skipped issue numbers in the state file under `## Phase 1 — Skipped backport candidates`. The risk-reviewer spawn in step 7 will get this list and flag any later phase where the skipped issue would bite.
+
+### 2. Detect integrations
+
+Scan the codebase to build an integration manifest. For each match, record: integration name, evidence (file path + line), category (template-generic vs project-specific).
+
+Start with the heuristic patterns below, then extend by reading `package.json` deps and the project's env schema. Cluster external services by category:
+
+| Category | Detect via |
+|---|---|
+| Database | ORM imports (`drizzle-orm`, `prisma`, `typeorm`), `DATABASE_URL` |
+| Auth provider | `@supabase/*`, `better-auth`, `next-auth`, `clerk`, `@auth/*` |
+| Hosting | `.vercel/`, `vercel.json`, `vercel.ts`, `netlify.toml`, `fly.toml` |
+| Payments | `@stripe/*`, `STRIPE_SECRET_KEY` |
+| OAuth providers | `*_CLIENT_ID` / `*_CLIENT_SECRET` pairs in env schema |
+| Background jobs | `inngest`, `trigger.dev`, `bullmq`, cron routes |
+| Email | `resend`, `@sendgrid/*`, `nodemailer`, SES |
+| Observability | `@sentry/*`, `posthog-*`, `langfuse`, `@vercel/otel` |
+| AI providers | Provider SDK imports (`@ai-sdk/*`, `openai`, `anthropic`), `*_API_KEY` |
+| Webhooks | Webhook route handlers, `*_WEBHOOK_SECRET` env vars |
+
+For each detected integration, check whether a reference file exists at `{integrationsDir}/<name>.md`. If yes, read it — it contains project-conventions and gotchas. If no, mark the integration as "new — will research via context7 in step 4".
+
+Classify each integration:
+- **Template-generic**: Supabase, Vercel, Resend (auth emails), Sentry, GitHub CI, PostHog. These are in every vt-saas-template deploy.
+- **Project-specific**: everything else.
+
+### 3. Audit tool availability
+
+For the required tool set (see orchestrator's Tool Strategy table) plus any provider-specific tools, run availability probes:
+
+```bash
+# CLIs
+vercel --version 2>/dev/null && vercel whoami 2>/dev/null
+gh --version 2>/dev/null && gh auth status 2>/dev/null
+stripe --version 2>/dev/null
+dig -v 2>&1 | head -1
+# Node/TS versioning vs Vercel
+node --version
+cat package.json | grep -E '"(typescript|next)"'
+```
+
+For MCPs, attempt a trivial read-only call for each (e.g., `context7:resolve-library-id` with a known lib; Stripe MCP `get_stripe_account_info`; Supabase MCP `authenticate` status check). Record availability.
+
+Produce a tool-availability table:
+```
+Tool                     | Status      | Action required
+------------------------ | ----------- | ---------------
+Vercel CLI               | OK          | —
+Vercel MCP               | Not auth'd  | Run: /mcp authenticate vercel
+gh CLI                   | OK          | —
+Supabase MCP             | Not auth'd  | Run: /mcp authenticate supabase
+Stripe MCP               | OK          | —
+context7 MCP             | OK          | —
+Playwright MCP           | OK          | —
+...
+```
+
+If any critical tool is missing (Vercel CLI, `gh`, context7), halt and ask the user to authenticate them. Offer to auto-auth the MCPs the user approves.
+
+### 3b. Context7 coverage probe
+
+Before relying on context7 as the primary source for current provider docs, check coverage. For each detected provider, attempt to resolve a library ID:
+
+```
+for each provider in detected_integrations:
+  result = mcp__context7__resolve-library-id(provider_name)
+  if result has match: record library_id
+  else: record as "no context7 coverage"
+```
+
+Produce a coverage table:
+```
+Provider      | context7 library_id              | Status
+------------- | -------------------------------- | --------
+supabase      | /supabase/supabase-js            | ✓ covered
+vercel        | /vercel/vercel                   | ✓ covered
+stripe        | /stripe/stripe-js                | ✓ covered
+nextjs        | /vercel/next.js                  | ✓ covered
+resend        | /resend/resend-node              | ✓ covered
+sentry        | /getsentry/sentry-javascript     | ✓ covered
+posthog       | /posthog/posthog-js              | ✓ covered
+oauth-{provider} | —                             | ✗ no match — will use WebFetch
+inngest       | —                                | ✗ no match — will use WebFetch
+n8n           | —                                | ✗ no match — will use WebFetch
+langfuse      | /langfuse/langfuse               | ✓ covered
+```
+
+**Fail loudly, not quietly.** If any provider with known drift risk (PostHog, Supabase, Next.js-on-Vercel, Sentry) lacks context7 coverage, surface as a HIGH-severity item to the Phase 1 gate — the skill's "live-docs-over-memory" guarantee is weaker for these and the user should know. For low-risk providers (unchanging OAuth providers like Google), note but don't block.
+
+For uncovered providers, step 4 falls back to `WebFetch` on the provider's canonical setup URL (stored per-provider in `references/integrations/{provider}.md`); training-data recall is tertiary and always flagged `[LLM memory — verify]`.
+
+### 4. Fetch current provider docs (live-docs-over-memory)
+
+For each detected integration with drift risk, fetch current setup docs via context7 (or the fallback chain from step 3b). Cross-reference findings against `{pitfallsRef}` for known drift sites.
+
+For each provider, validate that the project's code (env schema, config files) uses **current** API names, patterns, and conventions. Record any mismatches as "drift findings" to present at phase gate.
+
+_Focus areas:_ env var naming (providers rename these regularly), SDK initialization patterns, webhook event names, auth token scopes, DNS record formats.
+
+### 5. Build the deployment checklist
+
+Copy `{checklistTemplate}` to `{stateFile}` if the state file does not exist (or is empty). If it exists, preserve completed items.
+
+For each detected integration, ensure the checklist has a line item under the appropriate phase. For unknown integrations, append a phase-5 line item tagged `project-specific: <name>` with a "research via context7 at execution time" note.
+
+Write any drift findings from step 4 as "Pre-execution fixes" at the top of Phase 2 (Readiness).
+
+### 6. Known-pitfalls pass
+
+Read `{pitfallsRef}`. For each pitfall entry, check whether it applies to this project (match by integration + conditions listed). Apply dated filter — flag entries older than 6 months as "verify current via context7 before relying on this".
+
+Produce a "pitfalls to watch" list sized to the integrations detected.
+
+### 7. Spawn deploy-risk-reviewer (first invocation — establishes the pattern)
+
+The reviewer is bundled inside the skill, not at `.claude/agents/`. Spawn a `general-purpose` subagent with `model="opus"` and a prompt of the shape:
+
+```
+Read your persona and rubric at: .claude/skills/production-deploy/agents/deploy-risk-reviewer.md
+
+You are reviewing Phase 1 (Plan) of a production deployment. Apply the 5-dimension rubric with focus on security and drift for this phase.
+
+Artifacts to review (do not explore beyond these):
+- Integration manifest (below)
+- Tool-availability table (below)
+- Drift findings (below)
+- Pitfalls-to-watch list (below)
+- .claude/CLAUDE.md (project conventions)
+- src/libs/Env.ts (or the project's Zod env schema)
+- package.json (dependencies + scripts)
+
+<paste the manifest / table / findings / pitfalls here>
+
+Return findings per the template in the agent file. Cap at 10. Include a Confidence line at the end.
+```
+
+Subsequent step files use the same pattern ("Spawn `deploy-risk-reviewer` with {phase} rubric..."); the invocation shape is fixed to the above.
+
+### 8. Phase 1 Gate
+
+Present:
+
+```
+=== PHASE 1: PLAN — SUMMARY ===
+
+Integrations detected: <count>
+  Template-generic: <list>
+  Project-specific: <list>
+  New (no local reference): <list>
+
+Tools ready:    <count ready / total>
+Tools missing:  <list, with one-line auth instructions>
+
+Drift findings: <count>
+  <one-line each>
+
+Risk review findings (deploy-risk-reviewer):
+  HIGH:   <count> — <short list>
+  MEDIUM: <count>
+  LOW:    <count>
+
+State written to: _bmad-output/deployment-checklist.md
+
+Sharpest failure mode 3 months in if we skip fixing the HIGHs:
+  <one bullet, opinionated>
+
+[C] Continue to Phase 2 (Readiness)
+[R] Revise — address a specific finding or re-plan
+[X] Exit (state preserved; safe to resume)
+```
+
+**If C:** Load and execute `{nextStepFile}`. Pass forward: integration manifest, tool-availability table, drift findings, risk review findings, state file path.
+
+**If R:** Ask what to revise. Address the specific item (rerun a tool audit, fetch a specific provider doc, update the checklist, spawn the reviewer with a different rubric). Re-display the summary.
+
+**If X:** Stop cleanly. Ensure the state file is saved.

--- a/.claude/skills/production-deploy/steps/step-02-readiness.md
+++ b/.claude/skills/production-deploy/steps/step-02-readiness.md
@@ -1,0 +1,121 @@
+---
+name: step-02-readiness
+description: Three-bucket readiness audit — Mechanical (build/lint/test/PRs/git), Hygiene (rate limits, tiers, auth flows, admin gate, RLS, abuse), Cost (SSG, sampling, auto-migration, quotas, spend caps). Fixes gaps in-place before any production infra work begins.
+workflow_path: .claude/skills/production-deploy
+thisStepFile: .claude/skills/production-deploy/steps/step-02-readiness.md
+nextStepFile: .claude/skills/production-deploy/steps/step-03-env-strategy.md
+workflowFile: .claude/skills/production-deploy/SKILL.md
+stateFile: _bmad-output/deployment-checklist.md
+---
+
+# Phase 2 — Readiness
+
+## STEP GOAL
+
+Walk out of this phase with a repo that: (a) builds clean locally against production-like settings, (b) will not be abused or bypassed on day 1, and (c) won't leak money on idle traffic. Gaps found in any bucket are fixed in-place (committed to a branch, PR'd and merged) before moving on. If a gap cannot be fixed in-session, it gets logged in the state file with a decision ("defer with known risk" vs "block deploy").
+
+## MANDATORY EXECUTION RULES
+
+- **If `planMode=true` (from `--plan` invocation): propose fixes but do not apply or commit.** For each gap, output the proposed diff and note `[plan mode — not applied]`. Run all read-only checks (build, type-check, lint, test, audits) normally; skip every write/commit/PR. Mirrors the dry-run contract in `SKILL.md` ("Phase 2 hygiene fixes are proposed, not applied in plan mode") and the simulate-only pattern in `step-04-core-infra.md`.
+- Read the Phase 1 risk-review findings first — many HIGH-severity drift items are auto-fixed in this phase (e.g., PostHog env var rename).
+- Land readiness fixes before Phase 3 — branch + PR if the project gates on review, otherwise direct commits. Commit per bucket for legibility.
+- Do not suppress errors. If build fails, diagnose the root cause and fix. Do not lower the lint bar to pass.
+- Spawn `deploy-risk-reviewer` once at the end with the full Phase 2 artifact set.
+
+## Sequence of Instructions
+
+### 1. Mechanical readiness
+
+Run the project's production build, type-check, lint, and test commands as defined in the package manifest (or equivalent for the detected package manager). Note any missing script as a gap rather than failing.
+
+Checks to pass:
+- Clean dependency install
+- Production build
+- Type checking (strict mode)
+- Lint
+- Unit tests
+- No uncommitted drift (`git status --short`)
+- Nothing left in flight (`git log main..HEAD --oneline`)
+- Open PRs triaged (`gh pr list --state open`)
+
+_e.g. (npm):_ `npm ci && npm run build && npm run check-types && npm run lint && npm run test`
+
+Also verify:
+- Node version matches Vercel's current default (context7 fetch or `vercel.json` engines)
+- TypeScript version pinned in `package.json`
+- No migration files committed on a non-main branch (project's pre-commit hook verifies this)
+- Latest `main` pulled
+
+**Decisions:**
+- Failing checks → fix, do not proceed.
+- Open PRs → triage (merge/close). Stale Dependabot major bumps are a specific risk (session history: eslint group major broke post-deploy). Recommend merge/close all before starting Phase 3 so a clean main is the deploy base.
+
+### 2. Hygiene readiness
+
+Verify the following hygiene properties by inspecting the project's middleware, route handlers, and relevant utility modules:
+
+| Check | What to verify |
+|---|---|
+| RLS on all app tables | Row-level security policies exist for every user-facing table (check migration files + live DB) |
+| Quota/tier enforcement | AI and paid-feature endpoints are gated by the project's quota/tier mechanism |
+| Admin gate (defense in depth) | Admin routes protected at BOTH middleware and handler level |
+| Dev-only auth bypass blocked | Any development-only login endpoint is environment-gated to reject production requests |
+| Rate limiting on public endpoints | Rate limiter applied to each public API route |
+| CORS scoped | Allowed origins restricted to the project's domains |
+| Auth flow works | Run signup + sign-in locally against dev auth provider |
+| No secrets in repo | `git grep -E "(api_key|secret|password).*=.*['\"][^'\"]{20,}['\"]"` |
+| Env example current | Diff `.env.example` (or equivalent) against the env schema |
+
+_Discovery approach:_ Read the project's auth setup, middleware, and API directory to locate the actual function/module names. Do not assume specific symbols.
+
+For any gap: propose fix, show diff, confirm, apply, commit.
+
+### 3. Cost readiness
+
+| Check | Fix if gap |
+|---|---|
+| Landing page is SSG (not server-rendered per request) | Add `setRequestLocale()` + `generateStaticParams()` for locales |
+| Sentry `tracesSampleRate` env-aware (prod ≤ 0.1, dev = 1.0) | Env-gated config |
+| Sentry `replaysOnErrorSampleRate` off for alpha | 0 in prod |
+| DB auto-migration disabled in production | Guard `migratePg()` with `NODE_ENV !== 'production'` |
+| Free/expired user AI quotas gated to fallback model | Verify `src/libs/ai/config.ts` or quota gate |
+| Premium AI features quota-gated (image gen, high-tier models) | Verify `checkQuota` entries |
+| Separate API keys planned for prod vs dev | Flag for Phase 3 env strategy |
+| Vercel on-demand cap proposal | Default $200 for alpha; confirm with user |
+| OpenAI monthly cap | Proposal ($20-30 for alpha) |
+
+For each gap: propose fix, confirm, apply, commit.
+
+### 4. Land readiness fixes
+
+If `planMode=true`: do not land anything — present the consolidated set of proposed fixes (each marked `[plan mode — not applied]`) and move to the gate.
+
+Otherwise, land all readiness fixes before Phase 3. If the project gates on code review, use a feature branch + PR + merge. Otherwise, direct commits to the working branch are acceptable. Keep the bucket-per-commit structure for legibility regardless of workflow.
+
+### 5. Phase 2 Gate
+
+Spawn `deploy-risk-reviewer` with phase-2 rubric: "review the readiness fixes and confirm no regressions introduced. Flag any gap that was not fixed but should have been."
+
+Show summary, gate as standard:
+```
+=== PHASE 2: READINESS — SUMMARY ===
+
+Mechanical:  <pass/fail counts>
+Hygiene:     <gaps found / fixed / deferred>
+Cost:        <gaps found / fixed / deferred>
+
+Deferred items (with rationale):
+  - <item>: <why deferred — will address in Phase <N>>
+
+Risk review findings: HIGH {n} | MEDIUM {n} | LOW {n}
+
+[C] Continue to Phase 3 (env strategy)
+[R] Revise — re-run a specific bucket / fix a specific gap
+[X] Exit (state preserved)
+```
+
+**If C:** Load `{nextStepFile}`. Pass forward: PR URL, list of deferred items.
+
+**If R:** Jump to specific fix.
+
+**If X:** Stop cleanly.

--- a/.claude/skills/production-deploy/steps/step-03-env-strategy.md
+++ b/.claude/skills/production-deploy/steps/step-03-env-strategy.md
@@ -1,0 +1,121 @@
+---
+name: step-03-env-strategy
+description: Produce the per-environment variable + secret strategy for local / preview / production. Decides what must differ per env, what stays shared, what is auto-set by integrations. Output is a reference table Phase 4 executes against.
+workflow_path: .claude/skills/production-deploy
+thisStepFile: .claude/skills/production-deploy/steps/step-03-env-strategy.md
+nextStepFile: .claude/skills/production-deploy/steps/step-04-core-infra.md
+workflowFile: .claude/skills/production-deploy/SKILL.md
+stateFile: _bmad-output/deployment-checklist.md
+---
+
+# Phase 3 — Env Strategy
+
+## STEP GOAL
+
+Walk out of this phase with an env-plan document appended to `{stateFile}` listing, for every env var the project needs: its value-type (same-across-envs | per-env | auto-set | secret-rotated-per-env), its source (user-input | provider-dashboard | CLI-generated | integration-managed), and where it ends up (Vercel prod / preview / dev, GitHub Actions secrets, local `.env.local`). No infra action in this phase; pure planning.
+
+## MANDATORY EXECUTION RULES
+
+- Read `src/libs/Env.ts` (or the project's Zod env schema) as source of truth for required vars.
+- Read `.env.example` for documented defaults.
+- Do not add actual values anywhere in this phase. Names and strategy only.
+- Fetch current env var naming for providers via context7 (catches drift, e.g., PostHog).
+
+## Sequence of Instructions
+
+### 1. Build the canonical var list
+
+From `src/libs/Env.ts` + `.env.example`, produce the full list of required env vars. For each, start a row with: `name`, `type` (string / number / enum / secret), `used_by` (client | server | both — detected via `NEXT_PUBLIC_` prefix).
+
+### 2. Classify each var
+
+For each var, assign one of five strategies:
+
+| Strategy | Description | Examples |
+|---|---|---|
+| **`shared-all-envs`** | Same value in local, preview, production | `SEARCH_PROVIDER`, `EMAIL_FROM_NAME`, `DB_SCHEMA` |
+| **`per-env`** | Different value per env (cost attribution, scope, env tag) | `DATABASE_URL`, `NEXT_PUBLIC_SUPABASE_URL`, `OPENAI_API_KEY`, `TAVILY_API_KEY`, `LANGFUSE_TRACING_ENVIRONMENT` |
+| **`rotate-per-env`** | Must be unique per env for security; rotate together | `TOKEN_ENCRYPTION_KEY`, `STRIPE_WEBHOOK_SECRET`, `SUPABASE_SERVICE_ROLE_KEY` |
+| **`auto-set`** | Integration creates and injects (do not manage) | `INNGEST_EVENT_KEY`, `INNGEST_SIGNING_KEY`, `VERCEL_*` |
+| **`prod-only`** | Exists only in production (preview uses auto-detect, dev omits) | `NEXT_PUBLIC_APP_URL` (preview auto-uses Vercel URL) |
+
+### 3. Apply the cost lens (fold in Phase 2 findings)
+
+For any var that has a paid provider: decide whether prod and dev share the same key or use separate keys for cost attribution. Default: separate keys for paid AI providers (OpenAI, Anthropic, Gemini, Tavily, Perplexity), shared for unmetered providers (PostHog until growth, Langfuse if same project can env-tag).
+
+### 4. Apply the observability lens
+
+For observability providers:
+- **Sentry**: DSN shared across envs is OK (events tagged with env). Auth token shared OK (for source maps).
+- **Langfuse**: Same project + `LANGFUSE_TRACING_ENVIRONMENT=production|preview|development` is the cheap pattern.
+- **PostHog**: Same project is typical; env tag via event property.
+
+### 5. Assign destinations
+
+For each var, list destinations:
+- `vercel:production`
+- `vercel:preview`
+- `vercel:development` (if Vercel dev env used)
+- `github-actions:secrets` (CI only — typically dev-project Supabase, not prod)
+- `local:.env.local`
+
+Rule: **CI secrets should NOT point to prod** (CI tests shouldn't touch prod data). Point CI at dev-project Supabase.
+
+### 6. Output the env-plan table
+
+Append to `{stateFile}` under `## Phase 3 — Env Plan`:
+
+```markdown
+| Name | Strategy | Vercel prod | Vercel preview | Vercel dev | GH Actions | .env.local |
+|---|---|---|---|---|---|---|
+| NEXT_PUBLIC_SUPABASE_URL | per-env | prod-url | dev-url | dev-url | dev-url | dev-url |
+| TOKEN_ENCRYPTION_KEY | rotate-per-env | prod-key | dev-key | dev-key | — | dev-key |
+| OPENAI_API_KEY | per-env | prod-key | dev-key | dev-key | — | dev-key |
+| INNGEST_EVENT_KEY | auto-set | auto | auto | — | — | — |
+| NEXT_PUBLIC_APP_URL | prod-only | https://prod | — | — | — | — |
+| ... | | | | | | |
+```
+
+Also capture **var names that came out of context7 drift checks** (e.g., `NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN` vs legacy `NEXT_PUBLIC_POSTHOG_KEY` — confirm which one the code uses now; reconcile if needed).
+
+### 7. Flag secret-rotation concerns
+
+For each `rotate-per-env` var, note rotation strategy:
+- `TOKEN_ENCRYPTION_KEY`: rotating orphans encrypted-at-rest tokens. Plan: not rotated casually; tied to env creation.
+- `STRIPE_WEBHOOK_SECRET`: rotate when the webhook endpoint is re-created.
+- `SUPABASE_SERVICE_ROLE_KEY`: keep safe; rotate only on compromise.
+
+### 8. Phase 3 Gate
+
+```
+=== PHASE 3: ENV STRATEGY — SUMMARY ===
+
+Total vars: {N}
+  shared-all-envs:    {n}
+  per-env:            {n}
+  rotate-per-env:     {n}
+  auto-set:           {n}
+  prod-only:          {n}
+
+Drift reconciliations required: {n}
+  <one-liner each>
+
+Cost-attribution pairs (separate keys prod vs dev): {list}
+
+Destinations matrix appended to {stateFile}
+
+Sharpest failure mode 3 months in:
+  <typical: "prod env var mis-scoped to preview, leaking prod data through preview URLs">
+
+[C] Continue to Phase 4 (core infra execution using this plan)
+[R] Revise a strategy assignment
+[X] Exit
+```
+
+**If `planMode=true`:** Display `[Dry-run complete — phases 1–3 executed; re-invoke without --plan to run phases 4–8]` and stop. Do not load `{nextStepFile}`. This is the documented dry-run boundary (`SKILL.md` invocation modes: "Phase 3 exit adds a 'Dry-run complete — re-invoke without --plan to execute' banner instead of advancing to Phase 4").
+
+**If C:** Load `{nextStepFile}`. Pass forward: env-plan table.
+
+**If R:** Edit specific rows, re-display.
+
+**If X:** Stop cleanly.

--- a/.claude/skills/production-deploy/steps/step-04-core-infra.md
+++ b/.claude/skills/production-deploy/steps/step-04-core-infra.md
@@ -1,0 +1,161 @@
+---
+name: step-04-core-infra
+description: Dispatcher — executes the integrations in dependency-group A (infra that must be live before feature integrations) by walking the Phase 1 manifest in dependency order and dispatching each to its reference file. Typical group A contains DB + Auth, domain + hosting, env vars, email, observability, CI. Not hardcoded — whatever the manifest says.
+workflow_path: .claude/skills/production-deploy
+thisStepFile: .claude/skills/production-deploy/steps/step-04-core-infra.md
+nextStepFile: .claude/skills/production-deploy/steps/step-05-integrations.md
+workflowFile: .claude/skills/production-deploy/SKILL.md
+stateFile: _bmad-output/deployment-checklist.md
+integrationsDir: .claude/skills/production-deploy/references/integrations
+pitfallsRef: .claude/skills/production-deploy/references/known-pitfalls.md
+riskReviewerAgentFile: .claude/skills/production-deploy/agents/deploy-risk-reviewer.md
+---
+
+# Phase 4 — Core Infra (manifest dispatcher, group A)
+
+## STEP GOAL
+
+Execute every integration marked as dependency-group A in the Phase 1 manifest, in dependency order, using each integration's reference file as the instruction source. Walk out of this phase with: DB + Auth live and configured, domain + hosting + env vars complete, email domain verified AND custom SMTP actually wired, observability capturing signal, CI secrets set. Nothing left for Phase 5 or Phase 6 to discover is missing.
+
+## MANDATORY EXECUTION RULES
+
+- This step is a **dispatcher**. It reads the manifest from `{stateFile}` and executes integrations in dependency order.
+- For each integration, read `{integrationsDir}/{name}.md` as the setup source. If the file is missing, research via context7/WebFetch, execute with user confirmation, and offer to save a new reference file at end of section.
+- State granularity is **sub-item level**: each integration's sub-steps are tracked individually. Pre-checks read state and skip already-completed items (idempotency).
+- Secrets pattern: provider dashboard → Claude runs `vercel env add NAME env` (or equivalent) → `vercel env pull` → Claude verifies presence of `NAME`, never `VALUE`.
+- Destructive-op preview: show the exact SQL/DNS/config before executing, require `[C] Confirm` each time.
+- Spawn `deploy-risk-reviewer` at the end of each integration's section, with a narrow rubric scoped to what that integration just did.
+- If `planMode=true` (from `--plan` invocation), simulate only: describe what would happen per integration, do not call any provider write API.
+
+## Sequence of Instructions
+
+### 1. Load manifest and compute dependency order
+
+Read the integration manifest from `{stateFile}` (produced in Phase 1). Filter to `group: A` (or whatever the manifest field marks as "must-run-first"). Compute a topologically-sorted execution list.
+
+**Default dependency order** (override if manifest says otherwise):
+1. Database + Auth provider (Supabase / Neon+Clerk / Turso+Auth.js / etc.)
+2. Domain + Hosting (Vercel project, domain DNS, SSL)
+3. Vercel env vars applied from the Phase 3 env-strategy plan
+4. Email sending domain (Resend / SES / Postmark) — must be verified before wiring into Auth provider's SMTP
+5. Email wire-up into Auth provider (e.g., Supabase Auth → custom SMTP)
+6. Observability (Sentry → PostHog → optional Langfuse)
+7. AI provider spend caps (OpenAI / Gemini / Anthropic)
+8. CI secrets + branch protection (GitHub Actions)
+
+Rationale for each dependency: DB must exist before env vars (URL comes from DB). Domain must be live before OAuth can be configured (Phase 5 depends on this). Email domain must verify before SMTP wire-up. Observability can be parallel within itself but after env vars exist. AI caps are independent, can run anywhere after Vercel project exists.
+
+Display the computed order to the user for confirmation:
+```
+Phase 4 execution plan ({N} integrations):
+  1. supabase          (ref: supabase.md)
+  2. vercel            (ref: vercel.md)
+  3. vercel-env-apply  (applies Phase 3 plan)
+  4. resend            (ref: resend.md)
+  5. supabase-smtp-wire (ref: supabase.md#smtp — depends on resend verified)
+  6. sentry            (ref: sentry.md)
+  7. posthog           (ref: posthog.md)
+  8. ai-spend-caps     (ref: ai-providers.md)
+  9. github-ci         (ref: github.md)
+
+[C] Execute in this order / [R] Revise order / [X] Exit
+```
+
+### 2. Tool availability recap
+
+Re-run Phase 1's tool audit, filtered to tools needed by this phase's integrations. Missing tools → batch prompt for auth, halt until ready.
+
+### 3. Dispatcher loop
+
+For each integration in the execution list:
+
+```
+for integration in execution_list:
+  # Pre-check: skip if already complete
+  if state_file[phase_4][integration].status == "complete":
+    skip (log "resumed: {integration} already complete")
+    continue
+
+  # Load reference
+  ref = read("{integrationsDir}/{integration}.md")
+  if ref missing:
+    user_input = prompt("No reference for {integration}. Describe its purpose + link to provider docs.")
+    ref = generate_from_context7(integration, user_input)
+    offer_to_save(ref, path="{integrationsDir}/{integration}.md")
+
+  # Announce section start
+  display("━━━ Integration: {integration} ({position}/{total}) ━━━")
+  display(ref.summary)
+
+  # Execute ref's setup steps, respecting already-completed sub-items
+  for substep in ref.setup_steps:
+    if state_file[phase_4][integration][substep.id].status == "complete":
+      skip
+      continue
+    execute(substep)  # in planMode: describe only, no side effects
+    if substep.destructive:
+      require_confirm_C()
+    state_file[phase_4][integration][substep.id].status = "complete"
+    state_file.save()
+
+  # Risk review for this integration
+  spawn deploy-risk-reviewer with rubric scoped to what just ran
+  present findings
+  if HIGH findings: gate "[C] Continue acknowledging / [R] Fix before proceeding"
+
+  # Mark integration complete
+  state_file[phase_4][integration].status = "complete"
+  state_file.save()
+```
+
+### 4. Phase-level safety checks (run after dispatcher loop)
+
+After all group-A integrations execute, run these cross-cutting checks before the gate:
+
+- **Env var completeness**: `vercel env pull .env.prod-check` locally, diff against the project's env schema (Zod file, `.env.example`, or equivalent) required keys. Zero missing required keys is the gate to proceed. If any missing, loop back to the offending integration.
+- **First prod deploy green**: either a deploy has already landed green (via git push to main) or trigger one now. If red, diagnose via `vercel logs`, fix, re-deploy.
+- **Landing page resolves**: `curl -I https://{PRODUCTION_DOMAIN}` returns 200. SSL is active.
+- **Custom SMTP actually wired** (not just DNS verified): trigger a test signup in Supabase Auth UI, confirm sender is branded address. This is a check that real deploys silently fail — do not skip.
+
+### 5. Phase 4 Gate
+
+Spawn `deploy-risk-reviewer` with a **comprehensive Phase 4 rubric**: RLS across all tables, env var completeness, SMTP actually sending from branded address, spend caps set, CI secrets correct env (dev, not prod), no drift between code and live config.
+
+```
+=== PHASE 4: CORE INFRA — SUMMARY ===
+
+Integrations executed ({completed}/{total} from group A):
+  ✓ supabase             — project {ref}, schema exposed, migrations/seed/prod-setup applied, auth configured
+  ✓ vercel               — project {name}, domain live, SSL active
+  ✓ vercel-env-apply     — {present}/{required} env vars (0 missing required)
+  ✓ resend               — sending domain verified ({mail.domain})
+  ✓ supabase-smtp-wire   — custom SMTP verified via test signup (sender: {address})
+  ✓ sentry               — DSN + auth token; 10% trace, 0% replay
+  ✓ posthog              — project token set (env var name: {current})
+  ✓ ai-spend-caps        — OpenAI ${cap}/mo, Vercel ${cap} on-demand, Google AI quota
+  ✓ github-ci            — 4 secrets set (dev Supabase + shared)
+
+Cross-cutting checks:
+  Env var completeness:  PASS
+  First prod deploy:     READY
+  Landing page:          200 OK, SSL active
+  Custom SMTP verified:  PASS (sender confirmed)
+
+Risk review: HIGH {n} | MEDIUM {n} | LOW {n}
+  <top 3 findings if any HIGH>
+
+Sharpest failure mode 3 months in:
+  <opinionated one-liner>
+
+[C] Continue to Phase 5 (feature integrations)
+[R] Revise a specific integration
+[X] Exit (state preserved)
+```
+
+**If `planMode=true`:** Display "Dry-run complete at Phase 4 boundary — re-invoke without `--plan` to execute." and stop.
+
+**If C:** Load and execute `{nextStepFile}`. Pass forward: completed group-A integrations, Vercel project info, Supabase URLs, env var completeness confirmation.
+
+**If R:** Jump back to the offending integration in the dispatcher loop. Sub-item state ensures only the failing parts re-run.
+
+**If X:** Stop cleanly.

--- a/.claude/skills/production-deploy/steps/step-05-integrations.md
+++ b/.claude/skills/production-deploy/steps/step-05-integrations.md
@@ -1,0 +1,120 @@
+---
+name: step-05-integrations
+description: Dispatcher — executes dependency-group B integrations (OAuth providers, payment processors, background jobs, custom webhooks — things that need Phase 4's infra to be live). Uses the same dispatcher pattern as Phase 4: manifest-driven, reference-file-sourced, sub-item state, per-integration risk review.
+workflow_path: .claude/skills/production-deploy
+thisStepFile: .claude/skills/production-deploy/steps/step-05-integrations.md
+nextStepFile: .claude/skills/production-deploy/steps/step-06-smoke-test.md
+workflowFile: .claude/skills/production-deploy/SKILL.md
+stateFile: _bmad-output/deployment-checklist.md
+integrationsDir: .claude/skills/production-deploy/references/integrations
+riskReviewerAgentFile: .claude/skills/production-deploy/agents/deploy-risk-reviewer.md
+---
+
+# Phase 5 — Feature Integrations (manifest dispatcher, group B)
+
+## STEP GOAL
+
+Execute every integration marked as dependency-group B in the Phase 1 manifest — the ones that need Phase 4's infra to be live first. Typical group B contains OAuth providers, Stripe sandbox, background jobs (Inngest/QStash), and custom webhook integrations (n8n/Zapier). Exits with every declared integration functional on the deployed app.
+
+## MANDATORY EXECUTION RULES
+
+- Same dispatcher pattern as Phase 4 — read manifest (group B), walk in dependency order, dispatch to reference files.
+- **Live Stripe is out of scope** for this skill. Only configure Stripe in test/sandbox mode. Flag the live transition as a separate ceremony (future `stripe-live-transition` skill).
+- Sub-item state granularity applies (same as Phase 4). Stripe product creation is non-idempotent-by-default — the reference file's pre-checks matter.
+- Spawn `deploy-risk-reviewer` per integration with a narrow rubric.
+- Respect `planMode` — dry-run describes, doesn't execute.
+
+## Sequence of Instructions
+
+### 1. Load manifest and compute dependency order for group B
+
+Read `{stateFile}` manifest, filter to group B (or "feature" — whatever the manifest calls post-infra integrations).
+
+**Typical group B order** (override if manifest says otherwise):
+1. OAuth providers (parallel — no inter-dependency; but need domain live from Phase 4)
+2. Payment processor sandbox (Stripe test mode: products → prices → webhook → restricted key → DB linking)
+3. Background jobs (Inngest via Vercel integration, with Deployment Protection bypass)
+4. Custom webhook integrations (n8n, Zapier, etc.)
+5. Project-specific unknown integrations (context7-researched at runtime)
+
+### 2. Dispatcher loop
+
+Same shape as Phase 4 step 3. For each integration:
+
+```
+for integration in execution_list:
+  if state_file[phase_5][integration].status == "complete": skip
+  ref = read("{integrationsDir}/{integration}.md") or context7-generate
+  display ref.summary
+  for substep in ref.setup_steps:
+    if state_file[phase_5][integration][substep.id].status == "complete": skip
+    execute(substep)  # planMode: describe only
+    state_file.save()
+  spawn deploy-risk-reviewer (narrow rubric)
+  mark integration complete
+```
+
+### 3. Integration-specific concerns (applied via reference files)
+
+These notes are reminders of what the relevant reference files must cover. When authoring or updating a reference file, make sure these are addressed:
+
+**OAuth providers** (`oauth-{provider}.md`):
+- Dual-callback pattern for any provider used both for sign-in AND platform-connect. Register BOTH redirect URIs in the provider's app settings.
+- Supabase OIDC wire-up (if sign-in): enable provider under Supabase Auth → Providers, paste Client ID/Secret.
+- Verify the flow end-to-end via Playwright MCP if available.
+- Handle Google Safe Browsing caveat for fresh domains (see known-pitfalls.md).
+
+**Stripe sandbox** (`stripe.md`):
+- **TEST MODE ONLY**. Skill must refuse live-mode in Phase 5 — direct user to the separate live-transition skill.
+- Minimum webhook event set — grep `src/app/api/stripe/webhook` for what the app actually handles; don't subscribe to more.
+- Restricted API key scope: narrowest possible.
+- DB tier linking SQL: show before running.
+
+**Background jobs** (`inngest.md` or equivalent):
+- Deployment Protection bypass key — sync silently fails without it (see known-pitfalls.md).
+- Verify function registration in provider dashboard after deploy.
+- Fire one test event to confirm end-to-end.
+
+**Custom webhooks** (`n8n.md`, `zapier.md`):
+- Auth scheme from the app's webhook handler (`WEBHOOK_SECRET` HMAC / Bearer).
+- If origin system has plan limitations (e.g., n8n Starter has no `$vars`), generate a config-update script for workflows that reference env vars the plan doesn't support.
+- Test fire from origin → confirm app responds 200.
+
+### 4. Unknown integrations (context7-first pattern)
+
+For any integration in the manifest with no reference file:
+
+1. Prompt user: "Describe what {name} does in this project."
+2. Fetch current setup docs via context7 (or WebFetch fallback).
+3. Propose setup steps; execute with user approval.
+4. At phase end, offer to generate `{integrationsDir}/{name}.md` — persists the learning for future deploys of other forks.
+
+### 5. Phase 5 Gate
+
+Spawn `deploy-risk-reviewer` with phase-5 rubric: "for each integration, verify the flow works end-to-end, secrets are env-scoped correctly, webhook signatures verify, no drift between code and live config."
+
+```
+=== PHASE 5: FEATURE INTEGRATIONS — SUMMARY ===
+
+Integrations executed ({completed}/{total} from group B):
+  ✓ oauth-{provider}     — sign-in + platform-connect both working
+  ✓ stripe-sandbox       — test mode; products + webhook; {N} events subscribed
+  ✓ inngest              — {N} functions registered; bypass key configured
+  ✓ custom-webhooks      — verified via test fire
+
+New reference files generated for future deploys:
+  <list if any>
+
+Deferred for separate skills:
+  - Stripe live mode — invoke `stripe-live-transition` when ready for paying customers.
+
+Risk review: HIGH {n} | MEDIUM {n} | LOW {n}
+
+[C] Continue to Phase 6 (smoke test)
+[R] Re-run a specific integration
+[X] Exit (state preserved)
+```
+
+**If C:** Load `{nextStepFile}`.
+**If R:** Jump back; sub-item state ensures minimal re-work.
+**If X:** Stop cleanly.

--- a/.claude/skills/production-deploy/steps/step-06-smoke-test.md
+++ b/.claude/skills/production-deploy/steps/step-06-smoke-test.md
@@ -1,0 +1,131 @@
+---
+name: step-06-smoke-test
+description: End-to-end smoke test of the production deployment via Playwright MCP. Covers landing, signup/magic link (verifying branded sender), sign-in, OAuth connect flows, admin gate, dev-login blocked, plus a final cost-posture review gate.
+workflow_path: .claude/skills/production-deploy
+thisStepFile: .claude/skills/production-deploy/steps/step-06-smoke-test.md
+nextStepFile: .claude/skills/production-deploy/steps/step-07-document.md
+workflowFile: .claude/skills/production-deploy/SKILL.md
+stateFile: _bmad-output/deployment-checklist.md
+---
+
+# Phase 6 — Smoke Test
+
+## STEP GOAL
+
+Walk every critical user path on the live production URL. Catch silent failures: default-sender emails, OAuth 404s, admin bypasses, sampling not actually applied. Archive screenshots at `_bmad-output/implementation-artifacts/screenshots/deploy/` for the record. Close with a final cost-posture review gate.
+
+## MANDATORY EXECUTION RULES
+
+- Use Playwright MCP for all browser flows. If unavailable, prompt to authenticate it before starting.
+- Screenshot at every significant assertion.
+- Verify by observed behavior, not by "status says configured." Example: confirm the magic-link email sender is the branded address by inspecting the received email, not by "Resend DNS verified".
+- Treat any failed check as a phase blocker. Fix, redeploy, re-run just that check.
+
+## Sequence of Instructions
+
+### 1. Landing page
+
+- Navigate to `https://{PRODUCTION_DOMAIN}`.
+- Screenshot full page.
+- Confirm: SSG (view-source has rendered HTML, no client-fetch flash), no console errors, meta tags present (OG image, title).
+- Record response status, TTFB.
+
+### 2. Signup + magic link
+
+- Navigate to sign-up page.
+- Submit a fresh test email (use a real inbox you control — disposable mail services often block magic links).
+- Screenshot confirmation state.
+- Wait for email. **Inspect the `From` field.** Must be branded (`noreply@mail.{PRODUCTION_DOMAIN}`), not `noreply@mail.app.supabase.io`.
+- Click magic link. Confirm lands on dashboard. Screenshot.
+- Verify: new user has the expected trial subscription (DB query via Supabase MCP or dashboard).
+
+### 3. Sign-in (existing user)
+
+- Log out. Sign in with the same email. Screenshot dashboard.
+- Confirm session persists across refresh.
+
+### 4. OAuth connects (per configured provider)
+
+For each OAuth provider the app uses:
+
+- Navigate to connection settings.
+- Click Connect.
+- Complete provider OAuth flow.
+- Screenshot at each step.
+- **Special check**: if Google Safe Browsing flagged the domain earlier, expect the scary screen on provider redirect. Record that review is pending if so.
+- Verify token encrypted at rest (spot check the credentials table that stores third-party tokens via Supabase MCP — tokens should be opaque strings, not readable keys; see `.claude/rules/platforms.md`).
+
+### 5. Core feature path (project-specific)
+
+Pick the 1-2 features that represent the app's primary value. Exercise them on production with the test user:
+- Create a record / submit a form / run an AI call
+- Confirm it persists, completes, and shows in UI
+
+### 6. Admin gate
+
+- Discover the project's admin route(s) and admin-determination mechanism by reading the routing structure and middleware.
+- As the test user (non-admin): confirm 403/redirect.
+- As a user with admin privileges: confirm access.
+
+### 7. Dev-only auth bypass blocked
+
+Verify any development-only authentication endpoint is blocked in production. Discover the endpoint by reading auth route handlers (look for environment guards).
+
+_e.g. (vt-saas-template projects with `/api/auth/dev-login`):_
+
+```bash
+curl -sS -o /dev/null -w "%{http_code}" \
+  -X POST "https://{PRODUCTION_DOMAIN}/api/auth/dev-login" \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"test@test.com","password":"password"}'
+```
+
+Expected: `403` or `404`. Any success response is a production security bug — halt, fix, redeploy, re-verify.
+
+### 8. Observability check
+
+- Trigger a test Sentry event (small client-side error or `Sentry.captureException` via server action). Confirm it appears in Sentry.
+- Trigger an AI call. Confirm a Langfuse trace appears (if Langfuse detected).
+- Confirm PostHog captures a page view (check live events in PostHog).
+
+### 9. Cost posture final gate (the gap that the initial session missed)
+
+Verify **observed** (not configured) cost posture:
+
+| Check | Pass criteria |
+|---|---|
+| Landing page SSG | No function invocation in Vercel logs for landing page view |
+| Sentry prod trace sample rate | Actual traces being sampled at configured rate (visible in Sentry usage) |
+| Sentry replay off | 0 replay events in Sentry for alpha |
+| DB auto-migrate not running in prod | `vercel logs` shows no migration line on cold start |
+| AI quota gating live | Free-tier test call uses fallback model (verify via Langfuse trace model field) |
+| Vercel spend cap set | `vercel teams ls` or dashboard shows cap active |
+| OpenAI cap set | Dashboard shows monthly cap + alert thresholds active |
+
+### 10. Phase 6 Gate
+
+Spawn `deploy-risk-reviewer` with final rubric: "all five dimensions. This is the last-chance review before the deploy is declared successful."
+
+```
+=== PHASE 6: SMOKE TEST — SUMMARY ===
+
+Flow coverage:
+  Landing:            ✓ (SSG verified)
+  Signup + magic link:✓ (branded sender confirmed: noreply@mail.{PRODUCTION_DOMAIN})
+  Sign-in:            ✓
+  OAuth connects:     {per provider status}
+  Core feature path:  ✓
+  Admin gate:         ✓
+  Dev-login blocked:  ✓ (403 returned)
+  Observability:      Sentry ✓, PostHog ✓, {Langfuse ✓ if applicable}
+
+Cost posture: {pass / N gaps}
+
+Screenshots archived: _bmad-output/implementation-artifacts/screenshots/deploy/
+
+Final risk review: HIGH {n} | MEDIUM {n} | LOW {n}
+
+[C] Continue to Phase 7 (documentation)
+[R] Re-run a specific flow
+[X] Exit
+```

--- a/.claude/skills/production-deploy/steps/step-07-document.md
+++ b/.claude/skills/production-deploy/steps/step-07-document.md
@@ -1,0 +1,72 @@
+---
+name: step-07-document
+description: Capture the deployment into durable docs so the next deploy doesn't start from scratch — writes/updates docs/deployment-guide.md, adds a deployment section to CLAUDE.md, updates project memory with decisions + incidents, exports the checklist state for archive.
+workflow_path: .claude/skills/production-deploy
+thisStepFile: .claude/skills/production-deploy/steps/step-07-document.md
+nextStepFile: .claude/skills/production-deploy/steps/step-08-backport.md
+workflowFile: .claude/skills/production-deploy/SKILL.md
+stateFile: _bmad-output/deployment-checklist.md
+guideFile: docs/deployment-guide.md
+claudeMdFile: CLAUDE.md
+---
+
+# Phase 7 — Document
+
+## STEP GOAL
+
+Convert the state file + discoveries of this deploy into reference material that survives the session: a human-readable `docs/deployment-guide.md` future-you can skim, a short CLAUDE.md section telling AI assistants how the project is deployed, a memory entry with key decisions, and an archived copy of the checklist.
+
+## MANDATORY EXECUTION RULES
+
+- Never overwrite existing content silently. If a file exists, diff before writing.
+- Use the structure of the existing `docs/deployment-guide.md` if present (this pattern was established during prior deploys). Extend rather than replace.
+- Capture decisions WITH their *why*, not just *what* — future reviewers need to evaluate if the rationale still holds.
+
+## Sequence of Instructions
+
+### 1. Write/update `docs/deployment-guide.md`
+
+If file does not exist, scaffold from the template at `.claude/skills/production-deploy/templates/deployment-guide.template.md` (create this template if it doesn't exist yet — simple markdown with sections: Platform, Infrastructure Table, Key Architecture Decisions, CI/CD, Env Vars Strategy, DB Operations, Background Jobs, Observability, OAuth, Integrations, Known Issues & TODOs).
+
+If file exists, extend with a dated "Deployment N — {date}" subsection covering:
+- What changed vs prior deploy
+- New integrations added
+- Any drift reconciliations applied (e.g., env var renames)
+- New known issues
+
+### 2. Update `CLAUDE.md` deployment section
+
+Add (or update) a short section `## Deployment` containing:
+- Production URL
+- Vercel project name
+- Supabase project ref
+- Critical commands (`npm run db:migrate`, how to run prod-setup.sql)
+- Link to `docs/deployment-guide.md`
+- Any project-specific deploy hazards (e.g., "never db:push — apply dev schema via Supabase MCP; migrations get generated on main")
+
+### 3. Update project memory
+
+Via memory system: write or update `project_production_deployment.md` with:
+- Production URL
+- Infrastructure table (Vercel, Supabase, Resend, Sentry, etc. with one-line purposes)
+- Key decisions (free-tier lifecycle, TOKEN_ENCRYPTION_KEY policy, Sentry sampling, etc.) — each with a **Why** and **How to apply**
+- Operational reference (checklist location, guide location)
+
+### 4. Archive the state file
+
+Copy `{stateFile}` to `_bmad-output/deployments/deploy-{date}.md` (or project's preferred archive pattern). The active state file can then be cleared or renamed for the next deploy.
+
+### 5. Phase 7 Gate
+
+```
+=== PHASE 7: DOCUMENT — SUMMARY ===
+
+docs/deployment-guide.md:  updated | created
+CLAUDE.md deployment section: updated | added
+Memory entry updated: project_production_deployment.md
+State file archived: _bmad-output/deployments/deploy-{date}.md
+
+[C] Continue to Phase 8 (backport to template)
+[R] Revise a doc
+[X] Exit (deploy is complete; skipping backport only)
+```

--- a/.claude/skills/production-deploy/steps/step-08-backport.md
+++ b/.claude/skills/production-deploy/steps/step-08-backport.md
@@ -1,0 +1,132 @@
+---
+name: step-08-backport
+description: Review this deployment's discoveries for template-worthy fixes — drift reconciliations, version pins, scaffolding additions, pitfall callouts — and raise GitHub issues against thevarun/vt-saas-template so the next product fork doesn't re-learn them.
+workflow_path: .claude/skills/production-deploy
+thisStepFile: .claude/skills/production-deploy/steps/step-08-backport.md
+workflowFile: .claude/skills/production-deploy/SKILL.md
+stateFile: _bmad-output/deployment-checklist.md
+templateRepo: thevarun/vt-saas-template
+---
+
+# Phase 8 — Backport to Template
+
+## STEP GOAL
+
+Feed learnings back to the shared base. For every template-generic fix or pitfall surfaced during this deploy, raise a GitHub issue on `vt-saas-template` describing the change and why future forks would benefit. User approves each issue before it's created.
+
+## MANDATORY EXECUTION RULES
+
+- Only propose backports for **template-generic** items. Project-specific integrations, tier names, brand choices, etc. stay in the project.
+- Show the full proposed issue body before creating. User `[C]` approves → Claude runs `gh issue create`.
+- Use the issue label `backport-from-deploy` (create if absent) so template maintainer can filter.
+- If `gh` is not authenticated against the template repo, prompt the user and halt that backport.
+
+## Sequence of Instructions
+
+### 1. Scan for backport candidates
+
+From the current state file and the risk-review findings across phases, extract:
+
+| Category | Examples seen on real deploys |
+|---|---|
+| **Scaffolding files missing** | `supabase/prod-setup.sql` template, landing-page SSG pattern, `.env.example` key-coverage |
+| **Framework/toolchain pins** | TS 6 `baseUrl` deprecation fix (`ignoreDeprecations: "6.0"` in tsconfig), Node version pin |
+| **Runtime-config gaps** | `NODE_ENV=production` guard on DB auto-migration |
+| **Upstream drift fixes** | PostHog env var name update (`NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN`) |
+| **Cost defaults** | Env-aware Sentry sampling defaults (0.1 prod, 1.0 dev) |
+| **Security defaults** | `ADMIN_EMAILS` fallback check, dev-login hard block in prod |
+| **Deploy-day pitfall additions** | Inngest Deployment Protection bypass flow, Supabase custom SMTP wiring gotcha (it's not enough to verify DNS — must toggle SMTP in Supabase Auth too) |
+| **Provider instruction updates** | New dashboard paths, scope requirements, webhook event lists |
+
+For each candidate, determine: is it a code/config change (makes sense as a PR), a doc update (deployment-guide template), or a pitfall callout (skill's `known-pitfalls.md`)? Classify accordingly.
+
+### 2. Draft issue bodies
+
+For each candidate, draft a GitHub issue with this shape:
+
+```markdown
+## Backport candidate: {title}
+
+**Source deploy:** {project name} at {production URL}, deployed {date}
+**Category:** {from table above}
+
+### What surfaced
+{concrete symptom during deploy — cite the phase / evidence}
+
+### Why it's template-worthy
+{why future forks will hit the same thing}
+
+### Proposed change
+{a code snippet, config addition, doc section, or pitfall entry}
+
+### Risk / scope
+{what it breaks if applied blindly, what testing is needed}
+
+Label: `backport-from-deploy`
+```
+
+### 3. Review gate (batch)
+
+Present all drafted issues in one panel:
+
+```
+Drafted {N} backport candidates:
+
+1. [{category}] {title} — {one-line summary}
+   → [C] Create / [S] Skip / [R] Revise
+
+2. [{category}] ...
+
+[C all]   Create all
+[S all]   Skip all (close this phase)
+[R all]   Revise any
+[X]       Exit without action
+```
+
+### 4. Create approved issues
+
+For each approved candidate:
+
+```bash
+gh issue create \
+  --repo {templateRepo} \
+  --title "{issue title}" \
+  --label backport-from-deploy \
+  --body-file {tmp-body-file}
+```
+
+If repo doesn't have the `backport-from-deploy` label, create it first:
+```bash
+gh label create backport-from-deploy \
+  --repo {templateRepo} \
+  --description "Fixes/additions surfaced during a production deploy of a fork" \
+  --color 0E8A16
+```
+
+Record created issue URLs in the state file.
+
+### 5. Phase 8 Gate (final)
+
+```
+=== PHASE 8: BACKPORT — SUMMARY ===
+
+Backport candidates scanned: {N}
+Issues created on {templateRepo}: {M}
+  {list with URLs}
+Skipped: {count} (with reasons)
+
+=== DEPLOY COMPLETE ===
+
+Production URL: {url}
+Total time: {if trackable}
+Phases: 1-8 all green
+Deferred follow-ups: {list from various phases}
+
+Next steps you might want:
+  - Monitor Sentry + Vercel logs for the first 24h
+  - Invite your first alpha user
+  - Plan the Stripe live-mode transition when payments matter
+  - Run `/production-deploy` again for your next product — the integration reference library is now seeded
+
+Thank you for using production-deploy. Learnings captured; the next deploy will be faster.
+```

--- a/.claude/skills/production-deploy/templates/deployment-checklist.template.md
+++ b/.claude/skills/production-deploy/templates/deployment-checklist.template.md
@@ -1,0 +1,184 @@
+# {PROJECT_NAME} Production Deployment Checklist
+
+**Started:** {YYYY-MM-DD}
+**Domain:** {PRODUCTION_DOMAIN}
+**Invocation:** `/production-deploy` | `--plan` (dry-run) | `--resume`
+
+---
+
+## State file conventions
+
+This file is the **canonical state artifact**. The `production-deploy` skill reads and writes it. Notes for consumers:
+
+- **Phases 1, 2, 3, 6, 7, 8** track at phase granularity. An unchecked phase means "re-run the phase" — these phases are read-only or cheap to redo.
+- **Phases 4 and 5** track at sub-item granularity. Each integration has its own checklist filled from its reference file. Pre-checks at each sub-step read this state and skip already-completed items — mid-phase crash doesn't force redoing DB writes, DNS records, Stripe products, etc.
+- Safe to exit the skill at any gate; state persists.
+
+---
+
+## Phase 1 — Plan
+
+- [ ] Prior context absorbed (CLAUDE.md, Env.ts, .env.example, deployment-guide.md, memory)
+- [ ] Upstream backport candidates checked (`gh issue list --repo {template-repo} --label backport-from-deploy`)
+- [ ] Integrations detected (see manifest below)
+- [ ] Tool availability audited (see tool table below)
+- [ ] Context7 coverage probed (see coverage table below)
+- [ ] Current provider docs fetched for drift-prone providers
+- [ ] Risk review pass complete (findings logged)
+- [ ] Pitfalls-to-watch list surfaced
+
+**Integration manifest:**
+_(populated by step-01-plan — includes per-integration group assignment A vs B, dependencies, reference file status)_
+
+**Tool availability:**
+_(populated by step-01-plan — per tool: present | not-authenticated | not-installed)_
+
+**Context7 coverage:**
+_(populated by step-01-plan — per provider: ✓ library_id | ✗ no match → fallback plan)_
+
+**Drift findings:**
+_(populated by step-01-plan — e.g., "code uses NEXT_PUBLIC_POSTHOG_KEY, current docs use NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN")_
+
+**Skipped backport candidates:**
+_(populated if user chose `[P] Proceed as-is` in step-01-plan#1b — risk reviewer flags downstream)_
+
+---
+
+## Phase 2 — Readiness
+
+### Mechanical
+- [ ] `npm run build` passes locally
+- [ ] `npm run check-types` passes
+- [ ] `npm run lint` passes
+- [ ] `npm run test` passes
+- [ ] Git state clean
+- [ ] Open PRs triaged
+
+### Hygiene
+- [ ] RLS enabled on every app-schema table
+- [ ] User tier enforcement on quota-gated endpoints
+- [ ] Admin gate in middleware + route handlers
+- [ ] Dev-login endpoint blocked in prod
+- [ ] Rate limiting wired on public endpoints
+- [ ] `.env.example` up to date
+
+### Cost
+- [ ] Landing SSG
+- [ ] Sentry sampling env-aware
+- [ ] DB auto-migration disabled in prod
+- [ ] Free-tier AI quota gating active
+- [ ] Spend caps planned (Vercel, OpenAI, Google AI)
+
+---
+
+## Phase 3 — Env Strategy
+
+- [ ] Env-plan table produced (see appendix)
+- [ ] Per-env classifications decided
+- [ ] Drift reconciliations logged
+- [ ] CI secrets pointed at dev (not prod)
+
+**Env-plan table:**
+_(populated by step-03-env-strategy)_
+
+**If `--plan` invocation, dry-run ends here.** Re-invoke without `--plan` to execute Phases 4-8.
+
+---
+
+## Phase 4 — Core Infra (dispatcher, group A)
+
+**This section is populated at runtime from the Phase 1 manifest — sub-items vary by detected stack.** Fine-grained sub-item state enables safe resume. Pre-checks skip already-completed sub-items.
+
+### Execution plan
+_(populated at Phase 4 start — topologically-sorted list of group-A integrations with their reference files)_
+
+### Per-integration state
+
+_Template for each integration (repeated per manifest entry):_
+
+#### Integration: {name}  (ref: `references/integrations/{name}.md`)
+- [ ] Pre-check passed / skipped (already complete)
+- [ ] Sub-step 1: {from ref}
+- [ ] Sub-step 2: {from ref}
+- [ ] …
+- [ ] Per-integration risk review (deploy-risk-reviewer)
+
+_Typical group A integrations (will vary):_ supabase, vercel, vercel-env-apply, resend, supabase-smtp-wire, sentry, posthog, (langfuse), ai-spend-caps, github-ci.
+
+### Phase 4 cross-cutting gates
+- [ ] Env var completeness verified (0 missing required)
+- [ ] First prod deploy green
+- [ ] Landing page returns 200, SSL active
+- [ ] **Custom SMTP actually wired** — test signup email's From confirmed branded
+- [ ] Phase 4 comprehensive risk review
+
+---
+
+## Phase 5 — Feature Integrations (dispatcher, group B)
+
+**Same dispatcher pattern as Phase 4, for integrations that depend on infra being live.**
+
+### Execution plan
+_(populated at Phase 5 start)_
+
+### Per-integration state
+
+_Template for each integration:_
+
+#### Integration: {name}  (ref: `references/integrations/{name}.md`)
+- [ ] Pre-check passed / skipped
+- [ ] Sub-step 1: {from ref}
+- [ ] …
+- [ ] Per-integration risk review
+
+_Typical group B integrations:_ oauth-{provider}, stripe-sandbox, inngest (or equivalent background jobs), custom-webhook integrations, unknown integrations (context7-researched).
+
+**Stripe live mode is out of scope.** If the user asks, direct to a future `stripe-live-transition` skill.
+
+---
+
+## Phase 6 — Smoke Test
+
+- [ ] Landing (SSG verified via Vercel logs — no function invocation on landing view)
+- [ ] Signup + magic link (branded sender confirmed — inspect email From field)
+- [ ] Sign-in (session persists across refresh)
+- [ ] OAuth connects (per provider in manifest)
+- [ ] Core feature path exercised
+- [ ] Admin gate (non-admin gets 403, admin email gets access)
+- [ ] Dev-login returns 403
+- [ ] Observability captures events (Sentry, PostHog, Langfuse if applicable)
+- [ ] Cost posture final review (every spend cap active, sample rates correct in prod)
+
+---
+
+## Phase 7 — Document
+
+- [ ] `docs/deployment-guide.md` updated (per-deploy section appended)
+- [ ] `CLAUDE.md` deployment section added/updated
+- [ ] Memory entry updated (`project_production_deployment.md`)
+- [ ] State file archived to `_bmad-output/deployments/deploy-{date}.md`
+
+---
+
+## Phase 8 — Backport
+
+- [ ] Backport candidates scanned from this run's findings
+- [ ] Issues drafted and reviewed with user
+- [ ] `backport-from-deploy` label created on template repo (if missing)
+- [ ] Issues raised against `thevarun/vt-saas-template`
+- [ ] Created issue URLs logged below
+
+**Created issues:**
+_(populated by step-08-backport)_
+
+---
+
+## Deferred follow-ups
+
+_(anything skipped-with-note across any phase — not blocking but should be tracked. Example: "Stripe live-mode transition — invoke separate skill when ready".)_
+
+---
+
+## Decisions log
+
+_(key decisions made during this deploy, with rationale — memory-file candidates. Example: "Free tier = 30-day trial, then expired-with-reduced-quotas (vs full paywall) — lower friction for alpha users.")_

--- a/.claude/skills/production-deploy/templates/deployment-guide.template.md
+++ b/.claude/skills/production-deploy/templates/deployment-guide.template.md
@@ -1,0 +1,160 @@
+# {PROJECT_NAME} — Deployment Guide
+
+**Last updated:** {YYYY-MM-DD} | **Domain:** {PRODUCTION_DOMAIN}
+
+---
+
+## Deployment Platform
+
+{PROJECT_NAME} deploys to **Vercel** via Git Integration. Pushes to `main` trigger automatic production deployments. PR branches get preview deployments.
+
+**Vercel project:** `{vercel-project-name}` — env vars scoped per environment.
+
+---
+
+## Production Infrastructure
+
+| Service | Account | Purpose |
+|---|---|---|
+| **Vercel** | {plan} | Hosting, serverless functions, CDN |
+| **Supabase** | `{project-ref}` ({plan}) | PostgreSQL, Auth, RLS |
+| **Resend** | `mail.{domain}` sending | Transactional emails |
+| **Sentry** | `{org/project}` | Error tracking |
+| **PostHog** | shared project | Product analytics |
+| **Domain** | {registrar} | Domain registrar / DNS |
+| _(add per project integrations)_ |  |  |
+
+---
+
+## Key Architecture Decisions
+
+_(capture per-deploy — each decision with Why + How-to-apply)_
+
+### Database
+- Schema: all tables in `{DB_SCHEMA}` (not `public`), via `DB_SCHEMA` env var
+- Migration strategy: push-in-dev, migrate-on-main
+- Auto-migration disabled in production (`NODE_ENV` guard in `src/libs/DB.ts`)
+- Execution order: `db:migrate` → `seed.sql` → `prod-setup.sql`
+
+### Subscription lifecycle
+_(if applicable — trial, expiry, tier transitions)_
+
+### Cost Optimization
+- Landing page SSG
+- Sentry: ~10% traces / 0% replays in prod, 100% in dev
+- Separate AI provider keys for prod vs dev (cost attribution)
+- Spend caps: Vercel ${cap}, OpenAI ${cap}/mo
+
+### Security
+- RLS on all app-schema tables
+- Dev-login endpoint 403 in prod
+- `TOKEN_ENCRYPTION_KEY` differs per env (prod tokens undecryptable in dev)
+- Custom SMTP via Resend (branded sender in auth emails)
+
+---
+
+## CI/CD Pipeline
+
+### GitHub Actions
+_(describe pipeline jobs — CI, release, dependabot)_
+
+### Branch Protection
+_(status — enforced vs configured)_
+
+---
+
+## Environment Variables
+
+### Scoping Strategy
+
+See `_bmad-output/deployment-checklist.md` (archived per-deploy at `_bmad-output/deployments/`) for the full env plan produced in Phase 3.
+
+### GitHub Actions Secrets
+Point to **dev** Supabase project (CI tests shouldn't touch prod):
+- `NEXT_PUBLIC_SUPABASE_URL` (dev)
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY` (dev)
+- `SUPABASE_SERVICE_ROLE_KEY` (dev)
+- `SENTRY_AUTH_TOKEN` (shared for source maps)
+
+---
+
+## Database Operations
+
+### Production Setup (one-time)
+
+```bash
+# 1. Run Drizzle migrations
+DATABASE_URL="<prod-pooler-url>" DB_SCHEMA={schema} npx drizzle-kit migrate
+
+# 2. Seed via Supabase SQL Editor
+# File: supabase/seed.sql
+
+# 3. Prod-setup via Supabase SQL Editor
+# File: supabase/prod-setup.sql
+```
+
+### Ongoing Schema Changes
+Feature branch: edit schema files, apply to dev via Supabase MCP `apply_migration` (never `db:push`). Never commit migration files on feature branches.
+Main branch: run `npm run db:generate` to produce canonical migration, commit.
+Production: `npm run db:migrate:ci` via the Vercel build.
+
+---
+
+## Background Jobs
+
+_(if applicable — Inngest, QStash, Vercel Cron)_
+
+| Function | Schedule | Purpose |
+|---|---|---|
+| ... | ... | ... |
+
+---
+
+## Monitoring & Observability
+
+| Service | Purpose | Sample rate | Dashboard |
+|---|---|---|---|
+| Sentry | Error tracking | 10% traces, 0% replays (alpha) | sentry.io |
+| PostHog | Product analytics | client-side, lazy-loaded | app.posthog.com |
+| Vercel | Deploy + function logs | all requests | vercel.com |
+
+### Alerts
+- Sentry high-priority issues (auto-rule)
+- Vercel on-demand spend cap at ${cap}
+- OpenAI monthly budget with alert thresholds
+
+---
+
+## OAuth Configuration
+
+_(per provider in use — include BOTH callback URLs if dual-use)_
+
+### {Provider}
+- App/platform-connect callback: `https://{domain}/api/auth/callback/{provider}`
+- Supabase Auth OIDC callback: `https://{supabase-ref}.supabase.co/auth/v1/callback`
+
+---
+
+## Known Issues & TODOs
+
+_(carry-forward list — track what's deferred)_
+
+- [ ] _(item)_
+
+---
+
+## Runbook: Rollback
+
+See `.claude/skills/production-deploy/references/rollback-reference.md` for tested rollback commands per provider.
+
+---
+
+## Deployment History
+
+### Deploy {N} — {YYYY-MM-DD}
+- **What changed:** {summary}
+- **New integrations:** {list}
+- **Drift reconciliations:** {list}
+- **Incidents during deploy:** {list}
+
+_(append per deploy in reverse chronological order)_

--- a/.claude/skills/qa/README.md
+++ b/.claude/skills/qa/README.md
@@ -1,0 +1,82 @@
+# qa skill — on-demand manual QA runner
+
+Runs the QA flows that unit/E2E tests can't cover — real browser via Playwright MCP, real third-party providers, real env plumbing — across two targets:
+
+* **`/qa --dev`** — local stack: dev server + dev Supabase + Gmail MCP. Cheap, fast, catches the integration bugs that escape unit tests.
+* **`/qa --prod`** — the deployed production URL: a full chained auth sequence on a fresh `+alias` test user. One alias to clean up at the end.
+
+Default if you don't specify a flag: `--dev`.
+
+The production URL is not hardcoded. The skill resolves `<PRODUCTION_URL>` from the project's public app-URL env var (`NEXT_PUBLIC_APP_URL` / `NEXT_PUBLIC_SITE_URL`) in `.env.local`, or asks you once if it can't find one.
+
+## One-time setup
+
+### 1. Environment variables
+
+Add to `.env.local` (git-ignored):
+
+```
+QA_EMAIL=<your-gmail>@gmail.com
+QA_PASSWORD=<only needed if you want auth-cookies to sign in to the base user>
+```
+
+Destructive runbooks generate per-run aliases like `<your-gmail>+qa-<timestamp>@gmail.com` automatically — the base `QA_EMAIL` is only used for non-destructive sign-in flows (and only if that base user exists in the target Supabase project).
+
+### 2. Gmail MCP
+
+Connect the Gmail MCP and sign it into `QA_EMAIL`. The skill uses `search_threads` / `get_thread` for inbox checks — no browser navigation to mail.google.com. Confirm by asking the skill to run a benign `search_threads` call once; if the connected account isn't `QA_EMAIL`, reconnect.
+
+### 3. Playwright MCP
+
+Driving the sign-up/sign-in forms and clicking magic-links uses the template's Playwright MCP convention (see `CLAUDE.md` → "Visual Development & Inspection"). Screenshots land in `_bmad-output/implementation-artifacts/screenshots` via the `downloadsDir` parameter with `savePng: true`.
+
+### 4. (Dev only) Local services
+
+Boot whatever the runbook needs. The skill's pre-flight will tell you precisely what's missing if any of these aren't ready:
+
+* **Dev server** — `npm run dev`. The skill reads the actual port from the running process (default 3000).
+* **Supabase MCP** — connected to your dev project.
+
+### 5. (Optional) Supabase base user for `auth-cookies`
+
+If you want `auth-cookies` (the read-only smoke that inspects `sb-*` cookie flags) to run on prod, create `QA_EMAIL` as a confirmed Supabase user in the prod project once. Otherwise the skill skips it and continues.
+
+## How to invoke
+
+- `/qa` or `/qa --dev` — run all dev-eligible runbooks against the local stack.
+- `/qa --prod` — run the full chained auth sequence on prod. One alias, one report.
+- `/qa <runbook>` — run a single runbook (uses the default mode).
+- `/qa <runbook> --dev` / `/qa <runbook> --prod` — single runbook against the chosen target.
+- `/qa list` — menu of available runbooks.
+- Natural-language: "qa the auth flows on prod", "run the signup flow on dev".
+
+Before any destructive action, the skill prints the **resolved environment manifest** — which Supabase project, which background-jobs target, which Resend keys, which Gmail account — and asks once for confirmation. The dev/prod flag chooses defaults, but the manifest shows what's actually wired up so you don't accidentally fire against a prod backing service from a "local" run.
+
+## Output
+
+- Inline report in chat with per-runbook pass/fail, broken down by `verified` / `unit-only` / `not-tested`.
+- Key-frame screenshots in `_bmad-output/implementation-artifacts/screenshots` (signup confirmation, rendered email body, post-auth dashboard, any failure state).
+- A trailing cleanup pointer references either the prod admin UI or a Supabase MCP DELETE statement, depending on mode.
+
+## Cleanup after a destructive run
+
+**Prod:** sign into `<PRODUCTION_URL>/<locale>/admin/users`, search for the alias from the report (or the `+qa-` substring to see all QA users), open the row, and delete. The admin delete flow invokes `supabase.auth.admin.deleteUser`.
+
+**Dev:** the report includes a single SQL statement you can run via Supabase MCP `execute_sql`:
+
+```sql
+DELETE FROM auth.users WHERE id = '<uuid-from-report>';
+```
+
+Cascades take care of any rows the user owns.
+
+## Adding a runbook
+
+Drop a new `runbooks/<domain>-<flow>.md` with frontmatter (`name`, `domain`, `destructive`, `prod`, `dev`, `requires`, `summary`) and a prose body covering goal / preconditions / outcome-keyed checkpoints / known failure modes / cleanup. `/qa list` picks it up automatically.
+
+Two rules:
+
+1. **Prose, not step-by-step.** Let the model figure out the tool calls.
+2. **Outcomes, not implementation.** Say "user reaches the post-auth dashboard," not "click the button labeled `Continue`." See `SKILL.md` → "Cross-cutting practices" → "Decoupling" for the long form.
+
+Reference docs (filename starts with `_`, no frontmatter) aren't runbooks — they're shared snippets that runbooks can link to.

--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -1,0 +1,245 @@
+---
+name: qa
+description: On-demand manual-QA runner for a vt-saas-template-derived SaaS. Drives flows that unit/E2E tests can't cover — real browser via Playwright MCP, real third-party providers, real env plumbing — across two targets (`--dev` for the local stack, `--prod` for the deployed production URL). Verifies email delivery via Gmail MCP, supports SQL time-travel for date-driven flows, captures key-frame screenshots on prod runs, and reports pass/fail split into verified vs unit-only vs not-tested with cleanup reminders for any test accounts created. Use before releases, after touching auth code, or whenever the user asks to QA something. Triggers on `/qa`, `/qa --dev`, `/qa --prod`, `/qa <runbook>`, `/qa <runbook> --dev`, `/qa <runbook> --prod`, or natural-language requests.
+---
+
+# QA Runner
+
+## Purpose
+
+Pre-release QA for flows that unit/E2E tests can't cover: real browser, real email rendering, real third-party providers, real production env plumbing. Describe **what to verify**; let the model figure out the tool calls.
+
+## Resolving the production URL
+
+`--prod` runs target the project's deployed production URL. This is not hardcoded — resolve `<PRODUCTION_URL>` once per run, in this order:
+
+1. The project's public app-URL env var in `.env.local` (e.g. `NEXT_PUBLIC_APP_URL` / `NEXT_PUBLIC_SITE_URL`).
+2. If absent, ask the user once for the production URL and use it for the run.
+
+`<TARGET>` in a runbook resolves to `http://localhost:<port>` under `--dev` and to `<PRODUCTION_URL>` under `--prod`.
+
+## Invocation model
+
+| Form | App URL | Behavior |
+|---|---|---|
+| `/qa --dev` (no runbook) | `http://localhost:<port>` | Runs all dev-eligible runbooks against the local stack |
+| `/qa --prod` (no runbook) | `<PRODUCTION_URL>` | Runs all prod-eligible runbooks chained on one fresh `+qa-` alias |
+| `/qa <runbook> --dev` | as above | Single runbook on dev |
+| `/qa <runbook> --prod` | as above | Single runbook on prod |
+| `/qa list` | — | Print the menu of runbooks |
+
+Default if neither flag is given: `--dev`. Dev runs are cheaper, safer, and surface integration bugs (email render pipeline, webhooks, etc.) earlier.
+
+Natural language matches against summaries.
+
+### Resolved-environment manifest (always shown before destructive actions)
+
+The `--dev` / `--prod` flag chooses defaults but isn't sufficient — in practice the boundary between local and prod can be split per service (backend on local but background jobs in prod cloud, Resend with prod keys while everything else is local, etc.). Each split has different blast-radius implications.
+
+Before any destructive action, print a manifest derived from `.env.local` and connected MCPs, then ask the user to confirm once for the whole run:
+
+```
+Resolved environment for this run:
+  App                http://localhost:3000             (dev server, port from the running process)
+  Database           Supabase project <project-id>     (dev / prod — derived from DATABASE_URL host)
+  Auth               Supabase project <project-id>     (matches DATABASE_URL)
+  Background jobs     <local dev server | cloud prod>   (derived from the jobs provider's base-URL env, or default)
+  Email (Resend)     <test key | prod key | console>   (derived from RESEND_API_KEY metadata, or "console-only" if unset)
+  Email destination  <Gmail account from Gmail MCP>    (the inbox we'll be searching)
+
+Proceed? (y/n)
+```
+
+Each backing service gets its own line — the per-service split is the point, so you can spot a "local" run that would actually fire against a prod backing service. Flag inconsistencies inline before the prompt (e.g. "⚠️  --dev was requested but Resend has a prod key — emails would go through prod infra"). Don't re-prompt per runbook.
+
+### Dependency order for `/qa --prod`
+
+Runbooks chain on a single browser session and a single `+alias` account:
+
+1. **`auth-cookies`** — read-only. Needs an existing prod user; uses base `QA_EMAIL`. If that user doesn't exist in prod, skip gracefully and continue.
+2. **`auth-magic-signup`** — creates a fresh `+signup-<ts>` alias, signs up, verifies both magic-link + welcome emails. Leaves the session authenticated.
+3. **`auth-magic-signin`** — signs out, then signs back in with the same alias to exercise the returning-user magic-link path.
+4. **`auth-password-reset`** — runs the forgot-password flow on the same alias.
+5. **`auth-admin-access`** — with the signed-in non-admin session, verifies `/admin` redirect gating.
+
+End state: one prod test user to clean up (the alias).
+
+### Dependency order for `/qa --dev`
+
+Auth runbooks tagged `dev: true` chain the same way as on `--prod`. Each destructive runbook provisions and tears down its own test user (via `/api/auth/dev-login` + Supabase MCP cleanup).
+
+## Prerequisites (checked at run start)
+
+Abort with a clear message if any required check fails. The capabilities check from "Cross-cutting practices" runs **first** — these are the additional environment-specific checks that follow.
+
+### Environment variables (both modes)
+
+Read from `.env.local`:
+
+- `QA_EMAIL` — Gmail inbox base address. The `+alias` suffix is generated per run.
+- `QA_PASSWORD` — password for the base account (only needed by runbooks that sign in to the base user).
+
+### Prod mode (`--prod`)
+
+- **Playwright MCP** — available for driving the live site.
+- **Gmail MCP** — connected to `QA_EMAIL`. Inbox checks go through Gmail MCP; the browser is only used to design-review rendered email bodies.
+- **Inbox guard** — call `search_threads` once with a benign query (e.g. `from:gmail`) to confirm the connected account corresponds to `QA_EMAIL`. If the response is empty or the account doesn't match, abort with the actual vs expected.
+
+### Dev mode (`--dev`)
+
+- **Dev server** — running and reachable (`npm run dev`, default port 3000). Read the actual port from the running dev-server process rather than hard-coding it.
+- **Supabase MCP** — connected to the dev project (project ID derived from `.env.local`).
+- **Gmail MCP** — connected. Same role as in prod mode.
+- **Playwright MCP (only if a runbook needs UI)** — many dev-mode steps don't need a browser at all (API-path invocations via `/api/auth/dev-login` + DB inspection cover most checkpoints).
+
+## Running a sequence
+
+1. Capabilities check + baseline check (see "Cross-cutting practices" → pre-flight). Abort on missing capability.
+2. Generate the session's alias: `${QA_EMAIL_LOCAL}+qa-${unixTimestamp}@${QA_EMAIL_DOMAIN}`. Log it prominently — the user needs it for cleanup.
+3. **Print the resolved-environment manifest** (see "Invocation model") and confirm once with the user. Proceed only on affirmative.
+4. For each runbook in dependency order, emit a one-line progress gate: `[N/M] <runbook-name> — running…`, then execute.
+5. After each runbook, emit `[N/M] <runbook-name> — ✅ PASS | 🟡 PARTIAL | ❌ FAIL` with a one-line note. Continue to next runbook even on failure (unless the failure precludes chaining).
+6. Emit the final report (see below).
+
+## Running a single runbook
+
+Same shape, but skip the sequence loop.
+
+## Safety
+
+- **Destructive prod runs must use `+alias` emails.** Never touch the base `QA_EMAIL` account for signups.
+- **Ask once before a destructive prod sequence**, not per-runbook. One alias serves the whole chain.
+- **Never echo passwords** in logs, screenshots, or reports.
+- **Don't close the browser tabs on success** — the user may want to inspect state. On failure, capture one frame of the failing state and stop.
+
+## Screenshots
+
+Use the template's Playwright MCP convention: capture key-frame screenshots to `_bmad-output/implementation-artifacts/screenshots` (use the `downloadsDir` parameter and `savePng: true`, per `CLAUDE.md` → "Visual Development & Inspection"). On prod runs, capture the key frames the runbook calls out (signup confirmation, rendered email body, post-auth dashboard, any failure state). Don't screenshot every routine checkpoint — capture frames that are worth calling out inline in the report or that serve as design-review artifacts.
+
+## Defensive patterns when driving the browser
+
+Browser automation is lossy — tool/MCP behavior shifts, frameworks intercept events, email providers restructure DOM. Treat these patterns as the default, and only deviate when you have evidence the happy path worked.
+
+**Verify the outcome of any action you can't observe directly.**
+After clicking a link that should open a new tab, read tab state immediately — don't navigate elsewhere first and check later. After submitting a form, read the next-state signal (URL change, new text on page) before assuming success. Don't let a silent "no-op" cascade into downstream steps.
+
+**When a click appears to do nothing, don't retry it blindly.**
+Frameworks like React sometimes don't see tool-dispatched clicks as a "real" submit. Try the framework's own mechanism (e.g. triggering the form's native submit event directly) before concluding the UI is broken. Similarly, if an element was found but clicking has no effect, check whether it's actually visible and laid-out — some email clients collapse repeated messages in a thread and leave their anchors in the DOM as non-interactive.
+
+**URL inspection from page JS may be blocked for safety.**
+You often can't read `href` values containing tokens or cookies directly. Clicking the visible anchor is usually the only path. Rely on the resulting navigation, not on URL extraction.
+
+**Single-use token ⚠️ — don't touch links twice.**
+Supabase verification/magic-link URLs are single-use. Any interaction that fetches the URL (a programmatic click, a JS navigation, even some inspection patterns) consumes it. If a runbook step "re-checks" a link after an earlier touch, that second read will look expired even though the flow was fine. If a fresh link lands on an expired/error page, assume the token was already spent somewhere upstream before concluding a product bug.
+
+**Human-click fallback is not a failure mode — it's a valid completion path.**
+When MCP-driven clicks of a verification link consistently fail to produce an authenticated session, ask the user to click the link manually once and continue from the resulting signed-in state. That preserves the value of the runbook (you still verify email delivery, rendering, and the final app state) without burning time fighting tooling. Clearly mark findings as `✅ PASS via human click` vs `✅ PASS` so future runs can tell the difference.
+
+**Distinguish product findings from tooling quirks in the report.**
+If a behavior is surprising — a page doesn't advance, a link looks expired — consider whether a tooling quirk is the likeliest cause before concluding a product bug. State the hypothesis in the finding and name what would invalidate it ("verify by clicking manually / by opening in a fresh context / by running on preview").
+
+## Cross-cutting practices
+
+These apply to every runbook, regardless of domain. Read them once before authoring or running anything.
+
+### Decoupling — describe outcomes, not implementation
+
+Runbooks describe **user-observable outcomes**, not implementation. Examples of stable contracts you can reference: route paths (`/sign-up`, `/admin`), public API shapes, observable lifecycle states, email sender domain. Examples of brittle implementation details to avoid: button labels, banner copy, CSS selectors, element ordering, internal helper function names. When a checkpoint is naturally about copy, pattern-match loosely (substring or sender + recency), not exact-string. The point is that a UI redesign or copy refresh should not silently break runbooks.
+
+### Pre-flight: capabilities first, baseline second
+
+Pre-flight has two purposes, in this order:
+
+1. **Capabilities check** — every runbook declares its `requires` (e.g. `gmail-mcp`, `supabase-mcp`, `dev-server`, `playwright-mcp`). Before starting, walk that list and confirm each is actually reachable in the current session. **If any required tool/MCP is missing or not connected, stop with a clear message naming the missing capability and how to bring it in** (e.g. "Dev server is not running — run `npm run dev`, then re-invoke `/qa`"). Do not partially run a runbook with missing dependencies — partial runs produce false negatives.
+2. **Baseline check** — run `npm run check-types` and `npm run test`, note the pass/fail counts as the baseline. Abort if either is broken in a way the runbook can't possibly cause. This catches "tests were already red" so you don't conflate pre-existing breakage with run findings. Skipping the baseline is OK if explicitly opted out (e.g. `/qa --skip-baseline`); skipping capabilities is never OK.
+
+### Real-send verification for any email-emitting step
+
+When a step triggers an email, verification has three layers and you do all three:
+
+1. **Server logs** — grep dev/prod logs for `Email sent: <type>` (success line in `src/libs/email/emailLogger.ts`) and `Email failed:` (Resend rejection). A render-pipeline regression is visible here from the very first send — log inspection catches it before any inbox check.
+2. **Inbox via Gmail MCP** — `search_threads` with sender + recipient + recency. No browser navigation. Example query: `from:<configured-sender-domain> to:<alias> newer_than:5m`.
+3. **Body via Gmail MCP** — only if the runbook is design-reviewing the rendered email. `get_thread` with `messageFormat: FULL_CONTENT`. Optionally render in a browser tab for a screenshot if a visual artifact is requested.
+
+Layers 1 + 2 are required for every email-emitting runbook step. Layer 3 only when the email itself is the deliverable being verified.
+
+The configured sender domain comes from the project's Resend / Supabase-Auth sender config (derived from env, e.g. `EMAIL_FROM_ADDRESS`), not a hardcoded address.
+
+### Time-travel for date-driven flows
+
+For flows that depend on dates (countdowns, period-end windows, retention windows), don't wait for real time to pass. Use small targeted SQL `UPDATE` statements that move the user into the lifecycle state you want to verify. Always restore or delete test rows in teardown. (A shared `_fixtures.md` reference doc with canonical time-travel templates ships alongside date-driven runbooks when those land.)
+
+### Skeptical "what did we actually verify" audit
+
+Every report must explicitly distinguish, per checkpoint:
+
+* `verified` — exercised end-to-end against real systems
+* `unit-only` — the code path is covered by tests but real delivery / rendering / integration was not exercised in this session
+* `not tested` — out of scope or skipped
+
+This forces honesty. A run that looks like 12/12 PASS can split out to 8 verified, 3 unit-only, 1 not tested — and a critical bug can hide in the unit-only column.
+
+### Routine server-log inspection between steps
+
+Don't only check logs when something looks wrong. Between scenarios that emit webhooks, queue jobs, or send emails, do a quick grep for `error|exception|fail|warn` in the dev-server output (or production log stream) and surface anything new. Silent failures (fire-and-forget sends, swallowed exceptions) are the most common bugs that pass UI-only checks.
+
+## Report format
+
+```
+## QA run — <single runbook OR "full <sequence-name> sequence"> — <YYYY-MM-DD HH:MM>
+
+Mode: dev | prod
+Resolved env (manifest): see header above
+Test user: <alias>  (or "<dev test alias>")
+Screenshots: _bmad-output/implementation-artifacts/screenshots  (key frames)
+
+Per-runbook results:
+[1/N] runbook-name          ✅ PASS  (5 verified, 0 unit-only, 0 not tested)
+[2/N] runbook-name          🟡 PARTIAL — <one-line note>  (3 verified, 1 unit-only, 1 not tested)
+…
+
+Verification breakdown:
+  ✅ verified    — exercised end-to-end against real systems
+  🟡 unit-only   — code path covered by tests, but real delivery / integration not exercised
+  ⚪ not tested — out of scope or skipped this run
+
+Findings:
+- F1: [title] — [1-2 sentence description, file refs if applicable]
+- F2: [title] — [...]
+```
+
+The verification breakdown is mandatory. If everything came back PASS but every checkpoint was unit-only, that's a yellow run, not a green one.
+
+For destructive prod runs, append:
+
+```
+🧹 Cleanup required (prod):
+  Test user: <alias>
+  Delete via: <PRODUCTION_URL>/<locale>/admin/users
+  Requires admin auth; self-delete is blocked.
+```
+
+For destructive dev runs, append:
+
+```
+🧹 Cleanup required (dev):
+  Test user: <uuid>  (<alias>)
+  Delete via Supabase MCP: DELETE FROM auth.users WHERE id = '<uuid>';
+  Cascades clean up any rows the user owns.
+```
+
+## Adding a runbook
+
+Drop `runbooks/<domain>-<flow>.md` with frontmatter:
+
+* `name` — the slug used in `/qa <name>`.
+* `domain` — `auth`, etc.
+* `destructive` — `true` if the run creates or mutates real user state.
+* `prod` — `true` if safe to run on `<PRODUCTION_URL>`.
+* `dev` — `true` if supported under `--dev` against the local stack.
+* `requires` — array of capabilities. Allowed values: `playwright-mcp`, `gmail-mcp`, `supabase-mcp`, `dev-server`, `qa-email`, `qa-password`. The capabilities check at pre-flight reads this list.
+* `summary` — one-line description for `/qa list`.
+
+Prose body covers **goal, preconditions, checkpoints (outcome-keyed, not implementation-keyed), known failure modes, teardown / cleanup pointer**. Avoid step-by-step tool recipes — let the model figure out the calls. `/qa list` picks the runbook up automatically.
+
+Reference docs (no frontmatter; filename starts with `_`) are not runbooks — they're shared snippets that runbooks can reference.

--- a/.claude/skills/qa/runbooks/auth-admin-access.md
+++ b/.claude/skills/qa/runbooks/auth-admin-access.md
@@ -1,0 +1,36 @@
+---
+name: auth-admin-access
+domain: auth
+destructive: false
+prod: true
+dev: true
+requires: [playwright-mcp]
+summary: Admin route gating — non-admin user is redirected away from /admin with access_denied. No admin account needed.
+---
+
+# Admin route gating
+
+## Goal
+
+Verify the middleware-level gate on `/admin`: a signed-in non-admin user gets redirected to `/dashboard?error=access_denied` (and, ideally, sees a visible error banner or toast). This is a security invariant — if it regresses, non-admins could read admin data.
+
+We only test the deny branch. The admin-success branch is covered by unit tests (`src/libs/auth/isAdmin.test.ts`, `src/proxy.test.ts`) and isn't worth the cost of provisioning an admin account.
+
+## Preconditions
+
+- Browser already has a signed-in non-admin session. Easiest: chain after `auth-magic-signup` / `auth-magic-signin` / `auth-password-reset` in the same `/qa --prod` run.
+- If invoked standalone: sign in as the QA user first (magic-link or password), then proceed.
+
+## What to verify
+
+1. Navigate to `<TARGET>/en/admin`.
+2. Browser ends on `/en/dashboard` with `error=access_denied` in the URL (or an equivalent banner/toast surfaced by the dashboard).
+3. The admin page content never renders — no flash of admin UI before the redirect.
+
+Capture one frame showing the final redirected state (URL bar visible + whatever error affordance the dashboard renders).
+
+## Known failure modes
+
+- **Non-admin reaches `/admin` with no redirect** → critical authorization regression. Flag.
+- **Flash of admin UI before redirect** → middleware running too late; user briefly sees content they shouldn't. Flag.
+- **No visible error indicator on dashboard** → the query param is set but the dashboard doesn't surface it. Minor UX, not security.

--- a/.claude/skills/qa/runbooks/auth-cookies.md
+++ b/.claude/skills/qa/runbooks/auth-cookies.md
@@ -1,0 +1,50 @@
+---
+name: auth-cookies
+domain: auth
+destructive: false
+prod: true
+dev: true
+requires: [playwright-mcp, qa-email, qa-password]
+summary: Post-login cookie flag inspection — verifies sb-* cookies carry HttpOnly, Secure, SameSite=Lax.
+---
+
+# Cookie flag inspection
+
+## Goal
+
+After a successful sign-in, confirm the Supabase session cookies (`sb-*-auth-token`) are set with the correct security flags. Regression guard against domain/secure-flag misconfiguration that's only visible on deployed origins.
+
+Production-safe: read-only inspection.
+
+## Preconditions
+
+- `QA_EMAIL` + `QA_PASSWORD` work.
+- If running `--prod`, use `<PRODUCTION_URL>`. Otherwise use the local dev server (`http://localhost:<port>`).
+
+## Checkpoints
+
+1. Sign in via password mode (toggle magic-link → password, enter creds, submit).
+2. Lands on `/en/dashboard`.
+3. Retrieve cookies via Playwright's context (e.g. `playwright_evaluate` to dump `document.cookie` for the non-HttpOnly subset, AND use the devtools Application → Cookies panel screenshot for the HttpOnly view).
+4. For each cookie whose name starts with `sb-`:
+   - `HttpOnly` is true
+   - `Secure` is true (required on prod; should also be true on Vercel preview since it's HTTPS)
+   - `SameSite` is `Lax`
+   - `Domain` matches the current origin (not `.localhost` on a deployed env, not an unexpected parent domain)
+5. No `sb-*` cookie appears in `document.cookie` (because HttpOnly) — if any do, flag it.
+
+## Screenshots
+
+- `01-signin-form`
+- `02-dashboard`
+- `03-cookies-panel` — devtools Application → Cookies filtered to `sb-*`, showing the flag columns.
+
+## Teardown
+
+- Sign out if desired.
+
+## Known failure modes
+
+- `Secure: false` in production → deployment behind non-HTTPS or proxy stripping the flag. Incident-level finding.
+- `SameSite: None` or missing → cross-site request protection weakened. Flag.
+- `Domain: .<prod-domain>` (leading dot) vs `<prod-domain>` → can cause subdomain leak. Capture exact value.

--- a/.claude/skills/qa/runbooks/auth-magic-signin.md
+++ b/.claude/skills/qa/runbooks/auth-magic-signin.md
@@ -1,0 +1,46 @@
+---
+name: auth-magic-signin
+domain: auth
+destructive: false
+prod: true
+dev: true
+requires: [playwright-mcp, gmail-mcp, qa-email]
+summary: Magic-link sign-in round-trip — request link, open from inbox, land on dashboard.
+---
+
+# Magic-link sign-in
+
+## Goal
+
+Verify the full magic-link sign-in flow on the target environment (dev or prod): request a link from the sign-in page, receive the email, click through, and land authenticated on the dashboard.
+
+## Preconditions
+
+- The alias from `auth-magic-signup` exists as a confirmed Supabase user and the browser context has been signed out. (Standalone: any confirmed user whose inbox the Gmail MCP can read works — pass it in as the session alias.)
+- The browser context starts signed-out (no existing session). If reusing a context, clear cookies/localStorage first.
+
+## Checkpoints
+
+1. `<TARGET>/en/sign-in` renders with an email input (and any configured OAuth sign-in option(s)).
+2. Submitting `<alias>` transitions the page to a "check your inbox" confirmation surface that displays the submitted address.
+3. **Magic-link delivery (Gmail MCP, layer 2):** within ~60 seconds, `search_threads` with `to:<alias> from:<sender-domain> newer_than:5m` returns a thread. Sender domain is the configured Resend / Auth sender (derived from project config). Don't pin the subject — pattern-match on sender + recency.
+4. **Server-log layer (1):** dev/prod logs show `Email sent: magic_link` (or the project's equivalent emailType). For prod runs, confirming this is best-effort since logs may not be tailable; the inbox arrival itself is sufficient evidence on prod.
+5. Opening the magic link via Playwright MCP resolves to the post-auth surface (typically `/dashboard`, possibly via an auth-callback intermediary).
+6. The post-auth surface renders for a signed-in user (no sign-in CTA, user menu present).
+
+## Screenshots to capture
+
+- `01-signin-form` — the sign-in page before submission.
+- `02-confirmation-sent` — the "check your inbox" view with the email displayed.
+- `03-dashboard` — the post-auth dashboard.
+
+Capture an extra `99-failure-<reason>` if any checkpoint misses.
+
+## Teardown
+
+- Sign out to free the session for other runbooks, OR note that the context is now authenticated so downstream runbooks that need a clean state should start a new context.
+
+## Known failure modes
+
+- Email delivery delayed beyond 60s (per Gmail MCP `search_threads` returning empty) → Supabase SMTP misconfiguration on the target env, or Gmail filtered to Trash. Retry the search with `includeTrash: true` to discriminate before failing.
+- Magic link redirects to `/auth-code-error` → expired or reused code. Don't touch the link twice (single-use). Retry once with a freshly requested link before failing.

--- a/.claude/skills/qa/runbooks/auth-magic-signup.md
+++ b/.claude/skills/qa/runbooks/auth-magic-signup.md
@@ -1,0 +1,92 @@
+---
+name: auth-magic-signup
+domain: auth
+destructive: true
+prod: true
+dev: true
+requires: [playwright-mcp, gmail-mcp, qa-email]
+summary: Magic-link signup + welcome email — creates a new account using a +alias and verifies email rendering end-to-end.
+---
+
+# Magic-link sign-up
+
+## Goal
+
+Verify the full sign-up flow including real email rendering: request magic link → receive and screenshot the email → click link → land on dashboard → receive welcome email → screenshot welcome email for design review.
+
+Safe to run against production because it uses Gmail's `+alias` trick to create a unique, traceable, cleanable account every run.
+
+## Alias generation
+
+Construct the signup email before starting:
+
+```
+alias = `${QA_EMAIL_LOCAL}+signup-${unixTimestamp}@${QA_EMAIL_DOMAIN}`
+```
+
+Example: if `QA_EMAIL=my-qa@gmail.com`, alias = `my-qa+signup-1745400000@gmail.com`.
+
+Log the alias prominently before the first browser action — the user needs it for cleanup.
+
+## Preconditions
+
+- Playwright MCP for driving the sign-up form and the magic-link click-through.
+- Gmail MCP connected to `QA_EMAIL`. Inbox checks go through `search_threads` / `get_thread` — no Gmail browser tab needed.
+- Clean app context: no existing session for the alias (true by construction — alias is fresh every run).
+
+## Confirm before running on prod
+
+Ask the user once: "This will create a real Supabase auth user at `<alias>` on `<PRODUCTION_URL>`. Proceed? (y/n)"
+
+## Session chaining
+
+On success, **leave the authenticated session open** (don't sign out in teardown). Subsequent runbooks in a `/qa --prod` sequence can reuse this session:
+
+- `auth-magic-signin` — sign out, then sign back in as the same alias to exercise the returning-user magic-link path.
+- `auth-password-reset` — use the same alias to request a reset; Supabase's flow works regardless of whether the user has a password yet (it sets one).
+- `auth-admin-access` — hit `/admin` from the signed-in session to verify non-admin gating.
+
+The cleanup pointer at the end of the sequence should reference this single alias (one row to delete, not one per runbook).
+
+## Checkpoints
+
+1. `<TARGET>/en/sign-up` renders with an email input (and any configured OAuth sign-in option(s)).
+2. Submitting the alias transitions the page to a "check your inbox" confirmation surface that displays the alias.
+3. **Magic-link delivery (Gmail MCP, layer 2):** within ~60 seconds, `search_threads` returns a thread matching `to:<alias> from:<sender-domain> newer_than:5m`. Sender domain is the configured Supabase SMTP sender (derived from the project's Resend / Auth config, e.g. `EMAIL_FROM_ADDRESS`). Don't pin the subject — Supabase's default template and brand-customized templates differ.
+4. **Magic-link design review (layer 3, prod only):** call `get_thread` with `messageFormat: FULL_CONTENT` to fetch the rendered HTML; render in a browser tab and screenshot the body. Skippable when the run isn't focused on email design.
+5. Clicking the magic link in the email (use Playwright MCP to open the URL — Gmail MCP only reads, it doesn't navigate) opens an auth-callback route and lands on the post-signup app surface (typically `/dashboard` with a "verified" indicator). Note any redirect surface that differs from the documented routing.
+6. The post-signup surface renders for a fresh user — no sign-in CTA visible, user menu present, onboarding state appropriate for a brand-new account.
+7. **Welcome email (Gmail MCP layers 1+2):** within ~60 seconds of landing on the dashboard, dev-server logs show `Email sent: welcome` (server log layer) and `search_threads` returns a thread with subject pattern-matching "welcome" (loosely). Layer 3 screenshot of the welcome email is the intended design-review artifact for prod runs.
+
+## Screenshots to capture
+
+- `01-signup-form` — empty sign-up page
+- `02-confirmation-sent` — "check your inbox" with the alias visible
+- `03-email-magic-link-body` — rendered magic-link email body (design review frame, prod only)
+- `04-dashboard` — fresh-user dashboard
+- `05-email-welcome-body` — rendered welcome email body (design review frame, prod only)
+
+Save these to `_bmad-output/implementation-artifacts/screenshots` (Playwright MCP `downloadsDir` + `savePng: true`). Name failure captures `99-failure-<reason>.png`. Inbox-list screenshots from a Gmail browser tab are not necessary — the Gmail MCP `search_threads` result is the equivalent record.
+
+## Teardown
+
+None required inside the browser (account intentionally lives on).
+
+## Cleanup reminder (prod only)
+
+After a prod run, emit:
+
+```
+🧹 Cleanup required (prod):
+  Test user: <alias>
+  Delete via: <PRODUCTION_URL>/<locale>/admin/users
+  Search/filter by the full alias, then open the row and choose Delete.
+  Requires admin auth; self-delete is blocked server-side.
+```
+
+## Known failure modes
+
+- **Magic-link email not received within 60s (per Gmail MCP)** — Supabase SMTP misconfiguration on the target env, or Gmail routing to Spam. Pass `includeTrash: false` in `search_threads`, then retry without it; if the message is in Trash, that's a Gmail-side filter, not a product bug.
+- **Magic link opens `/auth-code-error`** — expired or previously-consumed code. Should not happen with a fresh alias; if it does, capture the error page and stop. Note from cross-cutting practices: don't touch the link twice — that itself can cause this.
+- **Welcome email missing** — the fire-and-forget send in the callback silently failed. The layer-1 server-log check (`Email failed:` for emailType `welcome`) is what catches this when the inbox check times out. Report as partial pass with the log evidence.
+- **Post-signup landing page 404 or broken** — onboarding defaults not provisioned for fresh users. Capture and report.

--- a/.claude/skills/qa/runbooks/auth-password-reset.md
+++ b/.claude/skills/qa/runbooks/auth-password-reset.md
@@ -1,0 +1,90 @@
+---
+name: auth-password-reset
+domain: auth
+destructive: true
+prod: true
+dev: true
+requires: [playwright-mcp, gmail-mcp, qa-email]
+summary: Forgot-password → reset → auto sign-out → re-login with new password. Uses disposable +alias account for prod runs.
+---
+
+# Password reset
+
+## Goal
+
+Verify the full forgot/reset-password flow including real email rendering: request reset → receive email → screenshot for design review → click link → set new password → confirm auto-sign-out security behavior → sign back in with new password.
+
+Safe against production because it only ever exercises a disposable `+alias` account — the session alias from `auth-magic-signup` when chained, or a freshly-provisioned `+reset-<ts>` alias when standalone. The base `QA_EMAIL` is never touched.
+
+## Setup & alias generation
+
+This runbook needs a user before it can test the reset flow. It runs in one of two modes:
+
+- **Chained** (inside `/qa --prod`, preceded by `auth-magic-signup`): reuse the session alias from the prior runbook — do **not** provision a fresh user. The reset flow works regardless of whether that user already has a password (it sets one). This keeps the sequence's end state at **one** prod test user to clean up, as `SKILL.md` documents.
+- **Standalone**: provision a disposable user first, since no session alias exists. Create `alias = ${QA_EMAIL_LOCAL}+reset-${unixTimestamp}@${QA_EMAIL_DOMAIN}` with a known initial password via the real sign-up flow (local dev: `/api/auth/dev-login` with `action: 'signup'`), then run the reset flow against it.
+
+If the caller passes an `existing-alias`, use it and skip the Provision phase entirely. Log the alias prominently either way.
+
+## Preconditions
+
+- Playwright MCP available for driving the password forms and reset-link click-through.
+- Gmail MCP connected to `QA_EMAIL`. Inbox lookups go through `search_threads` / `get_thread`.
+
+## Confirm before running on prod
+
+"This will create a disposable Supabase user at `<alias>` on `<PRODUCTION_URL>` and run the password-reset flow on it. Proceed? (y/n)"
+
+## Checkpoints
+
+### Phase 1 — Provision the test user
+
+**Skip this entire phase when chained** (a session alias from `auth-magic-signup` already exists, or an `existing-alias` was passed in). Sign that user out and jump to Phase 2.
+
+Standalone only:
+
+1. On local dev: POST `<TARGET>/api/auth/dev-login` with `{email: alias, password: 'InitialP@ss1', action: 'signup'}`. Expect 200. This endpoint only works on the LOCAL dev server (`NODE_ENV !== 'production'` and `ALLOW_DEV_LOGIN` set); on Vercel preview/prod `NODE_ENV=production`, so it returns 403 — use the prod-safe real-signup path below instead.
+2. On prod (or preview): sign up through `/en/sign-up` (magic-link flow, alias) → verify email (capture here too, reuses `auth-magic-signup` pattern).
+3. Confirm the alias can sign in with its initial password on `<TARGET>/en/sign-in` (password-mode toggle). Screenshot dashboard to confirm.
+4. Sign out.
+
+### Phase 2 — Reset flow
+
+5. Navigate to `<TARGET>/en/forgot-password`. Form renders.
+6. Submit the alias. UI shows the **generic** success message (should not reveal whether the email exists — security feature, verify this literal behavior).
+7. **Reset email delivery (Gmail MCP):** within ~60s, `search_threads` with `to:<alias> from:<sender-domain> newer_than:5m` returns the reset thread. Sender domain is the configured Resend / Auth sender (derived from project config). For design review, fetch the body via `get_thread` (FULL_CONTENT) and screenshot it in a browser tab.
+8. Click the reset link → `<TARGET>/en/reset-password` loads with a valid token (no error state).
+9. Enter a new valid password (8+ chars, upper, lower, digit — e.g. `NewP@ssw0rd1`). Submit.
+10. UI shows success message.
+11. Navigate to `<TARGET>/en/dashboard` → redirected to `/en/sign-in` (auto-sign-out after password update is a security invariant — critical to verify).
+12. Sign in as the alias with the **new** password. Dashboard renders.
+
+## Screenshots to capture
+
+- `01-forgot-form`
+- `02-generic-success`
+- `03-email-reset` — Gmail, opened email, design review frame
+- `04-reset-form`
+- `05-reset-success`
+- `06-auto-signout-redirect` — confirms session invalidation
+- `07-signin-with-new-password`
+- `08-dashboard-after-relogin`
+
+## Teardown
+
+None inside the browser — alias stays for cleanup step.
+
+## Cleanup reminder (prod only)
+
+```
+🧹 Cleanup required (prod):
+  Test user: <alias>
+  Delete via: <PRODUCTION_URL>/<locale>/admin/users
+  Search for the alias and delete. (The fresh signup and its password-reset state
+  are the same user row — one delete is enough.)
+```
+
+## Known failure modes
+
+- **Reset link shows "invalid or expired token"** — expired by rate-limit or re-use. Fresh alias should prevent; if it happens, capture and retry once.
+- **Auto sign-out fails** (checkpoint 11) — critical security regression. Flag prominently.
+- **Generic success message leaks email existence** (checkpoint 6) — do a negative case: submit a clearly nonexistent email (`nonexistent+QA-nothing@gmail.com`) and compare UI response. Should be identical.

--- a/.env.example
+++ b/.env.example
@@ -151,6 +151,12 @@ TEST_ADMIN_EMAIL=admin@test.com
 TEST_ADMIN_PASSWORD=password
 # Screenshots output folder (Playwright, visual checks)
 SCREENSHOTS_DIR=_bmad-output/screenshots
+# Manual-QA runner (/qa skill) — Gmail inbox for real-send email verification.
+# QA_EMAIL is the base inbox; the skill appends +alias suffixes per run for
+# disposable, traceable test accounts. QA_PASSWORD is only needed by runbooks
+# that sign in to the base user (e.g. auth-cookies).
+QA_EMAIL=
+QA_PASSWORD=
 
 # --- GitHub Actions Secrets (not in .env.local) ---
 # These are configured in GitHub repo Settings > Secrets:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -412,6 +412,15 @@ After implementing front-end changes, use Playwright MCP tools to navigate to af
 - **Git Hooks**: Husky runs linting on staged files + commit message validation
 - **No lazy-`require()` of local ESM modules**: Never use an `eslint-disable` to lazy-`require()` a local ESM module under Next 16 + Turbopack — the production bundle drops the named export under ESM↔CJS interop (this has caused a provider module to silently lose its named export in production). Use static `import` for local modules. Every `eslint-disable` needs a `-- reason`.
 
+## Deployment & QA Skills
+
+Two first-party Claude Code skills live under `.claude/skills/` for go-live work:
+
+- **`/production-deploy`** — provider-agnostic 8-phase first-deploy orchestrator (Plan → Readiness → Env Strategy → Core Infra → Integrations → Smoke Test → Document → Backport). Resume-safe via `_bmad-output/deployment-checklist.md`. Phase 7 extends `docs/deployment-guide.md` and adds a `## Deployment` section to this file with the actual production specifics once a real deploy runs.
+- **`/qa`** — on-demand manual-QA runner for flows unit/E2E tests can't cover (real browser via Playwright MCP, real email via Gmail MCP, real env plumbing). Two targets (`--dev` / `--prod`); ships generic auth runbooks (magic signup/signin, password reset, admin-route gating, cookie flags). Reads `QA_EMAIL` / `QA_PASSWORD` from `.env.local`.
+
+These compose with the read-only `/launch-checklist` audit: **audit (launch-checklist) → execute (production-deploy) → verify (qa)** — sequential and complementary, not duplicative.
+
 ## Research
 
 - During planning, use targeted web search early to find proven approaches; prefer established libraries/repos over building from scratch.


### PR DESCRIPTION
## Summary

Adds two first-party Claude Code skills to the template, completing the dev/agent-tooling cluster from the ContentFlow→template contribution plan:

- **`/production-deploy`** — provider-agnostic 8-phase first-deploy orchestrator (Plan → Readiness → Env Strategy → Core Infra → Integrations → Smoke Test → Document → Backport). Resume-safe via a `_bmad-output/deployment-checklist.md` state artifact; manifest-driven Phases 4-5 (reads `references/integrations/{name}.md`, not a hardcoded step list); phase-boundary risk reviews via a bundled `deploy-risk-reviewer` agent; live-docs-over-memory via context7. **Phase 8 closes the fork→template loop** — surfaces template-generic deploy gotchas as `backport-from-deploy` issues on this repo; **Phase 1 pulls them back inbound** before the next fork's deploy.
- **`/qa`** — on-demand manual-QA runner for flows unit/E2E tests can't cover (real browser via Playwright MCP, real email rendering via Gmail MCP, real env plumbing). Two targets (`--dev` local / `--prod`), capabilities-first preflight, 3-layer real-send email verification, SQL time-travel for date-driven flows, and a `verified` / `unit-only` / `not-tested` honesty audit in every report. Ships 5 generic auth runbooks (magic signup/signin, password reset, admin-route gating, cookie flags).

Both live under `.claude/skills/` and are committed as native template tooling (alongside `.claude/cloud-feature-builders/` and `.claude/rules/`).

## What was stripped (per the contribution plan + HARD RULES)

- All ContentFlow branding, `contentflow.club` URLs, `noreply@mail.contentflow.club` sender, `contentflow` schema literal → generic placeholders / config / `<app_schema>`.
- Product-domain endpoints: the LinkedIn/n8n/WhatsApp pitfall sections and the `publish-linkedin` runbook (dropped). LinkedIn/Twitter survive only as generic `oauth-{provider}` illustrative examples where the **dual-callback** invariant is the reusable lesson.
- Tooling brought to template conventions: `claude-in-chrome` + `gif_creator` + `launch-qa-chrome.sh` → **Playwright MCP** (per CLAUDE.md); `Claude_Preview` port discovery → template dev-server port.

## Deferred (not in this PR)

- **qa subscription runbooks** + `_fixtures.md` lifecycle SQL — bind to subscription tables that arrive with #336; port them in that wave against the net-new schema.
- **Stripe-sandbox wiring / `stripe-cli` capability** in the qa skill — meaningful only once there's a billing flow to QA (#336).

## Skill-overlap boundary (coordination)

Three skills now touch "go-live"; they are **sequential and complementary, not duplicative**:

- **`/launch-checklist`** (#153) — read-only static readiness **audit** (scorecard).
- **`/production-deploy`** (this PR) — **executes** the go-live (creates infra, runs SQL, deploys).
- **`/qa`** (this PR) — **verifies** runtime flows after deploy.

`marketing-site-polish` (#304) is disjoint (copy/content). Recommend landing/reconciling #153 + #304 first, then this.

## Notes for downstream sync

These skills originated in ContentFlow, so a naive upstream-sync back would create divergent copies. ContentFlow should use the selective-sync `ours` strategy (#322) for `.claude/skills/{production-deploy,qa}/` and re-layer its product-specific runbooks on top.

## Test plan

- [ ] `/production-deploy` and `/qa` appear in the Claude Code skill list.
- [ ] `/qa list` enumerates the 5 auth runbooks.
- [ ] `grep -rIiE 'contentflow|linkedin|twitter|whatsapp|claude-in-chrome|gif_creator' .claude/skills/{production-deploy,qa}/` returns 0 (outside generic `oauth-{provider}` examples).
- [ ] `npm run check-types` + `npm run lint` green (markdown + `.env.example` comment only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
