### PR TITLE
feat(settings): add email-notification preferences page + /api/profile/preferences endpoint

### DIFF
--- a/src/app/[locale]/(auth)/settings/loading.tsx
+++ b/src/app/[locale]/(auth)/settings/loading.tsx
@@ -1,0 +1,32 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function SettingsLoading() {
+  return (
+    <div className="mx-auto flex max-w-4xl flex-col gap-6 p-6 pt-12">
+      {/* Header */}
+      <div className="flex items-center gap-3 py-2">
+        <Skeleton className="size-10 rounded-xl" />
+        <div className="space-y-2">
+          <Skeleton className="h-7 w-24" />
+          <Skeleton className="h-4 w-48" />
+        </div>
+      </div>
+
+      <div className="space-y-6">
+        {/* Notifications section */}
+        <div className="space-y-4 rounded-lg border border-border bg-card p-6">
+          <Skeleton className="h-5 w-32" />
+          <div className="space-y-3">
+            <div className="flex items-center justify-between gap-4">
+              <Skeleton className="h-4 w-48" />
+              <Skeleton className="h-6 w-11 rounded-full" />
+            </div>
+          </div>
+          <div className="flex justify-end">
+            <Skeleton className="h-9 w-32 rounded-md" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/[locale]/(auth)/settings/page.tsx
+++ b/src/app/[locale]/(auth)/settings/page.tsx
@@ -1,0 +1,32 @@
+import { Settings } from 'lucide-react';
+import { getTranslations } from 'next-intl/server';
+
+import { NotificationsSection } from '@/components/settings/notifications-section';
+import { requireAuthOrRedirect } from '@/libs/auth/auth-redirects';
+
+export default async function SettingsPage() {
+  const t = await getTranslations('Settings');
+  await requireAuthOrRedirect('/settings');
+
+  return (
+    <div className="mx-auto flex max-w-4xl flex-col gap-6 p-6 pt-12">
+      <div className="flex items-center gap-3 py-2">
+        <div className="flex size-10 items-center justify-center rounded-xl bg-muted text-foreground">
+          <Settings className="size-5" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight text-foreground">
+            {t('page_title')}
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            {t('page_subtitle')}
+          </p>
+        </div>
+      </div>
+
+      <div className="space-y-6">
+        <NotificationsSection />
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/profile/preferences/route.test.ts
+++ b/src/app/api/profile/preferences/route.test.ts
@@ -1,0 +1,368 @@
+import { cookies } from 'next/headers';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { db } from '@/libs/DB';
+import { createClient } from '@/libs/supabase/server';
+
+import { GET, PATCH } from './route';
+
+vi.mock('@/libs/Logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+// Mock dependencies
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(),
+}));
+
+vi.mock('@/libs/supabase/server', () => ({
+  createClient: vi.fn(),
+}));
+
+vi.mock('@/libs/DB', () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+const mockUser = {
+  id: 'test-user-id',
+  email: 'test@example.com',
+};
+
+function mockAuthedUser() {
+  (createClient as any).mockReturnValue({
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user: mockUser },
+        error: null,
+      }),
+    },
+  });
+}
+
+function mockUnauthed() {
+  (createClient as any).mockReturnValue({
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user: null },
+        error: new Error('Not authenticated'),
+      }),
+    },
+  });
+}
+
+describe('GET /api/profile/preferences', () => {
+  const mockCookieStore = {} as any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (cookies as any).mockResolvedValue(mockCookieStore);
+  });
+
+  it('returns 401 when user is not authenticated', async () => {
+    mockUnauthed();
+
+    const request = new Request('http://localhost/api/profile/preferences', {
+      method: 'GET',
+    });
+
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.code).toBe('AUTH_REQUIRED');
+  });
+
+  it('returns existing preferences for the signed-in user', async () => {
+    mockAuthedUser();
+
+    const existingProfile = {
+      id: 'profile-id',
+      userId: mockUser.id,
+      username: 'existinguser',
+      emailNotifications: false,
+      language: 'hi',
+    };
+
+    const mockSelect = vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([existingProfile]),
+        }),
+      }),
+    });
+    (db.select as any) = mockSelect;
+
+    const request = new Request('http://localhost/api/profile/preferences', {
+      method: 'GET',
+    });
+
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({
+      emailNotifications: false,
+      language: 'hi',
+      username: 'existinguser',
+    });
+  });
+
+  it('returns schema defaults (no insert) when no row exists', async () => {
+    mockAuthedUser();
+
+    const mockSelect = vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([]),
+        }),
+      }),
+    });
+    const mockInsert = vi.fn();
+    (db.select as any) = mockSelect;
+    (db.insert as any) = mockInsert;
+
+    const request = new Request('http://localhost/api/profile/preferences', {
+      method: 'GET',
+    });
+
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({
+      emailNotifications: true,
+      language: 'en',
+      username: null,
+    });
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+});
+
+describe('PATCH /api/profile/preferences', () => {
+  const mockCookieStore = {} as any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (cookies as any).mockResolvedValue(mockCookieStore);
+  });
+
+  it('returns 401 when user is not authenticated', async () => {
+    mockUnauthed();
+
+    const request = new Request('http://localhost/api/profile/preferences', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        emailNotifications: true,
+        language: 'en',
+      }),
+    });
+
+    const response = await PATCH(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.code).toBe('AUTH_REQUIRED');
+  });
+
+  it('returns 400 for invalid language value', async () => {
+    mockAuthedUser();
+
+    const request = new Request('http://localhost/api/profile/preferences', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        emailNotifications: true,
+        language: 'invalid', // Invalid language
+      }),
+    });
+
+    const response = await PATCH(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 400 for invalid emailNotifications type', async () => {
+    mockAuthedUser();
+
+    const request = new Request('http://localhost/api/profile/preferences', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        emailNotifications: 'yes', // Should be boolean
+        language: 'en',
+      }),
+    });
+
+    const response = await PATCH(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('creates new preferences for new user via atomic upsert', async () => {
+    const mockInsertedProfile = {
+      id: 'profile-id',
+      userId: mockUser.id,
+      username: null,
+      emailNotifications: true,
+      language: 'en',
+    };
+
+    mockAuthedUser();
+
+    // Mock upsert chain: db.insert().values().onConflictDoUpdate().returning()
+    const mockInsert = vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        onConflictDoUpdate: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([mockInsertedProfile]),
+        }),
+      }),
+    });
+
+    (db.insert as any) = mockInsert;
+
+    const request = new Request('http://localhost/api/profile/preferences', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        emailNotifications: true,
+        language: 'en',
+      }),
+    });
+
+    const response = await PATCH(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({
+      emailNotifications: true,
+      language: 'en',
+      username: null,
+    });
+    expect(mockInsert).toHaveBeenCalled();
+  });
+
+  it('updates existing preferences via atomic upsert', async () => {
+    const mockUpdatedProfile = {
+      id: 'profile-id',
+      userId: mockUser.id,
+      username: 'existinguser',
+      emailNotifications: true,
+      language: 'en',
+    };
+
+    mockAuthedUser();
+
+    // onConflictDoUpdate handles the existing-row case in a single statement.
+    const mockInsert = vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        onConflictDoUpdate: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([mockUpdatedProfile]),
+        }),
+      }),
+    });
+
+    (db.insert as any) = mockInsert;
+
+    const request = new Request('http://localhost/api/profile/preferences', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        emailNotifications: true,
+        language: 'en',
+      }),
+    });
+
+    const response = await PATCH(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({
+      emailNotifications: true,
+      language: 'en',
+      username: 'existinguser',
+    });
+    expect(mockInsert).toHaveBeenCalled();
+  });
+
+  it('accepts all valid language options', async () => {
+    const languages = ['en', 'hi', 'bn'];
+
+    for (const language of languages) {
+      vi.clearAllMocks();
+
+      const mockUpdatedProfile = {
+        id: 'profile-id',
+        userId: mockUser.id,
+        username: 'testuser',
+        emailNotifications: true,
+        language,
+      };
+
+      mockAuthedUser();
+
+      const mockInsert = vi.fn().mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          onConflictDoUpdate: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([mockUpdatedProfile]),
+          }),
+        }),
+      });
+
+      (db.insert as any) = mockInsert;
+
+      const request = new Request('http://localhost/api/profile/preferences', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          emailNotifications: true,
+          language,
+        }),
+      });
+
+      const response = await PATCH(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.language).toBe(language);
+    }
+  });
+
+  it('returns 500 when database save fails', async () => {
+    mockAuthedUser();
+
+    // Mock upsert returning empty (failed)
+    const mockInsert = vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        onConflictDoUpdate: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([]),
+        }),
+      }),
+    });
+
+    (db.insert as any) = mockInsert;
+
+    const request = new Request('http://localhost/api/profile/preferences', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        emailNotifications: true,
+        language: 'en',
+      }),
+    });
+
+    const response = await PATCH(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.code).toBe('SAVE_FAILED');
+  });
+});

--- a/src/app/api/profile/preferences/route.ts
+++ b/src/app/api/profile/preferences/route.ts
@@ -1,0 +1,132 @@
+import { eq } from 'drizzle-orm';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import {
+  formatZodErrors,
+  internalError,
+  invalidRequestError,
+  logApiError,
+  saveFailedError,
+  validationError,
+} from '@/libs/api/errors';
+import { withAuth } from '@/libs/api/middleware/withAuth';
+import { db } from '@/libs/DB';
+import { userPreferences } from '@/models/Schema';
+
+// This route owns the notification/language preference surface. Username is set
+// once at onboarding via the dedicated flow and is intentionally not writable
+// here, so it stays out of the schema (the `.unique()` column has its own
+// conflict semantics that don't belong on this idempotent preference write).
+const preferencesSchema = z.object({
+  emailNotifications: z.boolean().optional(),
+  language: z.enum(['en', 'hi', 'bn']).optional(),
+});
+
+type PreferencesResponse = {
+  emailNotifications: boolean;
+  language: string;
+  username: string | null;
+};
+
+/**
+ * GET — returns the signed-in user's preferences. If no row exists yet
+ * (new user), returns the schema defaults without inserting.
+ *
+ * Returns the bare `{ emailNotifications, language, username }` payload (no
+ * `{ success, data }` envelope) because `use-user-preferences` reads these
+ * fields at the top level of the JSON response.
+ */
+export const GET = withAuth(async (_request, { user }) => {
+  try {
+    const existing = await db
+      .select()
+      .from(userPreferences)
+      .where(eq(userPreferences.userId, user.id))
+      .limit(1);
+
+    const row = existing[0];
+    const payload: PreferencesResponse = row
+      ? {
+          emailNotifications: row.emailNotifications,
+          language: row.language,
+          username: row.username,
+        }
+      : {
+          emailNotifications: true,
+          language: 'en',
+          username: null,
+        };
+
+    return NextResponse.json(payload);
+  } catch (error) {
+    logApiError(error, {
+      endpoint: '/api/profile/preferences',
+      method: 'GET',
+    });
+    return internalError();
+  }
+});
+
+export const PATCH = withAuth(async (request, { user }) => {
+  try {
+    let body;
+    try {
+      body = await request.json();
+    } catch {
+      return invalidRequestError('Invalid JSON in request body');
+    }
+
+    const parsed = preferencesSchema.safeParse(body);
+    if (!parsed.success) {
+      return validationError(formatZodErrors(parsed.error), 'Invalid request data');
+    }
+
+    const validated = parsed.data;
+
+    // Atomic upsert: insert defaults for a brand-new user, or update only the
+    // fields the caller actually sent. A single statement avoids the
+    // check-then-write race two concurrent first-time writes would hit on the
+    // `user_id` unique constraint. Mirrors `/api/profile/update-preferences`.
+    const updateData: Record<string, unknown> = {
+      updatedAt: new Date(),
+    };
+    if (validated.emailNotifications !== undefined) {
+      updateData.emailNotifications = validated.emailNotifications;
+    }
+    if (validated.language !== undefined) {
+      updateData.language = validated.language;
+    }
+
+    const [result] = await db
+      .insert(userPreferences)
+      .values({
+        userId: user.id,
+        emailNotifications: validated.emailNotifications ?? true,
+        language: validated.language ?? 'en',
+      })
+      .onConflictDoUpdate({
+        target: userPreferences.userId,
+        set: updateData,
+      })
+      .returning();
+
+    if (!result) {
+      return saveFailedError('Failed to save preferences');
+    }
+
+    const payload: PreferencesResponse = {
+      emailNotifications: result.emailNotifications,
+      language: result.language,
+      username: result.username,
+    };
+
+    return NextResponse.json(payload);
+  } catch (error) {
+    logApiError(error, {
+      endpoint: '/api/profile/preferences',
+      method: 'PATCH',
+    });
+    return internalError();
+  }
+});

--- a/src/components/layout/MainAppShell.tsx
+++ b/src/components/layout/MainAppShell.tsx
@@ -69,7 +69,7 @@ export function MainAppShell({ children }: MainAppShellProps) {
     { icon: Inbox, label: 'DS - Empty States', href: '/design-system/empty-states' },
     { icon: Loader2, label: 'DS - Loading', href: '/design-system/loading' },
     { icon: CreditCard, label: 'Pricing', href: '/pricing', disabled: true },
-    { icon: Settings, label: 'Settings', href: '/settings', disabled: true },
+    { icon: Settings, label: 'Settings', href: '/settings' },
     { icon: User, label: 'Profile', href: '/dashboard/user-profile' },
     { icon: UserPlus, label: 'Onboarding', href: '/onboarding' },
   ];

--- a/src/components/settings/notifications-section.test.tsx
+++ b/src/components/settings/notifications-section.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useTranslations } from 'next-intl';
+import { toast } from 'sonner';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  useUpdateUserPreferences,
+  useUserPreferences,
+} from '@/libs/hooks/use-user-preferences';
+
+import { NotificationsSection } from './notifications-section';
+
+vi.mock('next-intl', () => ({
+  useTranslations: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@/libs/hooks/use-user-preferences', () => ({
+  useUserPreferences: vi.fn(),
+  useUpdateUserPreferences: vi.fn(),
+}));
+
+const mockTranslate = vi.fn((key: string) => key);
+
+function mockPrefs(emailNotifications: boolean) {
+  (useUserPreferences as any).mockReturnValue({
+    data: { emailNotifications, language: 'en', username: 'tester' },
+    isLoading: false,
+  });
+}
+
+describe('NotificationsSection', () => {
+  const mutateAsync = vi.fn().mockResolvedValue({
+    emailNotifications: false,
+    language: 'en',
+    username: 'tester',
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useTranslations as any).mockReturnValue(mockTranslate);
+    (useUpdateUserPreferences as any).mockReturnValue({
+      mutateAsync,
+      isPending: false,
+    });
+  });
+
+  it('reflects loaded preferences in the switch', () => {
+    mockPrefs(true);
+
+    render(<NotificationsSection />);
+
+    const toggle = screen.getByRole('switch', { name: 'email_notifications' });
+
+    expect(toggle).toBeChecked();
+  });
+
+  it('disables Save until the toggle is changed, then saves with the new value', async () => {
+    const user = userEvent.setup();
+    mockPrefs(true);
+
+    render(<NotificationsSection />);
+
+    const saveButton = screen.getByRole('button', { name: 'save_notifications' });
+
+    expect(saveButton).toBeDisabled();
+
+    const toggle = screen.getByRole('switch', { name: 'email_notifications' });
+    await user.click(toggle);
+
+    expect(saveButton).toBeEnabled();
+
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledWith({ emailNotifications: false });
+    });
+
+    expect(toast.success).toHaveBeenCalled();
+  });
+});

--- a/src/components/settings/notifications-section.tsx
+++ b/src/components/settings/notifications-section.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { BellRing, Loader2 } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import {
+  useUpdateUserPreferences,
+  useUserPreferences,
+} from '@/libs/hooks/use-user-preferences';
+
+export function NotificationsSection() {
+  const t = useTranslations('Settings');
+  const { data: prefs, isLoading } = useUserPreferences();
+  const updatePrefs = useUpdateUserPreferences();
+
+  const [emailNotifications, setEmailNotifications] = useState(true);
+
+  // Sync form state once server data loads.
+  useEffect(() => {
+    if (prefs) {
+      setEmailNotifications(prefs.emailNotifications);
+    }
+  }, [prefs]);
+
+  const dirty = !!prefs && emailNotifications !== prefs.emailNotifications;
+
+  const handleSave = async () => {
+    try {
+      await updatePrefs.mutateAsync({ emailNotifications });
+      toast.success(t('notifications_saved_title'), {
+        description: t('notifications_saved_toast'),
+      });
+    } catch (err) {
+      toast.error(t('notifications_error_title'), {
+        description: err instanceof Error ? err.message : t('notifications_error_generic'),
+      });
+    }
+  };
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-6">
+      <div className="mb-4 flex items-center gap-2">
+        <BellRing className="size-5 text-muted-foreground" />
+        <h2 className="text-lg font-semibold text-foreground">
+          {t('notifications_title')}
+        </h2>
+      </div>
+
+      <p className="mb-4 text-sm text-muted-foreground">
+        {t('notifications_description')}
+      </p>
+
+      <div className="space-y-2">
+        <div className="flex items-center justify-between gap-4 rounded-md border border-border/60 bg-background/40 p-4 transition-colors hover:bg-accent/40">
+          <Label
+            htmlFor="email-notifications"
+            className="cursor-pointer text-sm font-medium text-foreground"
+          >
+            {t('email_notifications')}
+          </Label>
+          <Switch
+            id="email-notifications"
+            checked={emailNotifications}
+            disabled={isLoading || updatePrefs.isPending}
+            onCheckedChange={setEmailNotifications}
+          />
+        </div>
+      </div>
+
+      <div className="mt-6 flex justify-end">
+        <Button
+          type="button"
+          onClick={handleSave}
+          disabled={!dirty || isLoading || updatePrefs.isPending}
+        >
+          {updatePrefs.isPending
+            ? (
+                <>
+                  <Loader2 className="mr-2 size-4 animate-spin" />
+                  {t('saving')}
+                </>
+              )
+            : t('save_notifications')}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/libs/hooks/use-user-preferences.ts
+++ b/src/libs/hooks/use-user-preferences.ts
@@ -2,6 +2,8 @@
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
+import { parseApiError } from '@/libs/api/client';
+
 export type UserPreferences = {
   emailNotifications: boolean;
   language: string;
@@ -12,10 +14,10 @@ type UpdatePayload = Partial<Omit<UserPreferences, 'username'>>;
 
 const QUERY_KEY = ['user-preferences'] as const;
 
-// Integration seam: this route does NOT exist in the template yet. A fork
-// implements `GET`/`PATCH /api/profile/preferences` reading & writing the
-// `user_preferences` table (the server half's columns). Kept as a constant so
-// the client hook reads as native and the seam is obvious.
+// Read+write endpoint for the user's preferences, backed by the
+// `user_preferences` table. `GET` returns current prefs (or schema defaults for
+// a brand-new user) and `PATCH` upserts. Kept as a constant so the client hook
+// reads as native and the seam is obvious.
 const ENDPOINT = '/api/profile/preferences';
 
 const DEFAULTS: UserPreferences = {
@@ -52,8 +54,8 @@ async function patchPreferences(
   });
 
   if (!response.ok) {
-    const message = await response.text().catch(() => response.statusText);
-    throw new Error(message || `Failed to save preferences (${response.status})`);
+    const parsed = await parseApiError(response);
+    throw new Error(parsed.message);
   }
 
   const json = (await response.json()) as Partial<UserPreferences>;

--- a/src/locales/bn.json
+++ b/src/locales/bn.json
@@ -861,5 +861,18 @@
     "topics": {
       "title": "বিষয়"
     }
+  },
+  "Settings": {
+    "page_title": "সেটিংস",
+    "page_subtitle": "আপনার অ্যাকাউন্ট পছন্দ পরিচালনা করুন",
+    "notifications_title": "বিজ্ঞপ্তি",
+    "notifications_description": "আপনি কীভাবে আমাদের কাছ থেকে শুনতে চান তা চয়ন করুন।",
+    "email_notifications": "ইমেল বিজ্ঞপ্তি",
+    "notifications_saved_title": "পছন্দ সংরক্ষিত হয়েছে",
+    "notifications_saved_toast": "আপনার বিজ্ঞপ্তি পছন্দ আপডেট করা হয়েছে।",
+    "notifications_error_title": "পছন্দ সংরক্ষণ করা যায়নি",
+    "notifications_error_generic": "কিছু একটা ভুল হয়েছে। অনুগ্রহ করে আবার চেষ্টা করুন।",
+    "saving": "সংরক্ষণ করা হচ্ছে...",
+    "save_notifications": "পরিবর্তন সংরক্ষণ করুন"
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -865,5 +865,18 @@
     "topics": {
       "title": "Topics"
     }
+  },
+  "Settings": {
+    "page_title": "Settings",
+    "page_subtitle": "Manage your account preferences",
+    "notifications_title": "Notifications",
+    "notifications_description": "Choose how you want to hear from us.",
+    "email_notifications": "Email notifications",
+    "notifications_saved_title": "Preferences saved",
+    "notifications_saved_toast": "Your notification preferences have been updated.",
+    "notifications_error_title": "Couldn't save preferences",
+    "notifications_error_generic": "Something went wrong. Please try again.",
+    "saving": "Saving...",
+    "save_notifications": "Save changes"
   }
 }

--- a/src/locales/hi.json
+++ b/src/locales/hi.json
@@ -861,5 +861,18 @@
     "topics": {
       "title": "विषय"
     }
+  },
+  "Settings": {
+    "page_title": "सेटिंग्स",
+    "page_subtitle": "अपनी खाता प्राथमिकताएँ प्रबंधित करें",
+    "notifications_title": "सूचनाएँ",
+    "notifications_description": "चुनें कि आप हमसे कैसे सुनना चाहते हैं।",
+    "email_notifications": "ईमेल सूचनाएँ",
+    "notifications_saved_title": "प्राथमिकताएँ सहेजी गईं",
+    "notifications_saved_toast": "आपकी सूचना प्राथमिकताएँ अपडेट कर दी गई हैं।",
+    "notifications_error_title": "प्राथमिकताएँ सहेजी नहीं जा सकीं",
+    "notifications_error_generic": "कुछ गलत हो गया। कृपया फिर से प्रयास करें।",
+    "saving": "सहेज रहे हैं...",
+    "save_notifications": "परिवर्तन सहेजें"
   }
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -22,6 +22,7 @@ const protectedPaths = [
   '/onboarding',
   '/chat',
   '/admin',
+  '/settings',
 ];
 
 // Routes that require admin privileges


### PR DESCRIPTION
## What

Completes the email-notification-preferences seam that was half-wired in the template: the `use-user-preferences` hook already fetched `GET`/`PATCH /api/profile/preferences`, but that route did not exist (only `/api/profile/update-preferences` did) and there was no settings UI.

This PR adds:

- **`/api/profile/preferences` route** (`GET` + `PATCH`, `withAuth`-guarded, Drizzle on `userPreferences`) returning the bare `{ emailNotifications, language, username }` shape the hook expects — no hook change needed. The existing `update-preferences` route is left intact (still used by `LanguageSelector` + `OnboardingPreferences`).
- **`/{locale}/settings` page** (under the `(auth)` group, auth via `@/libs/auth/auth-redirects`) rendering the notifications section, plus a matching loading skeleton.
- **`notifications-section` component** — a single generic `emailNotifications` toggle wired through the existing `use-user-preferences` hook with optimistic cache write + sonner toasts.
- **`Settings` i18n namespace** in `en`/`hi`/`bn`.
- Enables the previously-disabled **Settings nav link** in `MainAppShell`.

## Source

Ported from ContentFlow (`src/app/api/profile/preferences/route.ts`, `src/components/settings/notifications-section.tsx`, `src/app/[locale]/(auth)/settings/*`), stripped of all LinkedIn/publish specifics — the CF `emailOnPublishSuccess`/`emailOnPublishFailure` pair collapses to the template's generic `emailNotifications` boolean (already the column in `userPreferences` and the field in the hook's `UserPreferences`).

## Integration notes

- Reuses existing template primitives: `withAuth`, `@/libs/api/errors` helpers, `db`/`userPreferences`, `requireAuthOrRedirect`, shadcn `switch`/`label`/`button`/`skeleton`, and the `use-user-preferences` hook + server-side `email-preferences` module — nothing duplicated.
- No new dependencies.
- Deferred: the additional profile/password/logout settings cards, a settings-specific error boundary (the `(auth)` group already has one), and `db:gen-types`-backed typing.

## Verification

`check-types`, `lint`, `test` (preferences route GET/PATCH + notifications-section), and `build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)