### PR TITLE
feat(skills): add upstream-contribute harvest loop + generic port-to-template engine

### DIFF
--- a/.claude/skills/upstream-contribute/SKILL.md
+++ b/.claude/skills/upstream-contribute/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: upstream-contribute
+description: >
+  Harvest a downstream product's generic, reusable improvements back into the
+  base template it was forked from — as verified, dependency-ordered PRs — and
+  supervise the merge with independent byte-level verification. Six phases:
+  Identify → Plan → Produce → Verify → Merge → Harvest. Re-runnable each time a
+  product accrues new contribution candidates. The template is the source of
+  truth; contributing up here propagates to the whole product fleet on the next
+  upstream-sync.
+when_to_use: >
+  Contributing code "up" from a product (e.g. ContentFlow) into its template
+  (vt-saas-template), or periodically upstreaming accumulated improvements.
+  Auto-detects whether you're in the template or a product and nudges. NOT for
+  syncing template changes DOWN into a product — that is upstream-sync, the
+  opposite direction.
+disable-model-invocation: true
+user-invocable: true
+argument-hint: "[phase | group]  e.g. 'identify'  or  'produce oauth-layer'"
+---
+
+# Upstream Contribute — harvest a product's improvements back into the template
+
+**Goal:** Take the generic, reusable improvements a product has accumulated since it forked, and land them in the base template as verified, dependency-ordered PRs — so the *next* product builds faster and the *whole fleet* improves together.
+
+---
+
+## WHY THIS EXISTS (the north star)
+
+The template is the **single source of truth** for shared/infra code. Every product is a fork. When one product contributes a generic improvement *up* to the template, every other product — and every future product — inherits it on the next `upstream-sync`. That is how a fleet of solo-built SaaS products compounds instead of diverging.
+
+So the test for everything this skill does is one line:
+
+> **Contribute it back if it makes the *next* product faster to build, or improves the *whole fleet*. Otherwise leave it in the product.**
+
+This is bidirectional fleet health: **contribute-up** (this skill) → **harvest-back** (re-apply, by hand, any product-source bugs found while porting) → **sync-down** (every product inherits it). Fix one thing once; the fleet gets it.
+
+---
+
+## PARTNER STANCE
+
+You are a release engineer who has shipped a base template across a fleet of products and has the scars to prove it. You've watched an agent confidently report a security fix it never actually applied, watched a "green" CI that silently skipped every check, and watched two parallel branches each invent the same table. You trust artifacts, not reports. Bring that taste:
+
+- **Trust bytes, never reports.** A produce agent's "I fixed it", a review bot's finding, a "green" check — all are *hypotheses*. Verify against the pushed diff (`git show`), re-run the exploit/test, confirm CI jobs actually *ran*. This is the spine; everything else is convenience.
+- **Recommend, don't ask.** Every gate ships a default + one-line rationale. Steelman the runner-up in a line when it's close.
+- **Serialize only what must be.** Maximize safe parallelism; sequence only where dependencies or the linear migration chain genuinely force it (see `plan`). Don't make 9 independent leaves wait on each other.
+- **Strip to the pattern, not the instance.** Contribute the seam + a placeholder/example, never the product's copy, prices, brand, or domain endpoints. Keep the template a *scaffold, not a library*.
+- **Red-team at every gate.** One bullet on the sharpest way this batch bites in three months.
+
+---
+
+## WHERE TO RUN THIS (auto-detected — step 01 nudges you)
+
+The engine addresses both repos by absolute path (`SOURCE`/`TARGET`/`PLAN`), so the loop *functions* from any cwd. But the loaded `CLAUDE.md`/rules shape judgment, and running from the canonical home avoids divergent copies. Step 01 runs `scripts/detect-context.sh`, confirms repo **identity** (remote/marker, not cwd name), and nudges:
+
+| Phase | Best run from | Why |
+|-------|---------------|-----|
+| Identify, Plan | the **product** | needs product depth; the plan is a product-side artifact |
+| Produce, Verify, Merge | the **template** (default) | template conventions matter; canonical skill home; where the risk lives |
+| Harvest | files issues on the **product** | (works from either cwd) |
+
+Default to the template; optionally start Identify/Plan in the product, then switch. It's an optimization, not a requirement — but the resolved `SOURCE`/`TARGET`/`PLAN` are **always echoed for confirmation before any produce or merge.**
+
+---
+
+## HARD RULES (non-negotiable — these are the institutionalized scars)
+
+1. **Independent byte-verification is the only merge gate.** A fresh subagent (no access to the produce run's reports) verifies the *pushed* PR: `git show` the claimed change, re-run the exploit/test, cite `file:line`. The engine's own review/fix is for draft quality only and **carries zero weight at merge.** See `checklists/merge-gate.md` — it is unskippable.
+2. **Never resume a half-finished produce run.** Size batches to complete in one engine run. If a run dies mid-group, **re-run that group fresh** — the idempotent precheck skips already-merged work. Resuming desyncs reports from bytes (it once nearly shipped an open-redirect).
+3. **Fail-closed selector + log resolved inputs.** The engine errors (never silently defaults to "all") if its group selection doesn't resolve, and logs the resolved set before running.
+4. **`main` is append-only.** Rebase-merge only. Never force-push or rewrite `main`. Feature branches may be force-pushed — but **force-push and hard-reset are hard guards: hand the exact `! git … --force-with-lease …` command to the user**; never `--admin`-bypass a merge — poll the checks to green.
+5. **Produce-only, then supervise.** The engine opens PRs; it never merges. Verify → merge is human-gated, dependency-ordered.
+6. **Strip to the pattern; template = scaffold, not library.** No product copy/brand/domain endpoints/schema-name. Opinionated or heavy subsystems ship **opt-in** (config-gated/flagged) so forks aren't forced into product-shaping choices.
+7. **Definition of done includes the loop-back.** Each run files a per-wave **harvest issue** on the product for source bugs found while porting (re-apply by hand, never cherry-pick — the divergence is real), and a **tracking issue for every deferral.**
+
+---
+
+## WORKFLOW ARCHITECTURE
+
+Two orchestration primitives, deliberately separate:
+
+- **Step files (this skill) = the conductor.** The main session walks the 6-phase lifecycle and owns everything needing judgment or a human gate (Identify, Plan, Verify, Merge, Harvest).
+- **The engine (`workflows/port-to-template.js`) = one instrument.** A deterministic, headless `Workflow`-tool script that the **Produce** step invokes to fan out produce-agents (prep → implement → ship) in isolated branches, with an idempotent precheck and per-group failure isolation. Its output is **always treated as unverified** — the `verify` step is the sole gate.
+
+### Step Processing Rules
+1. READ COMPLETELY — read the entire step file before acting.
+2. LOAD NEXT — only when directed; read the next step file fully, then execute.
+3. WAIT FOR INPUT — halt at gates until the user selects.
+
+---
+
+## INITIALIZATION SEQUENCE
+
+1. Set workflow variables:
+   - `skill_dir`: `${CLAUDE_SKILL_DIR}`
+   - `engine`: `{skill_dir}/workflows/port-to-template.js`
+   - step files: `{skill_dir}/steps/step-01-context-prereqs.md` … `step-07-harvest.md`
+2. Display a one-line intro:
+   ```
+   Upstream Contribute — harvest this product's generic improvements into the template.
+   Six phases: identify → plan → produce → verify → merge → harvest.
+   ```
+3. Load, read in full, and execute: `{skill_dir}/steps/step-01-context-prereqs.md`.
+   (If the user passed a `[phase | group]` argument, step 01 still runs detection + resume, then jumps to the named phase.)
+
+---
+
+## WORKFLOW STEPS
+
+| Phase | File | Purpose |
+|-------|------|---------|
+| 01 | step-01-context-prereqs.md | Detect cwd/repo identity + package manager + gh/git; resume-vs-new; nudge to the right repo/phase; echo resolved SOURCE/TARGET/PLAN |
+| 02 | step-02-identify.md | Audit the product↔template delta; screen each candidate against the contribution rubric → tag drop-in / generalize / opt-in / skip |
+| 03 | step-03-plan.md | Build the dependency DAG + collision graph; leverage-tier; emit the **wave schedule** (parallel within a wave, sequential across) into the plan sidecar |
+| 04 | step-04-produce.md | Run the engine one wave at a time (produce-only, fail-closed selector, small batches). Output is unverified |
+| 05 | step-05-verify.md | Independent fresh-context byte-gate per PR — the unskippable spine |
+| 06 | step-06-merge.md | Supervised dependency-ordered rebase-merge; append-only; reconcile known collisions; force-push → user |
+| 07 | step-07-harvest.md | Verify product-source bugs → harvest issue; tracking issue per deferral; sync-down decision |
+
+(Verify and Merge interleave per-PR: verify PR N → merge PR N → verify N+1. Verify is a mandatory gate before each merge.)
+
+---
+
+## ADOPTED PATTERNS
+
+- **Fresh-context verification subagent** + **evidence-based (file:line) output** — the byte-gate. *Proven:* `meta/skills/fresh-eyes/SKILL.md`, `product-factory/skills/technical-audit/shared-agent-instructions.md`.
+- **Multi-phase gates + resume sidecar** — gate between phases; the plan sidecar + the engine's idempotent precheck make the loop resumable at batch/PR boundaries. *Proven:* `product-factory/skills/fix-audit-findings/steps/step-01-plan.md`.
+- **Scripts for deterministic work** — byte-diff, rising-test-count, JSON.parse, CI-poll (treat "skipping" = success) are scripts; review/synthesis is the LLM. *Proven:* `meta/skills/nash/prune_transcript.py`.
+- **Tool/MCP detection + graceful degradation** — the cwd/package-manager nudge. *Proven:* `product-factory/skills/designer-founder/tools/stitch.md`.
+- **Risk-stratified autonomy** — light review for drop-ins; adversarial + sub-batching for L-effort / payment / auth / security. *Proven:* `product-factory/skills/fix-audit-findings/steps/step-02-execute.md`.
+- **Role-bounded handoff** — each produce/audit agent owns one group/dimension; structured returns. *Proven:* `product-factory/skills/implement-epic/steps/step-02-orchestrate.md`.
+
+---
+
+## SAFETY RULES
+
+- Show a diff/preview before any write, commit, or PR; produce-only — no auto-merge.
+- `main` is append-only; never force-push/rewrite it.
+- Destructive git (force-push, hard-reset) and `rm -rf` are routed to the user via `!` or replaced with `git stash -u` / `mv`-to-backup; never `--admin`-bypass branch protection.
+- Migration files: never `db:push`; regenerate (don't hand-merge) snapshots; in worktrees lacking `node_modules`, a `--no-verify` tooling commit is acceptable (note it).

--- a/.claude/skills/upstream-contribute/checklists/merge-gate.md
+++ b/.claude/skills/upstream-contribute/checklists/merge-gate.md
@@ -1,0 +1,20 @@
+# MERGE GATE — UNSKIPPABLE. Consult before merging ANY PR.
+
+> **THE ONE RULE: TRUST BYTES, NOT REPORTS.**
+> The produce run's "I fixed it", a review bot's finding, a "green" badge — all are *hypotheses*.
+> Nothing merges until an **independent** subagent confirms it against the **pushed** bytes.
+> The engine is unverified by definition; this gate is the only thing that makes a merge safe.
+
+Every box must be ticked from **artifacts you re-checked yourself** — not from any upstream claim. One unticked box = do not merge.
+
+- [ ] **Required CI green on the CURRENT head.** Checks ran against the rebased tip (not a stale pre-force-push run). A job reporting `skipping` counts as success. No `--admin` bypass; a red required check is signal, stop.
+- [ ] **INDEPENDENT byte-verify = PASS** (step-05, fresh subagent with **no access** to the produce run's reports): every claimed change confirmed *present in the pushed diff* via `git show`; every security / HIGH finding's exploit or test **re-run** to prove fix; `file:line` evidence cited. This is explicitly **NOT** the engine's or produce run's self-report — those carry zero weight here.
+- [ ] **Known collisions reconciled.** Migrations renumbered to the end of the chain **and** snapshot regenerated (journal lists the new file); additive registries (schema barrel, locale catalogs, `prod-setup.sql`) taken as a **union**; duplicate infra collapsed to the canonical one — no dupes.
+- [ ] **Non-empty diff + rising test count vs base.** `git diff main...HEAD` is non-empty (empty = the change evaporated into a collision); test count rose vs main (the change's tests survived the rebase).
+- [ ] **`main` append-only.** Rebase-merge only — no force-push, no rewrite, no rewind of main (revert forward if wedged).
+- [ ] **Destructive git routed to the user.** Any feature-branch `push --force-with-lease` / hard-reset handed off as an exact `!` command; checks polled to green, never `--admin`-merged.
+- [ ] **Loop-back captured.** Product-source bugs found while porting logged for the harvest issue; a tracking issue exists for every deferral.
+
+---
+
+**STOP RULE:** If you cannot tick the byte-verify box from the **actual pushed bytes** — do not merge. Loop back to step-05 (verify) and run the gate for real.

--- a/.claude/skills/upstream-contribute/references/collision-recipes.md
+++ b/.claude/skills/upstream-contribute/references/collision-recipes.md
@@ -1,0 +1,71 @@
+# Collision recipes — merge-time reconciliation playbook
+
+Loaded by **step-06 (Merge)**. Plan (step-03) already classified these files SERIALIZING vs ADDITIVE and scheduled waves to avoid the worst of them; this is what to *do* when two PRs still land on the same file at rebase time. Drawn from real 4-wave experience.
+
+Each recipe: **symptom → fix → trap**. The trap is the part that already bit us.
+
+> Rebase posture for all of them: reconcile, then trust the rebase **only on evidence** — non-empty `git diff main...HEAD` (empty = the change evaporated into the collision) **and** a rising test count vs main. If either fails, the reconciliation ate the change. Recreate the branch fresh from `origin` and replay rather than fight a tangled rebase.
+
+---
+
+## 1. Migrations — SERIALIZING (the linear spine)
+
+**Symptom.** PR adds migration `0042_*`; main already merged a different `0042_*` in the prior wave. The journal is an ordered chain — two files can't share an index.
+
+**Fix.** Renumber this PR's migration to the *next* free idx (`0043`), then **regenerate the snapshot** (`db:generate` against the renumbered schema) and **append** the journal entry. The snapshot must be machine-produced from the schema, the journal must *list* the new file.
+
+**Trap.**
+- **Never hand-merge the snapshot JSON** under `migrations/meta/`. It's a derived artifact; a hand-edit drifts from the schema and ships a broken migration. Regenerate, always.
+- A `.sql` file **not listed in `_journal.json` is silently skipped in prod** — renumbering the file without appending the journal looks merged but never runs.
+- Plan caps **≤1 migration-bearer per wave** precisely so this is the *only* migration to renumber per merge. If you're renumbering two in one wave, the wave was mis-planned — surface it.
+
+## 2. Schema barrel (`models/schema/index.ts`) — ADDITIVE
+
+**Symptom.** Two PRs each added an `export * from './…'` line; rebase conflicts on the export block.
+
+**Fix.** Take the **union** of export lines. Preserve existing ordering (let `lint:fix` sort if the repo auto-sorts) — don't reorder gratuitously.
+
+**Trap.** Dropping one side because "it looks like the same block" — a missing barrel export is a dangling table that compiles locally (the model file exists) but breaks the next consumer. Union means *both* new lines survive.
+
+## 3. `prod-setup.sql` — ADDITIVE
+
+**Symptom.** Two PRs appended RLS policies / grants / triggers to the same setup file.
+
+**Fix.** **Union the additive blocks.** Keep every policy/grant/trigger from both sides, in dependency order (grant before the policy that needs it).
+
+**Trap.** This file is replayed on every prod setup — it **must stay idempotent**. Preserve the `DO $$ … IF NOT EXISTS … END $$;` / `CREATE … IF NOT EXISTS` / `DROP … IF EXISTS` guards on each block. A unioned-in bare `CREATE POLICY` without the existence guard fails the *second* run. If a block lost its guard in the merge, restore it.
+
+## 4. Locale JSON — ADDITIVE (often auto-merges)
+
+**Symptom.** Two PRs added keys to the same `*.json` catalog. Frequently **auto-merges** clean (new keys land in non-adjacent regions).
+
+**Fix.** Union the keys. If git did flag it, take both sides' additions.
+
+**Trap.** A union that produces invalid JSON (trailing comma, duplicate key, an orphaned brace from a sloppy three-way merge) ships a catalog the app can't parse at boot. **Validate `JSON.parse`** on every locale file you touched before trusting the rebase — auto-merged ones included.
+
+## 5. `package.json` + lockfile — ADDITIVE deps, REGENERATED lock
+
+**Symptom.** Two PRs each added dependencies; `package.json` and the lockfile both conflict.
+
+**Fix.** In `package.json`, **keep ALL deps** — union the new ones from both sides into `dependencies`/`devDependencies` (mind which section each belongs in). Then **regenerate the lockfile** (`install` to resolve), don't hand-merge it.
+
+**Trap.** Hand-resolving lockfile conflict markers produces a tree that resolves to versions nobody tested — a silent, wide blast radius. The lock is derived: union the manifest, regenerate the lock. (Watch dep-*placement* gotchas: a build/CLI tool that belongs in `devDependencies` unioned into `dependencies` can drag a vulnerable transitive into the runtime bundle.)
+
+## 6. Duplicate infra — SERIALIZING (two PRs built the same thing)
+
+**Symptom.** Two PRs independently created the same table / util / helper / subsystem seam. Not a file conflict — a *semantic* one: the fleet ends up with two of the same thing.
+
+**Fix.** **Dependency order decides the owner.** The canonical owner merges **first** (it's the seam others build on). The consumer PR then **drops its duplicate** and **adapts to the canonical API** before its own rebase — re-point imports, delete the dup table/migration/util.
+
+**Trap.** Merging both and "deduping later" — later never comes, and now two migrations created the same table (the second fails on a live DB). Plan should have caught the overlap and serialized them (step-03 fails *closed*: when unsure additive-vs-overlapping, treat as overlapping). If it surfaces only at merge, **stop and re-order** — don't merge the second until it's been adapted onto the first.
+
+## 7. Re-trigger CI after a rebase
+
+**Symptom.** Rebased the head onto current main; CI still shows the stale run from the pre-rebase tip.
+
+**Fix.** Re-trigger by **force-pushing the rebased branch** (routed to the user as an exact `! git -C <repo> push --force-with-lease origin <branch>` — never run it yourself, never `--admin`).
+
+**Trap.**
+- **Close/reopen does NOT re-run CI** — it loses context and can skip path-filtered jobs. Force-push the rebase; that's the only reliable re-trigger.
+- **Post-force-push pending race:** checks briefly read stale-green from the prior head. Poll for the *new* run to register before trusting status — and treat a job reporting **"skipping" as success** (path filters legitimately skip docs/CI on a code-only PR).
+- **Land CI-correctness fixes FIRST.** If a wave includes a PR that fixes the CI itself (a broken workflow, a missing required check), merge it ahead of the batch so everything after it is gated by *real* CI — otherwise the rest of the wave goes green against a check that wasn't actually running.

--- a/.claude/skills/upstream-contribute/scripts/detect-context.sh
+++ b/.claude/skills/upstream-contribute/scripts/detect-context.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# detect-context.sh — resolve the runtime context for step-01 of upstream-contribute.
+#
+# Prints a greppable KEY=VALUE summary: repo IDENTITY (template | product | unknown),
+# package manager, gh auth, tree cleanliness, and SOURCE/TARGET hints. Identity is
+# decided by git remote + template marker — NEVER by folder name (worktrees lie).
+#
+# FAIL-CLOSED: if identity can't be resolved, role=unknown + a note. step-01 STOPS
+# and asks; it never guesses SOURCE/TARGET. Exit 0 always — the summary is the product.
+#
+# Usage: detect-context.sh [REPO_DIR]   (defaults to cwd)
+
+set -u
+
+# The canonical template. Identity hinges on this slug, not on any path.
+TEMPLATE_SLUG="vt-saas-template"
+
+REPO="${1:-$PWD}"
+
+# --- helpers -----------------------------------------------------------------
+# Run git scoped to REPO without an interactive cd (keeps the harness happy).
+g() { git -C "$REPO" "$@" 2>/dev/null; }
+have() { command -v "$1" >/dev/null 2>&1; }
+
+# --- not even a repo? bail clean --------------------------------------------
+if ! g rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "role=unknown"
+  echo "note=not a git work tree at ${REPO} — cannot resolve identity"
+  exit 0
+fi
+ROOT="$(g rev-parse --show-toplevel)"
+
+# --- identity: remote + marker, never the directory name ---------------------
+ORIGIN="$(g remote get-url origin || true)"
+UPSTREAM="$(g remote get-url upstream || true)"
+PKG_NAME="$(have node && [ -f "$ROOT/package.json" ] && node -p "require('$ROOT/package.json').name" 2>/dev/null || true)"
+
+ROLE="unknown"
+NOTE=""
+# Template signature: origin is the template slug, OR the cleanup marker exists,
+# OR package.json self-identifies. Any one is sufficient.
+if printf '%s' "$ORIGIN" | grep -q "$TEMPLATE_SLUG" \
+   || [ -f "$ROOT/.template-cleanup" ] \
+   || [ "$PKG_NAME" = "$TEMPLATE_SLUG" ]; then
+  ROLE="template"
+# Product signature: a fork — an `upstream` remote points at the template and
+# origin is something else.
+elif printf '%s' "$UPSTREAM" | grep -q "$TEMPLATE_SLUG" \
+     && ! printf '%s' "$ORIGIN" | grep -q "$TEMPLATE_SLUG"; then
+  ROLE="product"
+else
+  NOTE="no template slug in origin/upstream and no marker — add an 'upstream' remote pointing at ${TEMPLATE_SLUG}, or confirm identity by hand"
+fi
+
+# Product name from the origin slug (display only; never a decision input).
+PRODUCT_NAME=""
+[ "$ROLE" = "product" ] && PRODUCT_NAME="$(basename -s .git "$ORIGIN" 2>/dev/null)"
+
+# --- package manager: lockfile-driven ---------------------------------------
+if   [ -f "$ROOT/pnpm-lock.yaml" ];   then PKG_MGR="pnpm"
+elif [ -f "$ROOT/package-lock.json" ]; then PKG_MGR="npm"
+else PKG_MGR="unknown"; fi
+NODE_MODULES="absent"; [ -d "$ROOT/node_modules" ] && NODE_MODULES="present"
+
+# --- gh auth + tree state ----------------------------------------------------
+GH_AUTH="missing"
+have gh && gh auth status >/dev/null 2>&1 && GH_AUTH="ok"
+TREE="clean"; [ -n "$(g status --porcelain)" ] && TREE="dirty"
+
+# --- SOURCE/TARGET hints from the resolved role ------------------------------
+# TARGET is always the template. SOURCE is the product. We only know the half we
+# are standing in; the other side is a hint for step-01 to confirm, not assert.
+case "$ROLE" in
+  template) SOURCE_HINT="(unknown — point at the product repo)"; TARGET_HINT="$ROOT" ;;
+  product)  SOURCE_HINT="$ROOT"; TARGET_HINT="(unknown — point at ${TEMPLATE_SLUG})" ;;
+  *)        SOURCE_HINT="(unresolved)"; TARGET_HINT="(unresolved)" ;;
+esac
+
+# --- summary -----------------------------------------------------------------
+echo "role=${ROLE}"
+[ -n "$PRODUCT_NAME" ] && echo "product=${PRODUCT_NAME}"
+echo "repo_root=${ROOT}"
+echo "origin=${ORIGIN:-none}"
+echo "upstream=${UPSTREAM:-none}"
+echo "pkg_mgr=${PKG_MGR}"
+echo "node_modules=${NODE_MODULES}"
+echo "gh_auth=${GH_AUTH}"
+echo "tree=${TREE}"
+echo "source_hint=${SOURCE_HINT}"
+echo "target_hint=${TARGET_HINT}"
+[ -n "$NOTE" ] && echo "note=${NOTE}"
+exit 0

--- a/.claude/skills/upstream-contribute/scripts/verify-pushed-pr.sh
+++ b/.claude/skills/upstream-contribute/scripts/verify-pushed-pr.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# verify-pushed-pr.sh — deterministic byte-verify helpers for step-05 (verify) + step-06 (merge).
+#
+# These are *checks*, not judgment. The merge gate is a fresh, produce-blind verify subagent
+# (SKILL.md HARD RULE 1); these subcommands give it — and the merge step — scriptable, trustworthy
+# facts to reason over: does the claimed change exist in the *pushed* bytes, does a new file really
+# land on the branch, did the test count rise (not silently fall), is the JSON parseable, are the
+# required checks conclusively green. Each prints `PASS`/`FAIL <evidence>` and exits 0/1 so a caller
+# can branch on it. The JUDGMENT — is this change correct, stripped-to-pattern, exploit-closed —
+# stays with the subagent. Trust bytes, never reports.
+#
+# Usage: verify-pushed-pr.sh <subcommand> [args]
+#   diff-has   <repo> <base> <branch> <regex>   change appears in pushed branch..base diff
+#   file-on-branch <repo> <branch> <path>       a claimed new file exists on the pushed branch
+#   test-count <repo> <branch>                  print the test count on a ref (for a human/agent)
+#   test-delta <repo> <base> <branch>           assert branch's test count >= base (rising-count integrity)
+#   json-ok    <file>...                        every file JSON.parse-es cleanly (registries/journals)
+#   ci-poll    <repo> <pr>                       poll required checks to a conclusive state
+#
+# Conventions: <repo> is an absolute path (engine addresses repos by path). Refs are resolved against
+# `origin/` first (we verify what was *pushed*, not local state), falling back to the bare ref.
+set -uo pipefail
+
+die()  { echo "FAIL $*" >&2; exit 1; }
+pass() { echo "PASS $*"; exit 0; }
+
+# Resolve a ref to what was pushed: prefer origin/<ref>, else <ref>. Echoes the resolved ref.
+resolve_ref() {
+  local repo="$1" ref="$2"
+  if git -C "$repo" rev-parse --verify --quiet "origin/$ref" >/dev/null; then
+    echo "origin/$ref"
+  elif git -C "$repo" rev-parse --verify --quiet "$ref" >/dev/null; then
+    echo "$ref"
+  else
+    return 1
+  fi
+}
+
+# Count test cases on a ref without checking it out: grep test/it( across the tree at that ref.
+# Heuristic but monotonic — we only ever compare it to itself across base vs branch, so the
+# absolute number doesn't matter; a *drop* is the smell (tests clobbered in a rebase/port).
+count_tests() {
+  local repo="$1" ref="$2"
+  git -C "$repo" grep -hoE "\b(it|test)(\.(only|skip|each))?\s*\(" "$ref" -- \
+    '*.test.ts' '*.test.tsx' '*.spec.ts' '*.spec.tsx' 2>/dev/null | wc -l | tr -d ' '
+}
+
+cmd="${1:-}"; shift || true
+case "$cmd" in
+
+  # --- diff-has: the claimed change is present in the pushed diff (branch vs base) ----------------
+  diff-has)
+    repo="$1"; base="$2"; branch="$3"; regex="$4"
+    rb=$(resolve_ref "$repo" "$base")   || die "base ref not found: $base"
+    rh=$(resolve_ref "$repo" "$branch") || die "branch ref not found: $branch"
+    # Match against added lines only (leading '+', excluding the +++ file header).
+    hit=$(git -C "$repo" diff "$rb...$rh" | grep -E '^\+' | grep -vE '^\+\+\+' | grep -E "$regex" | head -3)
+    [ -n "$hit" ] || die "regex not in $rh...$rb added lines: /$regex/"
+    pass "diff-has /$regex/ in $rh (vs $rb):\n$hit"
+    ;;
+
+  # --- file-on-branch: a claimed new file actually exists on the pushed branch -------------------
+  file-on-branch)
+    repo="$1"; branch="$2"; path="$3"
+    rh=$(resolve_ref "$repo" "$branch") || die "branch ref not found: $branch"
+    if git -C "$repo" cat-file -e "$rh:$path" 2>/dev/null; then
+      bytes=$(git -C "$repo" cat-file -s "$rh:$path" 2>/dev/null)
+      pass "file-on-branch $path on $rh (${bytes}B)"
+    fi
+    die "file absent on $rh: $path"
+    ;;
+
+  # --- test-count: report the count on a ref (informational; pairs with test-delta) -------------
+  test-count)
+    repo="$1"; branch="$2"
+    rh=$(resolve_ref "$repo" "$branch") || die "ref not found: $branch"
+    pass "test-count $rh = $(count_tests "$repo" "$rh")"
+    ;;
+
+  # --- test-delta: rising-test-count integrity (branch must not lose tests vs base) -------------
+  test-delta)
+    repo="$1"; base="$2"; branch="$3"
+    rb=$(resolve_ref "$repo" "$base")   || die "base ref not found: $base"
+    rh=$(resolve_ref "$repo" "$branch") || die "branch ref not found: $branch"
+    cb=$(count_tests "$repo" "$rb"); ch=$(count_tests "$repo" "$rh")
+    [ "$ch" -ge "$cb" ] || die "test count fell: $rb=$cb -> $rh=$ch (tests clobbered?)"
+    pass "test-delta non-regressing: $rb=$cb -> $rh=$ch"
+    ;;
+
+  # --- json-ok: every file parses (additive registries, migration journals, locale catalogs) ----
+  json-ok)
+    [ "$#" -ge 1 ] || die "json-ok needs >=1 file"
+    bad=0
+    for f in "$@"; do
+      if node -e 'JSON.parse(require("fs").readFileSync(process.argv[1],"utf8"))' "$f" 2>/dev/null; then
+        echo "  ok   $f"
+      else
+        echo "  FAIL $f"; bad=1
+      fi
+    done
+    [ "$bad" -eq 0 ] || die "json-ok: one or more files did not parse"
+    pass "json-ok: $# file(s) parse"
+    ;;
+
+  # --- ci-poll: poll required checks to a conclusive state --------------------------------------
+  # Treats bucket=skipping as success (path filters legitimately skip docs/CI on a code-only PR).
+  # Handles the post-force-push pending race: a fresh push leaves checks briefly stale/pending, so
+  # we never trust the first read — we require a poll where NOTHING is pending before judging.
+  ci-poll)
+    repo="$1"; pr="$2"
+    deadline=$(( $(date +%s) + ${CI_POLL_TIMEOUT:-600} ))   # bounded loop; default 10m
+    interval="${CI_POLL_INTERVAL:-20}"
+    while :; do
+      # bucket ∈ pass | fail | pending | skipping | cancel  (gh categorizes state for us)
+      buckets=$(gh pr checks "$pr" -R "$(git -C "$repo" remote get-url origin 2>/dev/null)" \
+                  --json bucket -q '.[].bucket' 2>/dev/null) \
+        || buckets=$(gh pr checks "$pr" --json bucket -q '.[].bucket' 2>/dev/null) \
+        || die "ci-poll: gh pr checks failed for #$pr"
+      [ -n "$buckets" ] || die "ci-poll: no checks reported for #$pr (none registered yet?)"
+      pend=$(grep -c '^pending$'  <<<"$buckets")
+      fail=$(grep -cE '^(fail|cancel)$' <<<"$buckets")
+      # Force-push race: don't judge until the new run has registered (no pending left).
+      if [ "$pend" -eq 0 ]; then
+        [ "$fail" -eq 0 ] || die "ci-poll: #$pr has $fail failing/cancelled check(s) — red gate is signal, do NOT --admin"
+        pass "ci-poll: #$pr conclusive — $(grep -c '^pass$' <<<"$buckets") pass, $(grep -c '^skipping$' <<<"$buckets") skipping (treated as success)"
+      fi
+      [ "$(date +%s)" -lt "$deadline" ] || die "ci-poll: #$pr still pending after timeout ($pend pending)"
+      sleep "$interval"
+    done
+    ;;
+
+  *)
+    die "unknown subcommand: '$cmd' — see header for usage"
+    ;;
+esac

--- a/.claude/skills/upstream-contribute/steps/step-01-context-prereqs.md
+++ b/.claude/skills/upstream-contribute/steps/step-01-context-prereqs.md
@@ -1,0 +1,87 @@
+---
+name: 'step-01-context-prereqs'
+description: 'Resolve repo identity, package manager, gh/git readiness; resume-vs-new; nudge to the right repo/phase; echo + confirm SOURCE/TARGET/PLAN before anything downstream.'
+workflow_path: '${CLAUDE_SKILL_DIR}'
+thisStepFile: '{workflow_path}/steps/step-01-context-prereqs.md'
+nextStepFile: '{workflow_path}/steps/step-02-identify.md'
+workflowFile: '{workflow_path}/SKILL.md'
+detectScript: '{workflow_path}/scripts/detect-context.sh'
+---
+
+# Step 01 — Context & Prereqs
+
+## STEP GOAL
+
+Pin down *where we are* and *that we can work*, then point at the right next move. By the end you've resolved repo **identity** (template or which downstream product), the package manager, `gh` auth and a clean tree; decided **resume vs. fresh**; nudged toward the canonical home for the requested phase; and **echoed + had the user confirm** the absolute `SOURCE` / `TARGET` / `PLAN` paths. Nothing produces or merges until that confirmation lands.
+
+## Constraints
+
+- **Fail closed on identity.** If `detect-context.sh` can't resolve which repo is which, STOP and ask — never guess `SOURCE`/`TARGET`. Two repos addressed by absolute path is the whole safety model; a wrong guess ports product copy into the template or merges into a product.
+- **Identity = remote/marker, not folder name.** Worktrees and clones get renamed; the cwd basename lies. Trust the git remote or the template marker the script checks, never the directory name.
+- **The engine is unverified and the plan is the only resumable state.** There is no "produce checkpoint" to resume — resuming means re-pointing at an in-progress plan sidecar in the *product*, not continuing a dead engine run (see HARD RULE 2 in `{workflowFile}`).
+- **Confirmation is a hard gate.** No identify/produce/merge reasoning before the user OKs the echoed paths.
+
+## Sequence of Instructions
+
+### 1. Detect context
+
+Run `{detectScript}` and read its output as the source of truth for: repo identity (template vs. a named product, by remote/marker), package manager (pnpm vs. npm), `gh` auth status, and whether the tree is clean. Don't re-derive any of this from the cwd name or your own `git` pokes — the script exists so judgment isn't load-bearing here.
+
+If identity is ambiguous or the script errors, surface exactly what it couldn't resolve and ask. Do not proceed on a guess.
+
+### 2. Readiness, stated plainly
+
+Report the resolved facts in one compact block (identity, package manager, `gh`, tree state). Flag blockers, don't paper over them:
+
+- Dirty tree → offer to stash (`git stash -u`) or stop; never barrel ahead.
+- `gh` unauthenticated → produce/merge can't open or poll PRs; call it now, not at wave time.
+- **npm + missing `node_modules`** → note the worktree friction: pre-commit hooks fire on tooling commits and there's no installed husky, so a `--no-verify` tooling commit is the escape hatch (and must be noted when used). **pnpm sidesteps this** — its worktree story is cleaner; mention it as the standing recommendation, don't force a switch.
+
+### 3. Resume vs. fresh
+
+Look for an in-progress contribution-plan sidecar **in the product** (the plan is a product-side artifact). If one exists, summarize it (wave schedule, what's merged, what's pending) and offer:
+
+- **Continue** — adopt that plan, jump past Identify/Plan to where it left off.
+- **Fresh** — start a new pass from Identify; leave the old sidecar untouched.
+
+No sidecar → fresh, silently.
+
+### 4. Nudge to the right repo for the phase
+
+Per the WHERE-TO-RUN table in `{workflowFile}`: **Identify/Plan want the product** (product depth; the plan lives there); **Produce/Verify/Merge default to the template** (its conventions matter, it's the canonical skill home, it's where the risk lives); the engine is cwd-agnostic. If the current cwd doesn't match the upcoming phase, say so and recommend the switch — it's an optimization, not a wall. Don't block on it.
+
+### 5. Echo SOURCE / TARGET / PLAN — and confirm
+
+Resolve and print the three absolute paths:
+
+```
+SOURCE (product) : <abs path>
+TARGET (template): <abs path>
+PLAN  (sidecar)  : <abs path>   [new | resuming]
+```
+
+Get an explicit OK before any downstream phase touches these. This is the byte-level safety contract — wrong paths here defeat every later gate.
+
+### 6. Route
+
+If the user passed a `[phase | group]` argument, jump to that phase **after** detection + resume + path-confirm (never skip those). Otherwise fall through to the gate.
+
+### 7. Phase Gate
+
+```
+=== CONTEXT SUMMARY ===
+
+Identity        : <template | product:NAME>   (by remote/marker)
+Package manager : <pnpm | npm>   <node_modules note if relevant>
+gh / git tree   : <auth ok? | clean?>
+Mode            : <fresh | resuming plan @ wave N>
+SOURCE / TARGET / PLAN : <confirmed?>
+Next phase      : <Identify | jumped-to: PHASE>   best run from: <product | template>
+
+[C] Continue
+[R] Revise — fix a resolved value or re-point a path
+```
+
+**If C:** Load and execute `{nextStepFile}`. Pass forward: identity, SOURCE, TARGET, PLAN, package manager (+ `node_modules` note), resume-mode, and any `[phase | group]` jump target.
+
+**If R:** Ask what to revise (path, identity override, stash, resume choice), apply it, re-display the summary.

--- a/.claude/skills/upstream-contribute/steps/step-02-identify.md
+++ b/.claude/skills/upstream-contribute/steps/step-02-identify.md
@@ -1,0 +1,68 @@
+---
+name: 'step-02-identify'
+description: 'Audit the product↔template delta and tag each candidate against the contribution rubric'
+workflow_path: '${CLAUDE_SKILL_DIR}'
+thisStepFile: '{workflow_path}/steps/step-02-identify.md'
+nextStepFile: '{workflow_path}/steps/step-03-plan.md'
+workflowFile: '{workflow_path}/SKILL.md'
+---
+
+# Identify — what is worth contributing up?
+
+## STEP GOAL
+
+Compute the delta between the product and template main, screen each candidate against the contribution rubric, and walk away with a **tagged candidate list** (drop-in / generalize / opt-in / skip) — the input the next phase turns into a wave schedule. Nothing is written to either repo here; this is a read-only audit ending in a gate.
+
+## Constraints
+
+- **Best run from the product** (per WHERE-TO-RUN) — the delta needs product depth, and the plan it feeds is a product-side artifact. If step 01 landed you in the template, say so and offer to switch; don't fake product depth from the template side.
+- **Verify generic-vs-specific against source, never names.** A file called `email-service.ts` may be 90% template seam + 10% product copy. Read it. The one-line test for every candidate: *does this create fleet leverage?* If not, it stays in the product.
+- **Dedupe ruthlessly.** A candidate already on template `main` or sitting in an open template PR is not a candidate. Check both before tagging.
+- This phase is unverified scouting, not the byte-gate. Cite evidence so phase 03 can trust the list, but the merge gate is still phase 05.
+
+## Sequence of Instructions
+
+### 1. Fan out a read-only delta audit
+
+Spread the audit across the product's subsystems rather than reading it as one blob — auth, middleware/proxy, AI layer, jobs/publish, payments/subscriptions, email, DB workflow/migrations, UI primitives, config/env, scripts/CI. Dispatch parallel **read-only** subagents, one per subsystem cluster, each returning candidates as `file:line` + a one-line "what's generic here." Maximize the fan-out; these don't depend on each other.
+
+Each subagent's job is the *delta*, not an inventory: what does the product now have that is generic **and** not already upstream. Hand every subagent the dedupe inputs — template `main` (the canonical home) and the list of open template PRs (`gh pr list`) — so it screens before it reports.
+
+### 2. Screen each candidate against the rubric
+
+For every returned candidate, answer the spine's five questions against the actual source:
+
+1. **Generic?** — pattern, not product instance. (If it carries ContentFlow copy/brand/domain/schema-name, it's not generic *as-is* — see the strip-recipe below.)
+2. **Leverage?** — does it speed the *next* product, or prevent a *class* of bug? This is the one-line test; a yes here is the whole reason to contribute.
+3. **Battle-tested?** — proven in product prod, not dormant/experimental code (e.g. don't harvest a phase-2 feature that's never shipped).
+4. **Most forks want it?** — broadly useful, not a one-off product shape.
+5. **Not already upstream?** — confirmed absent from template main + open PRs.
+
+### 3. Tag each candidate
+
+Resolve every screened candidate to exactly one TAG:
+
+- **drop-in** — generic as-is; copies up unchanged. Low-effort.
+- **generalize** — useful but carries product specifics. Attach a **strip-recipe**: the exact product copy / brand / domain endpoints / schema-name / prices to strip, and the placeholder or example that replaces it. *Strip to the pattern, not the instance — template = scaffold, not library.*
+- **opt-in** — opinionated or heavy subsystem. Note how it ships config-gated / flagged so forks aren't forced into a product-shaping choice.
+- **skip** — fails the rubric (product-specific, dormant, already upstream, or no fleet leverage). One-line reason each; skips are evidence the audit was honest, so keep them visible.
+
+### 4. Phase Gate
+
+Present the tagged list grouped by tag, each row: candidate · `file:line` · tag · one-line rationale (+ strip-recipe for generalize, gating note for opt-in). Add one red-team line: the sharpest way *missing* a candidate — or harvesting one that's secretly product-shaped — bites the fleet in three months.
+
+```
+=== IDENTIFY SUMMARY ===
+
+Audited from:   <PRODUCT repo + identity>
+Candidates:     <N>  →  drop-in <a> · generalize <b> · opt-in <c> · skip <d>
+Deduped against: template main + <k> open PRs
+Red-team:       <one line>
+
+[C] Continue to Plan — build the dependency DAG + wave schedule
+[R] Revise — re-audit a subsystem, retag, or move a candidate across tags
+```
+
+**If C:** Load and execute `{nextStepFile}`. Pass forward the tagged candidate list (candidate, `file:line`, tag, rationale, strip-recipe / gating notes), the resolved SOURCE/TARGET, and the dedupe baseline (template main SHA + open-PR set).
+
+**If R:** Ask what to revise — re-run a subsystem audit, retag a candidate, or split/merge a generalize strip-recipe — apply it, and re-display the summary.

--- a/.claude/skills/upstream-contribute/steps/step-03-plan.md
+++ b/.claude/skills/upstream-contribute/steps/step-03-plan.md
@@ -1,0 +1,84 @@
+---
+name: 'step-03-plan'
+description: 'Turn tagged candidates into a dependency-ordered wave schedule; write the plan sidecar in the product'
+workflow_path: '${CLAUDE_SKILL_DIR}'
+thisStepFile: '{workflow_path}/steps/step-03-plan.md'
+nextStepFile: '{workflow_path}/steps/step-04-produce.md'
+workflowFile: '{workflow_path}/SKILL.md'
+planTemplate: '{workflow_path}/templates/contribution-plan.template.md'
+---
+
+# Phase 03 — Plan: candidates → wave schedule
+
+## STEP GOAL
+
+Take the rubric-tagged candidates from Identify and schedule them into **waves** — batches the engine can produce in parallel without stepping on each other. You walk away with a wave schedule written to the **product-side plan sidecar** (the produce phase's input), and the user has signed off on order, batching, and the serial migration spine.
+
+A wave is the unit the engine runs (step 04). Get the waves right here and produce is mechanical; get them wrong and you'll reconcile collisions PR-by-PR at merge.
+
+## Constraints
+
+- **The plan sidecar lives in the PRODUCT** (e.g. `_bmad-output/`), built from `{planTemplate}`. Never write it into the template engine — the template stays a scaffold, and this artifact is product state.
+- **The migration journal is a serial spine, not a parallel field.** `migrations/meta/_journal.json` is an ordered, linear chain — two PRs that each append a migration cannot coexist in one wave. Cap **≤1 migration-bearer per wave**; chain the rest across waves. Most non-migration PRs hang off this spine as parallel leaves.
+- **Across waves is sequential by construction:** the next wave is produced *off the updated `main`* (deps + prior migrations already merged), so produce sees zero reconciliation. Within a wave is parallel. Don't serialize leaves that don't collide.
+- **Engine batch cap ~3–4 per wave.** Bigger batches dilute the byte-gate and risk a half-run you can't resume (HARD RULE 2). Prefer more, smaller waves.
+- Planning only — no branches, no PRs, no engine. Skip anything tagged `skip`; it never enters a wave (but record the deferral so step 07 files a tracking issue).
+
+## Sequence of Instructions
+
+### 1. Build the dependency DAG (what needs what ON MAIN first)
+
+For each candidate, ask: does this build on a seam another candidate introduces? An opt-in feature that imports a config helper, a route that needs a middleware wrapper, a second migration that assumes the first table — these are edges. The dependent can't be produced until its dependency is *merged to main*. Resolve cycles by splitting or merging candidates; a real cycle is a planning bug.
+
+### 2. Build the collision graph over shared hot files
+
+Two PRs collide when they both touch a file `main` will see at merge time. Classify each shared file — the treatment differs:
+
+- **SERIALIZING — migration journal** (`migrations/meta/_journal.json` + snapshots): the linear chain. ≤1 migration-bearer per wave; the rest become a dependency chain across waves.
+- **SERIALIZING — overlapping infra:** two candidates building the *same* table / the *same* subsystem seam. Dependency-order them; never parallel, even if files look additive — the second must be produced against the first.
+- **ADDITIVE — cheap union** (schema barrel/`index.ts`, prod-setup, locale JSON, `package.json`): append-only edits that union trivially. Parallel within a wave is fine; reconcile the union at merge.
+
+When unsure whether two PRs are additive or overlapping, treat as overlapping (serialize) — fail-closed, matching the engine's selector posture.
+
+### 3. Assign leverage tier
+
+Order by fleet payoff, per the spine: **guardrails & discipline > infra spine > drop-in features > opt-in heavy**. Bug-fixes jump the queue regardless (one fix, whole fleet, on next sync-down). Tier breaks ties on wave ordering and sets how hard the byte-gate leans in step 05 — higher-risk tiers (auth/payment/security/infra) get adversarial verification.
+
+### 4. Emit the WAVE SCHEDULE
+
+Pack waves greedily against four gates. A candidate is eligible for wave N when:
+
+1. all its DAG deps are in waves `< N` (buildable depth — they'll be on main),
+2. it's collision-free with every other candidate in wave N (no shared SERIALIZING file),
+3. wave N holds **≤1 migration-bearer**, and
+4. wave N is **within the batch cap (~3–4)**.
+
+Within a wave: parallel. Across waves: sequential, each produced off the updated main. The result is a serial migration chain with parallel leaves fanning off each wave. State for each candidate: tier, deps, the hot files it touches, and which collision class triggered its placement — so the user can see *why* it landed where it did.
+
+### 5. Write the sidecar, present, gate
+
+Read `{planTemplate}`, populate it in the product (resolved `PLAN` path from step 01), and write the wave schedule + the deferral list (everything tagged `skip` or punted). Then present the schedule and gate.
+
+### 6. Phase Gate
+
+```
+=== PLAN SUMMARY ===
+
+Candidates scheduled: {N}  ·  deferred: {M}
+Waves: {W}   (serial migration chain: {migration-bearers} across {chain-length} waves)
+Leverage mix: {guardrails}/{infra}/{drop-in}/{opt-in}  ·  bug-fixes: {B}
+
+  Wave 1: {ids}        ← {migration-bearer? }, leaves: {…}
+  Wave 2: {ids}        ← off updated main; deps {…} merged
+  …
+
+Sidecar: {PLAN}
+Sharpest risk (3-month): {one line — the collision or dep most likely to bite}
+
+[C] Continue to Produce
+[R] Revise — reorder, re-tier, re-batch, or split a candidate
+```
+
+**If C:** Load and execute `{nextStepFile}`. Pass forward: the wave schedule, the `PLAN` sidecar path, resolved `SOURCE`/`TARGET`, and the deferral list.
+
+**If R:** Ask what to revise (wave membership, ordering, tier, batch size, a split/merge), apply it, re-validate the four gates, rewrite the sidecar, re-display.

--- a/.claude/skills/upstream-contribute/steps/step-04-produce.md
+++ b/.claude/skills/upstream-contribute/steps/step-04-produce.md
@@ -1,0 +1,72 @@
+---
+name: 'step-04-produce'
+description: 'Run the engine for ONE wave, produce-only — open PRs, verify nothing'
+workflow_path: '${CLAUDE_SKILL_DIR}'
+thisStepFile: '{workflow_path}/steps/step-04-produce.md'
+nextStepFile: '{workflow_path}/steps/step-05-verify.md'
+workflowFile: '{workflow_path}/SKILL.md'
+engine: '{workflow_path}/workflows/port-to-template.js'
+---
+
+# Phase 04 — Produce (one wave, produce-only)
+
+## STEP GOAL
+
+Fan out the engine across exactly **one wave** of the plan's schedule — produce-agents prep, implement, and push each group's branch and open its PR — and hand the resulting PR list to verify. You walk away with N draft PRs and **zero confidence in them**. The engine's output (including any self-review it ran) is a hypothesis; it carries **zero weight**. The gate is step-05, not here.
+
+## Constraints
+
+- **Best run from the template** (canonical skill home, where the risk lives). The engine addresses both repos by absolute path, so it functions from any cwd — but confirm repo *identity* before invoking, not cwd name.
+- **One wave only.** Never widen the group set to drain the backlog faster. Small batches are what let a single engine run finish without resuming, and what keep the verify gate tractable. Later waves come back through this step.
+- **Fail-closed, never default to "all".** If the wave's group set doesn't resolve cleanly from the plan sidecar, STOP and surface it. A silent fallback to every group is the failure this guard exists to prevent — the engine itself errors on an unresolved selector, and so do you.
+- **Never resume a half-finished produce run.** If the engine dies mid-group, re-run that group **fresh** — the idempotent precheck skips already-merged work, so a clean re-run is safe and a resume is not (resuming desyncs reports from bytes). Do not hand the engine a "continue from group K" instruction.
+- **Produce-only.** The engine opens PRs; it never merges. Nothing here touches `main`.
+
+## Sequence of Instructions
+
+### 1. Resolve this wave's group set
+
+Read the plan sidecar (the wave schedule emitted by step-03). Identify the **next wave that isn't fully merged** and pull its group set — the groups that are parallel-safe *within* this wave. If resolution is ambiguous or empty, treat it as the fail-closed case below — do not guess.
+
+### 2. Echo resolved inputs + confirm (fail-closed)
+
+Before invoking anything, echo the resolved `SOURCE` / `TARGET` / `PLAN` (absolute paths) and the **exact group set** for this wave. This is the same log-the-resolved-set discipline the engine enforces, surfaced to the user. If any of these failed to resolve — STOP here, report what's missing, and wait. Do not default to "all".
+
+```
+=== WAVE n / N ===
+SOURCE: {abs path}      TARGET: {abs path}      PLAN: {abs path}
+Groups (parallel this wave): {group, group, …}
+Proceed? [C] produce  ·  [R] revise the wave
+```
+
+### 3. Invoke the engine (Workflow tool)
+
+On confirm, run the engine via the **Workflow** tool — not Bash, not Task:
+
+- `scriptPath`: `{engine}`  (i.e. `${CLAUDE_SKILL_DIR}/workflows/port-to-template.js`)
+- `args`: `{ source, target, plan, groups }` — `groups` = exactly the resolved set from step 1, never broader.
+
+Let it run to completion for this wave. It fans out produce-agents in isolated branches with per-group failure isolation; a single group failing does not poison its siblings.
+
+### 4. On completion — list the opened PRs, claim nothing
+
+Collect the PRs the engine opened this wave (number, branch, group). Report them as a plain inventory. Do **not** echo, paraphrase, or lend weight to any self-review, "I fixed X", or "looks good" the engine emitted — that output is unverified by construction and the next step re-derives the truth from the pushed bytes.
+
+If a group failed or its PR is missing: note it, and **re-run that one group fresh** through steps 2–3 (fresh, never resumed). Do not advance to verify with a phantom PR in the list.
+
+### 5. Phase Gate
+
+```
+=== PRODUCE SUMMARY (wave n / N) ===
+Groups run:   {set}
+PRs opened:   #… ({group}), #… ({group}), …
+Failed/re-run: {group | none}
+Status:       UNVERIFIED — engine output carries zero weight
+
+[C] Continue to verify (the only merge gate)
+[R] Revise — re-run a group fresh, or re-resolve the wave
+```
+
+**If C:** Load and execute `{nextStepFile}`. Pass forward: `SOURCE`, `TARGET`, `PLAN`, this wave's group set, and the opened-PR inventory.
+
+**If R:** Ask which group/wave to redo, re-run it **fresh** via steps 2–3 (never a resume), then re-display this summary.

--- a/.claude/skills/upstream-contribute/steps/step-05-verify.md
+++ b/.claude/skills/upstream-contribute/steps/step-05-verify.md
@@ -1,0 +1,77 @@
+---
+name: 'step-05-verify'
+description: 'Independent fresh-context byte-gate per PR — the only merge gate'
+workflow_path: '${CLAUDE_SKILL_DIR}'
+thisStepFile: '{workflow_path}/steps/step-05-verify.md'
+nextStepFile: '{workflow_path}/steps/step-06-merge.md'
+workflowFile: '{workflow_path}/SKILL.md'
+merge_gate: '{workflow_path}/checklists/merge-gate.md'
+verify_helpers: '{workflow_path}/scripts/verify-pushed-pr.sh'
+---
+
+# Step 5: Verify — independent byte-gate per PR
+
+## STEP GOAL
+
+The spine. For every PR the produce wave opened, an independent fresh-context subagent verifies the **pushed bytes** match the claim — `git show` proves the change exists, security/HIGH findings get their exploit or test **re-run**, every PASS cites `file:line`. The engine's "I fixed it" is a hypothesis; this is where it becomes fact or gets sent back. You walk away with a PASS/FAIL verdict per PR and evidence behind each — only PASS PRs cross into merge.
+
+## Constraints
+
+- **This is the ONLY merge gate.** The produce run's own review/fix carries zero weight here (`merge-gate.md` is unskippable). Nothing merges that didn't independently PASS.
+- **The verifier is fresh-context and produce-blind.** Its entire context is: PR number/branch, the original finding/claim, and `{merge_gate}`. Do **not** hand it (and instruct it never to read) the produce reports, engine logs, or implementation brief. By construction it sees only the pushed branch — that's the point. A verifier that read the report would just be grading the report.
+- **Trust bytes, not reports.** "Green CI", "tests pass", an engine summary — all hypotheses until `git show` / a re-run confirms them. Treat a check that *skipped* as not-run, not as pass.
+- **FAIL means re-produce fresh, not patch-in-place.** Never resume or hand-tweak a failed branch from the main session — that desyncs reports from bytes. Loop the failed group back through produce clean (step 04); the idempotent precheck skips what already merged.
+- Read-only here. This step opens no PRs and merges nothing.
+
+## Sequence of Instructions
+
+### 1. Enumerate what the wave actually pushed
+
+Collect the PRs this wave opened — number, branch, the finding/claim each one answers, and its risk tier (carried from the plan). Confirm each is real and open (`gh pr view`); a PR the engine *reported* but didn't push is itself a FAIL — flag it, no verifier needed.
+
+### 2. Tier verification depth by risk
+
+Match scrutiny to blast radius — over-verifying drop-ins wastes the budget that security needs.
+
+- **Drop-in / low-risk** (config, copy-stripped scaffold, mechanical): light pass — confirm the bytes exist and nothing product-specific leaked.
+- **Generalize / medium**: standard gate — bytes + the relevant test re-run + strip-to-pattern check.
+- **Security / payment / auth / HIGH**: adversarial — spawn **multiple skeptics**, and **replay the exploit or failing test against the pushed branch** (the helpers in `{verify_helpers}` exist for exactly this). One PASS isn't enough until the original attack provably no longer works.
+
+### 3. Spawn one fresh verifier per PR
+
+Give each subagent only its three inputs (PR/branch · claim · `{merge_gate}`) and the depth from step 2. It must:
+
+- `git show` / diff the **pushed branch** and confirm the claimed change is actually there.
+- For security/HIGH: re-run the exploit or failing test via `{verify_helpers}` and show it now fails-closed/passes.
+- Return **PASS or FAIL with evidence** — `file:line` cites, command output, exploit result. A PASS without evidence is a FAIL.
+- Stay strip-to-pattern aware: leaked product copy/brand/domain/schema-name is a FAIL even if the logic is correct.
+
+Run independent verifiers in parallel; they share no state.
+
+### 4. Aggregate verdicts
+
+For each PR: PASS (with evidence) or FAIL (with the specific gap — missing bytes, exploit still fires, leaked instance, skipped check). PASS PRs are cleared to merge. Keep the evidence — step 06 reconciles in dependency order and may want it.
+
+### 5. Route the failures
+
+Any FAIL → the affected group goes **back through produce, fresh** (step 04), then back here. Do not hand-wave, do not patch the branch by hand, do not "just re-push." Re-verify the re-produced result from scratch. A group churning twice is a signal the finding itself is wrong — say so rather than forcing a green.
+
+### 6. Phase Gate
+
+```
+=== VERIFY SUMMARY ===
+
+Wave: {wave}
+PRs verified: {n}   PASS: {p}   FAIL: {f}
+  PASS → cleared for merge (dependency-ordered): {list}
+  FAIL → re-produce fresh (step 04): {list + one-line gap each}
+Adversarial (security/payment/auth): {which PRs, exploit-replay result}
+Red-team: the sharpest way a PASS here still bites in 3 months — {one line}
+
+[C] Continue to merge (only PASS PRs advance)
+[R] Revise — re-tier a PR, re-run a verifier, or send a group back to produce
+```
+
+**If C:** Load and execute `{nextStepFile}`. Pass forward: the PASS PR list with evidence, the wave's dependency order, and any open FAIL groups still owed a re-produce.
+
+**If R:** Ask what to revise (depth tier, a single verifier re-run, or routing a group back to step 04), apply it, re-run the affected verification, re-display the summary.

--- a/.claude/skills/upstream-contribute/steps/step-06-merge.md
+++ b/.claude/skills/upstream-contribute/steps/step-06-merge.md
@@ -1,0 +1,81 @@
+---
+name: step-06-merge
+description: Supervised, dependency-ordered, append-only merge of VERIFIED PRs into the template — rebase each onto current main, reconcile known collisions, re-trigger CI via force-push (routed to the user), poll to green, then rebase-merge. One PR at a time; main never rewinds.
+workflow_path: '${CLAUDE_SKILL_DIR}'
+thisStepFile: '{workflow_path}/steps/step-06-merge.md'
+nextStepFile: '{workflow_path}/steps/step-07-harvest.md'
+workflowFile: '{workflow_path}/SKILL.md'
+collisionRecipes: '{workflow_path}/references/collision-recipes.md'
+mergeGate: '{workflow_path}/checklists/merge-gate.md'
+---
+
+# Phase 6 — Merge (supervised, dependency-ordered, append-only)
+
+## STEP GOAL
+
+Land the PRs that **passed step-05's byte-gate** into the template, one at a time, in dependency order — so the next product inherits them on the next sync. Each PR is rebased onto the *current* main, has its known collisions reconciled, gets CI re-triggered and polled to green, and is then rebase-merged. Main advances; the next PR rebases onto the new tip. You walk away with verified work merged and main never rewound.
+
+## Constraints
+
+- **Verification (step-05) is the precondition.** Never merge a PR the fresh-context byte-gate hasn't passed — the engine's own review/fix carries *zero* weight here (`{mergeGate}`). Verify N → merge N → verify N+1; never batch-merge ahead of the gate.
+- **`main` is append-only.** Rebase-merge only. Never force-push, hard-reset, or otherwise rewrite `main` — not even to "fix" a bad merge (revert forward instead).
+- **Destructive git is the user's to run.** Any feature-branch `push --force-with-lease` / hard-reset is *handed to the user* as an exact `!`-prefixed command. Never run it yourself; never `--admin`-bypass branch protection.
+- **Dependency order is load-bearing.** Merge along the plan's wave schedule. A leaf that depends on an unmerged parent has nothing correct to rebase onto — wait.
+
+## Sequence of Instructions
+
+### 1. Confirm the merge queue
+
+Take the verified PRs in plan dependency order (parents before children; within a wave, any order). Echo the resolved `TARGET` repo and the ordered queue for confirmation before touching anything. Skip any PR not marked verified — surface it, don't merge it.
+
+### 2. Per PR: rebase onto current main
+
+Main has moved since produce. Rebase the head onto the live tip. If branch integrity is in any doubt (mid-run death, dirty local state, a force-push you didn't author), don't fight a tangled rebase — **recreate the branch fresh from `origin`** and replay the change.
+
+Reconcile the **known collisions** per `{collisionRecipes}` — these recur every wave:
+- **Migrations:** renumber to the end of the chain and **regenerate the snapshot** (never hand-merge `meta/`); the journal must list the new file or prod silently skips it.
+- **Additive registries** (schema barrel, locale catalogs, `prod-setup.sql`): take the **union**, not one side.
+- **Duplicate infra** (two branches added the same helper/table): collapse to the **canonical** one; drop the dupe.
+
+Then **trust the rebase only on evidence**: a *non-empty* diff vs main (`git show` / `git diff main...HEAD` — empty means the change evaporated into a collision) **and** a *rising* test count vs main (the change's tests survived the rebase, didn't get clobbered). Both must hold before you proceed.
+
+### 3. Re-trigger CI and poll to green
+
+CI must run against the rebased head. Re-trigger by **force-pushing the rebased branch** — *not* close/reopen (that loses context and can skip path-filtered jobs). This is a destructive op: hand the user the exact command and wait for them to run it.
+
+```
+! git -C <repo> push --force-with-lease origin <branch>
+```
+
+Then poll the **required** checks to green:
+- Treat a job reporting **"skipping" as success** (path filters legitimately skip docs/CI on a code-only PR, and vice-versa).
+- Handle the **post-force-push pending race** — checks briefly read stale/green from the prior head; wait for the new run to register before trusting status. Poll, don't trust the first read.
+- **Never `--admin`.** If a required check is red, stop and surface it — a red gate is signal, not friction.
+
+### 4. Rebase-merge — main advances
+
+With green CI and an evidence-backed rebase, **rebase-merge** (append-only — fast-forwards main, no merge commit rewrite, no force-push to main). Confirm main's new tip. Then move to the next PR/wave — it rebases onto *this* new tip, repeating from step 2.
+
+If a merge ever wedges main, **revert forward** with a new commit. Do not rewind.
+
+### 5. Phase 6 Gate
+
+```
+=== PHASE 6: MERGE — SUMMARY ===
+
+Merged (dependency order): {N}
+  {list: PR # · branch · new main tip}
+Collisions reconciled: {migrations renumbered / unions / dup-infra collapsed}
+Force-pushes routed to user: {count}
+Deferred / blocked (red CI, unmet dep): {list with reason}
+main: append-only — never rewound ✓
+
+Red-team (one line): {sharpest way this wave bites the fleet in three months}
+
+[C] Continue to harvest
+[R] Revise — re-order the queue, re-rebase a PR, or hold one back
+```
+
+**If C:** Load and execute `{nextStepFile}`. Pass forward: merged PRs (with new main tips), any product-source bugs noticed while rebasing/reconciling, and the deferred/blocked list.
+
+**If R:** Ask what to revise (queue order, a specific PR's rebase, a hold), apply it, re-display the summary.

--- a/.claude/skills/upstream-contribute/steps/step-07-harvest.md
+++ b/.claude/skills/upstream-contribute/steps/step-07-harvest.md
@@ -1,0 +1,67 @@
+---
+name: 'step-07-harvest'
+description: 'Close the loop — verify and file product-source bugs as harvest issues, file a tracking issue per deferral, decide on sync-down, and conclude the run as re-runnable.'
+workflow_path: '${CLAUDE_SKILL_DIR}'
+thisStepFile: '{workflow_path}/steps/step-07-harvest.md'
+workflowFile: '{workflow_path}/SKILL.md'
+harvestIssueTemplate: '{workflow_path}/templates/harvest-issue.template.md'
+---
+
+# Phase 07 — Harvest (terminal)
+
+## STEP GOAL
+
+The PRs are merged; the template improved. Now pay the debt the merge created. While porting, you almost certainly tripped over bugs that live in the **product's own source** — and you accumulated deferrals (candidates skipped, generalizations punted, opt-in flags left for later). Both must leave this run as **tracked artifacts on the product**, not as facts that survive only in this transcript. Harvest is part of "done," not a nicety. You walk away with: one harvest issue per real product-source bug, a tracking issue per deferral, an explicit sync-down call, and a completion summary that names this loop as re-runnable.
+
+## Constraints
+
+- **Verify each suspected bug against the product source BEFORE filing.** Many "bugs" you saw while porting are *port artifacts* — the seam shifted, an import got generalized, a placeholder replaced product copy — and do not exist in the product. Open the cited product file, confirm the defect is real there, capture `file:line`. No verification, no issue. This is the same trust-bytes spine as the merge gate, pointed the other way.
+- **Re-apply by hand, never cherry-pick.** The template PR is the *spec*, not a patch source — the divergence between template and product is real. The harvest issue points at the template PR and the product `file:line`; the human applies the fix in the product's idiom on its own schedule.
+- **One harvest issue per wave**, batching that wave's verified bugs — not one per bug, not one for the whole run.
+- **Nothing lives only in memory.** Every deferral gets an issue, even the small ones. A deferral you can't be bothered to file is a deferral you've silently dropped.
+
+## Sequence of Instructions
+
+### 1. Triage suspected product-source bugs
+
+Collect every "this looks wrong in the source too" you flagged during produce/verify/merge. For each, open the **product** file at the cited location and decide: real product defect, or port artifact? Discard the artifacts (note them in the summary so the reader knows they were checked, not missed). Keep the confirmed ones with severity + product `file:line` + the template PR that fixes the same shape upstream.
+
+### 2. File one harvest issue per wave
+
+Using `{harvestIssueTemplate}`, file ONE issue on the **product** repo per wave that produced confirmed bugs. Each lists: severity, product `file:line`, fix-intent, and the template PR as the spec — with an explicit "re-apply by hand, do not cherry-pick" note. Show the drafted body and get a `[C]` before `gh issue create`. Record the issue URLs.
+
+### 3. File a tracking issue per deferral
+
+Walk the plan sidecar's deferral set — skipped candidates, "generalize later," opt-in flags not yet wired, anything the rubric tagged but a wave didn't carry. File a tracking issue (on the product, or the template if the deferral is template-side) for **each**, so the next run of this loop rediscovers them as candidates instead of re-deriving them from scratch. One line of rationale each: why deferred, what unblocks it.
+
+### 4. Decide sync-down
+
+Note that the whole fleet inherits these template changes on its next `upstream-sync` — that's automatic and out of scope here. The only open question is the **source product**: should it run a formal sync-down to pull its own contributions back as canonical template code? Usually **no** — the source is the origin of most of this batch, so a sync-down is redundant churn and risks re-introducing the strip-to-pattern divergence you just resolved. Recommend skip unless the generalization meaningfully reshaped the seam (then the product benefits from adopting the cleaned-up template form). State the call with a one-line rationale; don't run it.
+
+### 5. Phase Gate (final)
+
+```
+=== PHASE 07: HARVEST — SUMMARY ===
+
+Suspected source bugs triaged: {N}  ({k} confirmed, {N-k} port artifacts discarded)
+Harvest issues filed:          {per wave, with URLs}
+Deferrals tracked:             {count, with URLs}
+Sync-down (source product):    {skip | run} — {one-line rationale}
+
+=== UPSTREAM-CONTRIBUTE COMPLETE ===
+
+Waves merged:        {list}  (all byte-verified at the gate)
+Template PRs landed: {count}
+Fleet impact:        propagates to every product on its next upstream-sync
+Loop-back closed:    source bugs + deferrals are now tracked artifacts, not memory
+
+This loop is re-runnable. As the product accrues new contribution candidates,
+start again at step-01 — the plan sidecar and idempotent precheck mean prior
+work is recognized and skipped, not redone.
+
+[C] Continue / [R] Revise
+```
+
+**If C:** The run is complete — there is no next step. Confirm closure and stop; the loop re-enters at `step-01-context-prereqs.md` only when the user re-invokes the skill on fresh candidates.
+
+**If R:** Ask which artifact to revise (a harvest issue body, a missed/over-eager bug call, a deferral, the sync-down decision), apply the change, re-display the summary.

--- a/.claude/skills/upstream-contribute/templates/contribution-plan.template.md
+++ b/.claude/skills/upstream-contribute/templates/contribution-plan.template.md
@@ -1,0 +1,152 @@
+# Upstream Contribution Plan — {PRODUCT} → {TEMPLATE}
+
+<!--
+  PRODUCT-SIDE SIDECAR. Lives in the PRODUCT (e.g. _bmad-output/), never in the template —
+  this is product state, and the template stays a scaffold, not a library.
+  Authored in step-03 (plan); read/advanced through steps 04–07.
+  It is the resume spine: the plan + the engine's idempotent precheck make the loop
+  re-enterable at wave / PR boundaries. Keep the Progress tracker current as the only
+  truth that outlives this transcript.
+-->
+
+- **SOURCE (product):** {SOURCE repo + identity}
+- **TARGET (template):** {TARGET repo + identity}
+- **Dedupe baseline:** template main `{SHA}` + `{k}` open PRs (checked in identify)
+- **Run started:** {date}  ·  **Plan path (PLAN):** {abs path to this file}
+
+---
+
+## 1. Candidates
+
+<!--
+  One row per screened candidate from identify (skips included — visible skips are
+  evidence the audit was honest). Tag is exactly one of drop-in / generalize / opt-in / skip.
+  strip-recipe is REQUIRED for generalize (the exact copy/brand/domain/schema-name/prices to
+  strip + the placeholder that replaces it) and for opt-in (the config/flag gating note).
+  Leverage tier orders fleet payoff: guardrail > infra > drop-in > opt-in; bug-fix jumps the queue.
+-->
+
+| ID | Title | Tag | Tier | Strip-recipe / gating | Source files (`file:line`) |
+|----|-------|-----|------|-----------------------|----------------------------|
+| C1 | {…} | drop-in | {guardrail\|infra\|drop-in\|opt-in} | — | {file:line} |
+| C2 | {…} | generalize | {tier} | strip `{product copy/brand/domain/schema-name}` → `{placeholder}` | {file:line} |
+| C3 | {…} | opt-in | {tier} | ships `{config-gated / flagged}` so forks aren't forced in | {file:line} |
+| C4 | {…} | skip | — | reason: `{product-specific / dormant / already upstream / no leverage}` | {file:line} |
+
+---
+
+## 2. Dependency DAG
+
+<!--
+  An edge A → B means B builds on a seam A introduces, so A must be MERGED TO MAIN before
+  B can be produced. A real cycle is a planning bug — split or merge candidates to break it.
+-->
+
+```
+{C1} → {C3}          # C3 imports the config helper C1 adds
+{C1} → {C2}
+{C5}                 # no deps — free leaf
+```
+
+- Roots (no deps): {…}
+- Leaves (depended on by nothing): {…}
+- Cycles broken: {none | how}
+
+---
+
+## 3. Collision graph (shared hot files)
+
+<!--
+  Two candidates collide when they both touch a file main sees at merge.
+  Classify each shared file — treatment differs. When unsure additive vs overlapping,
+  treat as overlapping (serialize): fail-closed, matching the engine's selector.
+-->
+
+| Shared file | Touched by | Class | Treatment |
+|-------------|-----------|-------|-----------|
+| `migrations/meta/_journal.json` (+ snapshots) | {C2, C6} | SERIALIZING — migration journal | ≤1 bearer/wave; chain the rest across waves |
+| {same table / subsystem seam} | {C1, C3} | SERIALIZING — overlapping infra | dependency-order; never parallel |
+| {schema barrel / `index.ts` / `prod-setup.sql` / locale JSON / `package.json`} | {C4, C5} | ADDITIVE — cheap union | parallel OK; reconcile the union at merge |
+
+---
+
+## 4. Wave schedule
+
+<!--
+  A wave is the unit the engine produces (step 04). Within a wave: parallel. Across waves:
+  sequential — each wave is produced off the UPDATED main (deps + prior migrations merged),
+  so produce sees zero reconciliation. Pack greedily against four gates per candidate:
+    (1) all DAG deps in waves < N, (2) collision-free with the rest of wave N,
+    (3) ≤1 migration-bearer in wave N, (4) within the batch cap (~3–4).
+  Prefer more, smaller waves — big batches dilute the byte-gate and risk an unresumable half-run.
+-->
+
+### Wave 1
+- **Group:** {C1, C5, …}
+- **Parallel:** {which run together, and why they don't collide}
+- **Migration-bearer (≤1):** {C? | none}
+- **Why safe:** {no shared SERIALIZING file; deps are roots}
+
+### Wave 2  *(produced off updated main; deps {…} already merged)*
+- **Group:** {C2, C3, …}
+- **Parallel:** {…}
+- **Migration-bearer (≤1):** {C? | none}
+- **Why safe:** {dep already on main; collision-free within wave}
+
+<!-- add waves until every non-skip candidate is scheduled -->
+
+**Serial migration spine:** {bearers} across {chain-length} waves — the linear `_journal.json` chain. All other PRs hang off it as parallel leaves.
+
+---
+
+## 5. Progress tracker
+
+<!--
+  The single source of truth that outlives this transcript — keep it CURRENT.
+  Status lifecycle: planned → produced (engine opened the PR; UNVERIFIED) →
+  verified (fresh-context byte-gate PASSed, step 05 — the only merge gate) →
+  merged (rebase-merged into template main, step 06).
+  FAIL at verify → back through produce FRESH (never patch the branch); reset that row to planned.
+-->
+
+| ID | Wave | Status | PR# | Verified by | Notes |
+|----|------|--------|-----|-------------|-------|
+| C1 | 1 | planned | — | — | {…} |
+| C5 | 1 | planned | — | — | {…} |
+| C2 | 2 | planned | — | — | {…} |
+| C3 | 2 | planned | — | — | {…} |
+
+Legend: `planned` · `produced` (unverified) · `verified` (byte-gate PASS) · `merged`
+
+---
+
+## 6. Deferrals
+
+<!--
+  Everything tagged skip, plus anything punted: "generalize later," an opt-in flag left
+  unwired, a candidate no wave carried. Nothing lives only in memory — step 07 files a
+  tracking issue for EACH so the next run rediscovers it as a candidate, not from scratch.
+-->
+
+| ID / item | Why deferred | What unblocks it | Tracking issue |
+|-----------|--------------|------------------|----------------|
+| {C4} | {product-specific / dormant / already upstream} | {n/a or condition} | {URL — filed in step 07} |
+| {opt-in flag for C3} | {wired later} | {…} | {URL} |
+
+---
+
+## 7. Harvest issues filed
+
+<!--
+  Source bugs you tripped over while PORTING — confirmed against the PRODUCT source
+  (open the file, prove the defect is real there; discard port artifacts).
+  ONE issue per wave, batching that wave's confirmed bugs. The template PR is the SPEC,
+  not a patch source — re-apply by hand in the product's idiom; never cherry-pick.
+-->
+
+| Wave | Confirmed bug(s) — product `file:line` | Severity | Template PR (spec) | Harvest issue |
+|------|----------------------------------------|----------|--------------------|---------------|
+| 1 | {file:line} | {sev} | {#PR} | {URL} |
+
+- **Port artifacts discarded (checked, not real):** {note them so the reader knows they were verified, not missed}
+- **Sync-down (source product):** {skip | run} — {one-line rationale; default skip — source is the origin of this batch}

--- a/.claude/skills/upstream-contribute/templates/harvest-issue.template.md
+++ b/.claude/skills/upstream-contribute/templates/harvest-issue.template.md
@@ -1,0 +1,24 @@
+**Harvest from wave `{WAVE_ID}` — bugs found while porting code UP to the template.**
+
+These defects surfaced while generalizing this product's code into [`{TEMPLATE_REPO}`]({TEMPLATE_REPO_URL}). Each one was **verified to exist in this product's own source** (cited `file:line` below), not invented by the port — port artifacts were triaged out before filing.
+
+**Re-apply BY HAND. Do not cherry-pick.** The linked template PR is the **spec**, not a patch source. Its code is generalized — stripped to the seam, placeholders swapped for product copy/brand/domain, schema name neutralized. Pulling it verbatim re-introduces the divergence the strip-to-pattern pass just resolved. Read the PR, then fix each one in this product's own idiom, on your own schedule.
+
+---
+
+<!-- repeat this block once per confirmed bug in the wave -->
+### [{SEVERITY}] {SHORT_TITLE}
+
+- **Where:** `{PRODUCT_FILE}:{LINE}`
+- **Problem:** {what's actually wrong here in the product source — the defect, not the symptom}
+- **Fix:** {fix-intent in one or two lines — what the corrected behavior is, not a diff}
+- **Spec:** {TEMPLATE_PR_URL} — the same shape, fixed upstream
+
+<!-- /repeat -->
+
+---
+
+**Source:** wave `{WAVE_ID}` of the `upstream-contribute` loop · template PRs {TEMPLATE_PR_LIST}
+**Verified against:** product `main` @ `{PRODUCT_COMMIT_SHA}` ({YYYY-MM-DD})
+
+This is part of the bidirectional fleet-health loop (contribute-up → harvest-back → sync-down). The harvest pattern continues each time a wave ships — expect a follow-up issue per future wave that trips over product-source bugs.

--- a/.claude/skills/upstream-contribute/test-prompts.md
+++ b/.claude/skills/upstream-contribute/test-prompts.md
@@ -1,0 +1,21 @@
+# Test Prompts — upstream-contribute
+
+Manual iteration aids. Invoke the skill with each and note pass/fail; no automated harness.
+
+## Should handle well
+1. "Contribute this product's reusable improvements back to the template."
+2. "Audit what's worth upstreaming from this product into vt-saas-template."
+3. "Run the next contribution wave" / "produce the oauth-layer group."
+4. "Verify and merge the open contribution PRs."
+5. "We've added a generic rate-limiter and an email helper here — harvest them up to the template."
+
+## Should NOT trigger (out of scope — recognize and redirect)
+1. "Sync the latest template changes **down** into this product." → that's `upstream-sync` (the opposite direction).
+2. "Deploy this product to production." → `/production-deploy`.
+3. "Fix this bug in the product's checkout flow." → normal product dev, not a contribution.
+
+## Smoke checks (when dry-running)
+- Step 01 detects repo identity by remote/marker (not folder name) and **echoes resolved SOURCE/TARGET/PLAN** before anything downstream.
+- The fail-closed selector **errors** (never silently runs "all") when groups don't resolve.
+- The `verify` step spawns a **fresh, produce-blind** subagent and checks **pushed bytes** (`git show` / re-run), not the engine's report.
+- `main` is only ever **rebase-merged**; force-pushes are handed to the user via `!`.

--- a/.claude/skills/upstream-contribute/workflows/port-to-template.js
+++ b/.claude/skills/upstream-contribute/workflows/port-to-template.js
@@ -1,0 +1,306 @@
+export const meta = {
+  name: 'port-to-template',
+  description: 'Produce-only engine: port a product\'s generic improvements UP into its base template as opened, UNVERIFIED PRs (the skill\'s verify step is the gate)',
+  phases: [
+    { title: 'Setup', detail: 'fetch + clean-tree check on the template; report main HEAD' },
+    { title: 'Produce', detail: 'per group: idempotent precheck → prep → implement + local-verify → ship PR (no merge)' },
+    { title: 'Summary', detail: 'list opened PRs as UNVERIFIED; hand off to the skill\'s verify step' },
+  ],
+}
+
+// ── What this engine is (and is NOT) ────────────────────────────────────────
+// This is ONE instrument of the `upstream-contribute` skill: a deterministic,
+// headless produce engine. It opens PRs and STOPS. It NEVER merges, never enables
+// auto-merge, never waits for CI. Its output is ALWAYS UNVERIFIED — the skill's
+// independent byte-verification step is the sole merge gate. The light self-review
+// below is for DRAFT QUALITY only and carries ZERO weight at merge.
+//
+// Never resume a half-finished run: size batches to finish in one run. If a run
+// dies mid-group, re-run that group fresh — the idempotent precheck skips
+// already-merged work and reuses an open PR.
+
+// ── Inputs (args only — cwd-agnostic) ───────────────────────────────────────
+// Required: source, target, repo. The group set comes from `groups` (inline) or
+// is parsed from the PLAN file (`plan`). FAIL-CLOSED: if no group set resolves,
+// THROW — never default to "all".
+//
+// The harness sometimes delivers `args` as a JSON STRING; parse that first.
+function parseArgs(a) {
+  let v = a
+  if (typeof v === 'string') {
+    try { v = JSON.parse(v) } catch { return {} }
+  }
+  return (v && typeof v === 'object') ? v : {}
+}
+const A = parseArgs(args)
+
+const SOURCE = A.source // product repo (read-only)
+const TARGET = A.target // template repo (where work happens)
+const REPO = A.repo // GitHub "owner/name" of the template
+const PLAN = A.plan || '' // optional: product's contribution-plan file with the wave/group list
+
+if (!SOURCE || !TARGET || !REPO) {
+  throw new Error('port-to-template: missing required args. Provide { source, target, repo } (absolute paths + GitHub owner/name). Optionally { plan } and/or { groups }.')
+}
+
+// ── Group selection (FAIL-CLOSED) ───────────────────────────────────────────
+// A group is: { id, branch, title, scope, notes? }. Two sources:
+//  1) inline `args.groups` — an array of group objects, OR an array of {id} to
+//     select FROM the plan, OR a single id string.
+//  2) the PLAN file — the engine asks an agent to parse the product's
+//     contribution-plan and return the wave/group list as structured objects.
+// If neither yields a non-empty, valid set → THROW. Never run "all" by accident.
+
+const GROUP_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  properties: {
+    id: { type: 'string' }, branch: { type: 'string' }, title: { type: 'string' },
+    scope: { type: 'string' }, notes: { type: 'string' },
+  },
+  required: ['id', 'branch', 'title', 'scope'],
+}
+const PLAN_GROUPS_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  properties: { groups: { type: 'array', items: GROUP_SCHEMA } },
+  required: ['groups'],
+}
+
+function inlineGroups(a) {
+  let g = a.groups
+  if (typeof g === 'string') {
+    try { g = JSON.parse(g) } catch { g = [g] }
+  }
+  if (!Array.isArray(g) || !g.length) return { full: null, ids: null }
+  // Fully-specified group objects?
+  if (g.every(x => x && typeof x === 'object' && x.id && x.branch && x.title && x.scope)) {
+    return { full: g, ids: null }
+  }
+  // Otherwise treat as id selectors (strings or {id}).
+  const ids = g.map(x => (typeof x === 'string' ? x : (x && x.id))).filter(Boolean)
+  return { full: null, ids: ids.length ? ids : null }
+}
+
+const inline = inlineGroups(A)
+let GROUPS
+
+if (inline.full) {
+  // Inline, fully-specified groups — use as-is.
+  GROUPS = inline.full
+} else {
+  // Need the plan to source group definitions.
+  if (!PLAN) {
+    throw new Error('port-to-template: no inline group objects given and no `plan` provided. Pass `groups` as full {id,branch,title,scope} objects, OR pass `plan` (+ optional `groups` ids to select from it). Refusing to default to "all".')
+  }
+  const parsed = await agent(
+    `Read the product's contribution plan at ${PLAN}. Extract the wave/group list as structured objects. Each group must have: \`id\` (slug), \`branch\` (e.g. \`contrib/<id>\`), \`title\`, \`scope\` (the full port instruction — what to port, what to strip/parameterize, what to defer), and optional \`notes\`. Preserve the plan's wording for scope/notes; do NOT summarize away the strip/integrate guidance. Return EVERY group in the plan, in plan order.`,
+    { label: 'parse-plan', phase: 'Setup', schema: PLAN_GROUPS_SCHEMA },
+  )
+  const all = (parsed && Array.isArray(parsed.groups)) ? parsed.groups : []
+  if (!all.length) {
+    throw new Error(`port-to-template: parsed 0 groups from plan ${PLAN}. Cannot resolve a group set — refusing to run.`)
+  }
+  GROUPS = inline.ids ? all.filter(g => inline.ids.includes(g.id)) : all
+}
+
+if (!GROUPS || !GROUPS.length) {
+  throw new Error(`port-to-template: group selection resolved to EMPTY (ids: ${JSON.stringify(inline.ids)}). Check args.groups against the plan. Refusing to default to "all".`)
+}
+
+// Echo resolved inputs BEFORE running anything (HARD RULE: log resolved set).
+log(`Resolved SOURCE: ${SOURCE}`)
+log(`Resolved TARGET: ${TARGET}  (repo ${REPO})`)
+log(`Resolved PLAN:   ${PLAN || '(none — inline groups)'}`)
+log(`Resolved groups (${GROUPS.length}): ${GROUPS.map(g => g.id).join(', ')}`)
+
+// ── Shared context for all produce agents ───────────────────────────────────
+const CTX = `You are porting tested code FROM a product (SOURCE) INTO its base template (TARGET).${PLAN ? `\nThe product's contribution plan is at ${PLAN} — read the matching section for strip/integrate guidance.` : ''}
+
+PATHS:
+- SOURCE (read-only): ${SOURCE}  (the product, on its default branch)
+- TARGET (where you work): ${TARGET}  (the base template)
+- GitHub repo: ${REPO}
+
+HARD RULES:
+- Operate on TARGET without disruption: use \`git -C ${TARGET} ...\`, \`npm --prefix ${TARGET} run <script>\`, \`gh ... -R ${REPO}\`, Edit/Write with absolute paths. Avoid bare \`cd\`.
+- The template is a GENERIC, multi-product SaaS starter — NOT this product. STRIP ALL product specifics: branding/copy, product-domain endpoints + integrations, the product's DB schema name, hardcoded product routes, and any product-only features. Strip to the PATTERN, not the instance — contribute the seam + a placeholder/example, never the product's copy, prices, brand, or domain endpoints. The template is a SCAFFOLD, not a library.
+- INTEGRATE, DON'T TRANSPLANT: study how the template already does similar things (read CLAUDE.md, .claude/rules/, neighbouring files) and mirror them; REUSE existing template utilities/types/config instead of duplicating; place files where the template's structure dictates and fix import paths. The result must read as native template code.
+- ADDITIVE + GENERIC: opinionated or heavy subsystems ship OPT-IN (config-gated/flagged) so forks aren't forced into product-shaping choices. Keep changes additive.
+- Match template conventions: TS strict (noUnusedLocals/Parameters, noUncheckedIndexedAccess, noImplicitReturns; prefix unused with _), \`type\` not \`interface\`, kebab-case component files, snake_case DB, the template's server-action result shape, shadcn/ui only, Zod at boundaries. Let lint:fix handle import order.
+- NEVER run \`db:push\`. Regenerate migrations from schema diffs; never hand-merge snapshots.
+- DON'T HALLUCINATE: if you cite a rule/convention, quote it from an ACTUAL file in the repo (confirm the text exists); never invent rules.`
+
+// ── Schemas (kept minimal — a StructuredOutput glitch once made a post-ship ──
+// agent fail to return; prefer no-schema or thin-schema agents) ──────────────
+const PORTSPEC_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  properties: {
+    group: { type: 'string' },
+    portable: { type: 'array', items: { type: 'object', additionalProperties: false, properties: {
+      title: { type: 'string' }, action: { type: 'string', enum: ['add', 'modify'] },
+      targetPath: { type: 'string' }, sourcePath: { type: 'string' },
+      transforms: { type: 'string', description: 'what to strip/rename/parameterize' },
+      integration: { type: 'string', description: 'existing template utilities/types/config to reuse (not duplicate), correct target placement, import fixes' },
+      tests: { type: 'string' }, rationale: { type: 'string' },
+    }, required: ['title', 'action', 'targetPath', 'transforms'] } },
+    newDeps: { type: 'array', items: { type: 'string' } },
+    deferred: { type: 'array', items: { type: 'object', additionalProperties: false, properties: {
+      title: { type: 'string' }, reason: { type: 'string' }, dependsOn: { type: 'string' },
+    }, required: ['title', 'reason'] } },
+    acceptanceCriteria: { type: 'array', items: { type: 'string' } },
+    syncDownRisk: { type: 'string' },
+    prTitle: { type: 'string' }, prBody: { type: 'string' },
+  },
+  required: ['group', 'portable', 'newDeps', 'deferred', 'prTitle', 'prBody'],
+}
+
+const IMPL_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  properties: {
+    branch: { type: 'string' },
+    filesChanged: { type: 'array', items: { type: 'string' } },
+    verify: { type: 'object', additionalProperties: false, properties: {
+      lint: { type: 'string' }, types: { type: 'string' }, test: { type: 'string' }, build: { type: 'string' },
+    }, required: ['lint', 'types', 'test', 'build'] },
+    status: { type: 'string', enum: ['green', 'blocked'] },
+    blockers: { type: 'string' },
+  },
+  required: ['branch', 'status', 'verify'],
+}
+
+const REVIEW_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  properties: {
+    verdict: { type: 'string', enum: ['pass', 'changes-needed', 'block'] },
+    findings: { type: 'array', items: { type: 'object', additionalProperties: false, properties: {
+      severity: { type: 'string', enum: ['critical', 'high', 'medium', 'low'] },
+      file: { type: 'string' }, issue: { type: 'string' }, fix: { type: 'string' },
+    }, required: ['severity', 'issue'] } },
+    summary: { type: 'string' },
+  },
+  required: ['verdict', 'findings', 'summary'],
+}
+
+const SHIP_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  properties: { prUrl: { type: 'string' }, prNumber: { type: 'number' }, notes: { type: 'string' } },
+  required: ['prUrl'],
+}
+
+const PRECHECK_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  properties: { state: { type: 'string', enum: ['merged', 'open', 'none'] }, prNumber: { type: 'number' } },
+  required: ['state'],
+}
+
+// ── Phase: Setup ────────────────────────────────────────────────────────────
+phase('Setup')
+const setup = await agent(
+  `${CTX}\n\nSETUP: 1) \`git -C ${TARGET} fetch origin --prune\`. 2) Confirm the working tree is clean (\`git -C ${TARGET} status --porcelain\`); if dirty, STOP and report what's dirty. 3) Report \`origin/main\` HEAD sha + subject. 4) Confirm \`gh auth status\` can see ${REPO}. Return a short status line. Don't change branches.`,
+  { label: 'setup', phase: 'Setup' },
+)
+log(`Setup: ${String(setup).slice(0, 300)}`)
+
+// ── Phase: Produce (per-group, produce-only, failure-isolated) ──────────────
+const results = []
+
+for (let i = 0; i < GROUPS.length; i++) {
+  const g = GROUPS[i]
+  phase(`G${i + 1}: ${g.title}`)
+  log(`▶ Group ${i + 1}/${GROUPS.length}: ${g.title}`)
+
+  try {
+    // 0) Idempotency — skip merged, reuse an already-open PR.
+    const pre = await agent(
+      `Check existing PRs for head branch "${g.branch}" on ${REPO}: \`gh pr list -R ${REPO} --head ${g.branch} --state all --json number,state,mergedAt\`. If any MERGED → state="merged". Else if any OPEN → state="open" with prNumber. Else "none".`,
+      { label: `precheck:${g.id}`, phase: `G${i + 1}: ${g.title}`, schema: PRECHECK_SCHEMA },
+    )
+    if (pre && pre.state === 'merged') {
+      log(`  ⏭ ${g.id} already merged — skip`)
+      results.push({ group: g.id, skipped: true, prUrl: '(already merged)' })
+      continue
+    }
+    const existingPr = (pre && pre.state === 'open') ? (pre.prNumber || 0) : 0
+
+    // 1) Prep — study target, trace deps, plan native integration.
+    const spec = await agent(
+      `${CTX}\n\n## GROUP: ${g.title}\n${g.scope}\nNotes: ${g.notes || ''}\n\nProduce a concrete PortSpec. (1) STUDY THE TARGET FIRST (CLAUDE.md, .claude/rules/, nearest existing files) so the port integrates idiomatically; identify existing utilities to REUSE. (2) Read each SOURCE file and TRACE ITS IMPORTS — DEFER anything needing a later wave or a subsystem not yet on template main (with a reason). (3)${PLAN ? ` Read the matching plan section (${PLAN}) for strip guidance;` : ''} check \`git -C ${TARGET} ls-files\` to avoid duplicating. For each portable item set BOTH \`transforms\` (strip/rename → generic) and \`integration\` (reuse template utilities, correct placement). List newDeps, deferrals, acceptance criteria, sync-down risk, conventional-commit PR title + body. No code in this step.`,
+      { label: `prep:${g.id}`, phase: `G${i + 1}: ${g.title}`, schema: PORTSPEC_SCHEMA },
+    )
+    if (!spec || !spec.portable || spec.portable.length === 0) {
+      log(`  ${g.id}: nothing portable (all deferred) — skip`)
+      results.push({ group: g.id, skipped: true, deferred: spec ? spec.deferred : [], reason: 'no portable items' })
+      continue
+    }
+
+    // 2) Implement + local verify (iterate to green).
+    let impl = await agent(
+      `${CTX}\n\n## IMPLEMENT GROUP: ${g.title}\nPortSpec:\n${JSON.stringify(spec)}\n\nSteps: (a) \`git -C ${TARGET} fetch origin -q && git -C ${TARGET} checkout -B ${g.branch} origin/main\`. (b) Apply every portable item — create/modify target files, applying BOTH \`transforms\` and \`integration\` so it reads as native template code. (c) If newDeps: add to package.json and \`npm --prefix ${TARGET} install\`. (d) Write/adapt tests in the template's style. (e) Run \`npm --prefix ${TARGET} run lint\`, \`run check-types\`, \`run test\`, \`run build\` — fix and re-run until all pass (lint:fix for import order). If you can't reach green, status=blocked + explain. Do NOT commit/push yet.`,
+      { label: `impl:${g.id}`, phase: `G${i + 1}: ${g.title}`, schema: IMPL_SCHEMA },
+    )
+    if (!impl) throw new Error(`implement agent died for ${g.id}`)
+
+    // 3) LIGHT self-review for DRAFT QUALITY ONLY — NOT a gate. The skill's
+    //    independent byte-verification step is the sole merge gate. One pass,
+    //    no heavy re-review loops that would imply authority.
+    const diffCmd = `git -C ${TARGET} diff origin/main...${g.branch}`
+    const review = await agent(
+      `${CTX}\n\nLIGHT self-review (DRAFT QUALITY ONLY — this is NOT a merge gate; an independent verifier checks the pushed PR later) of the diff (\`${diffCmd}\`) for the "${g.title}" port. Focus on FUNCTIONALITY, CORRECTNESS, and SECURITY hygiene: real bugs / broken logic, broken type/contract changes, missing error handling on important paths, secret/token handling (never logged or returned), missing input validation at boundaries, dev-only endpoints that must be prod-gated, and leftover PRODUCT specifics that break genericness (product endpoints/schema-name/brand/copy in shared code).\nDO NOT flag COSMETIC/STYLE (comment length, JSDoc, naming, import order, commit wording, whitespace) — at most 'low', never critical/high.\nVERIFY BEFORE FLAGGING — only cite a rule if you can quote it from an ACTUAL repo file; cite file:line per finding.`,
+      { label: `self-review:${g.id}`, phase: `G${i + 1}: ${g.title}`, schema: REVIEW_SCHEMA },
+    )
+
+    // 4) Fix only VERIFIED real findings (severity × effort gate). Single pass.
+    const findings = (review && review.findings) || []
+    if (findings.length) {
+      log(`  ${g.id}: ${findings.length} self-review finding(s) — verifying then fixing the real ones`)
+      impl = await agent(
+        `${CTX}\n\n## ADDRESS SELF-REVIEW FINDINGS on branch ${g.branch} for "${g.title}".\nFINDINGS:\n${JSON.stringify(findings)}\n\nFor EACH finding:\n1) VERIFY against the actual code/source — if it cites a rule, confirm that exact text exists. If unfounded (non-existent rule, misread code) → SKIP.\n2) If COSMETIC/style → SKIP.\n3) For VERIFIED real functional/correctness/security findings, apply a SEVERITY × EFFORT gate: critical/high → fix; medium → fix if reasonable, else SKIP and note for human review; low → fix only if cheap, else note.\nThis is DRAFT cleanup, not the gate — don't over-engineer. After fixes, re-run lint/check-types/test/build to green. In \`blockers\`, list what you FIXED and what you SKIPPED-and-why. Return updated impl status.`,
+        { label: `fix:${g.id}`, phase: `G${i + 1}: ${g.title}`, schema: IMPL_SCHEMA },
+      )
+    }
+    if (!impl || impl.status !== 'green') {
+      throw new Error(`STOP (local verify not green): ${impl ? impl.blockers : 'impl agent died'}`)
+    }
+
+    // 5) Ship (PRODUCE-ONLY) — commit + push + open PR, idempotent. No merge,
+    //    no auto-merge, no wait, no main-sync. NO output schema here: a thin/no
+    //    schema avoids the StructuredOutput glitch that once made a post-ship
+    //    agent fail to return AFTER it had already shipped.
+    const ship = await agent(
+      `${CTX}\n\n## OPEN PR for GROUP: ${g.title} (branch ${g.branch}) — PRODUCE-ONLY: do NOT merge, do NOT enable auto-merge, do NOT wait for CI.\nSteps: (a) Commit with a conventional-commit message. (b) \`git -C ${TARGET} push -u origin ${g.branch}\`. (c) IDEMPOTENT — check \`gh pr list -R ${REPO} --head ${g.branch} --state open --json number -q '.[0].number'\` (known open PR is #${existingPr} when >0); if one exists, REUSE it (your push updates it) — do NOT open a second. Otherwise \`gh pr create -R ${REPO} --base main --head ${g.branch} --title "${spec.prTitle.replace(/"/g, "'")}" --body <body>\` using:\n---\n${spec.prBody}\n---\nReturn ONLY the PR URL on the last line as \`PR: <url>\`. Then STOP.`,
+      { label: `ship:${g.id}`, phase: `G${i + 1}: ${g.title}` },
+    )
+    const prUrl = (String(ship).match(/https?:\/\/\S*\/pull\/\d+/) || [])[0] || ''
+    if (!prUrl) {
+      throw new Error(`STOP (PR url not found in ship output): ${String(ship).slice(0, 300)}`)
+    }
+
+    log(`  📬 ${g.id} PR opened (UNVERIFIED): ${prUrl}`)
+    results.push({
+      group: g.id, opened: true, prUrl, verified: false,
+      deferred: spec.deferred, selfReview: review && review.verdict,
+      skippedFindings: impl.blockers || '',
+    })
+    // No merge / no main-sync: each group branches off the same origin/main; any
+    // package.json overlap is reconciled at the skill's supervised merge step.
+  } catch (err) {
+    // Per-group failure isolation: one blocked group does NOT halt the wave.
+    // Each group branches off origin/main independently, so a failure is local.
+    const msg = String(err && err.message ? err.message : err)
+    results.push({ group: g.id, opened: false, stopped: msg })
+    log(`  ⚠️ ${g.id} blocked: ${msg} — continuing to next group`)
+  }
+}
+
+// ── Phase: Summary ──────────────────────────────────────────────────────────
+phase('Summary')
+const opened = results.filter(r => r.opened)
+return {
+  engine: 'port-to-template',
+  unverified: true,
+  ran: GROUPS.map(g => g.id),
+  opened: opened.map(r => ({ group: r.group, prUrl: r.prUrl, verified: false, selfReview: r.selfReview })),
+  skipped: results.filter(r => r.skipped).map(r => r.group),
+  blocked: results.filter(r => r.opened === false && r.stopped).map(r => ({ group: r.group, error: r.stopped })),
+  results,
+  reminder: `${opened.length} PR(s) OPENED and UNVERIFIED — engine output carries ZERO merge weight. Hand off to the skill's VERIFY step: a fresh-context subagent (no access to this run's reports) byte-verifies each pushed PR (\`git show\`, re-run the exploit/test, cite file:line) BEFORE any merge. Merge is human-gated, dependency-ordered, append-only (rebase only; force-push → user). After the wave merges, file a per-wave HARVEST issue on the product for source bugs found while porting (re-apply by hand, never cherry-pick) + a tracking issue per deferral. Never resume a half-finished run — re-run a blocked group fresh.`,
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -421,6 +421,13 @@ Two first-party Claude Code skills live under `.claude/skills/` for go-live work
 
 These compose with the read-only `/launch-checklist` audit: **audit (launch-checklist) → execute (production-deploy) → verify (qa)** — sequential and complementary, not duplicative.
 
+## Contributing back to the template
+
+**This template is the source of truth for shared/infra code.** When a product accumulates a generic, reusable improvement, contribute it **up** here — it then reaches every product (and every future fork) via `upstream-sync`. Never keep divergent copies of shared code.
+
+- **`/upstream-contribute`** — the repeatable harvest loop: Identify → Plan → Produce → Verify → Merge → Harvest. A produce-only fan-out (`workflows/port-to-template.js`) opens dependency-ordered PRs; the merge is human-supervised and gated on **independent byte-level verification** — trust the pushed bytes, never an agent's "I fixed it" report. It auto-detects whether you're in the template or a product and nudges; re-run it whenever a product accrues new candidates.
+- **What to contribute:** does it make the *next* product faster to build, or improve the *whole fleet*? If not, leave it in the product. Strip to the pattern, not the instance — keep the template a scaffold, not a library.
+
 ## Research
 
 - During planning, use targeted web search early to find proven approaches; prefer established libraries/repos over building from scratch.


### PR DESCRIPTION
Adds **`/upstream-contribute`** — a reusable skill that institutionalizes the product→template contribution loop we ran across four waves, so the *next* product builds faster and the *whole fleet* improves together. The template is the source of truth; this flows to every fork on the next `upstream-sync`.

## What it is
A guided, human-supervised loop: **Identify → Plan → Produce → Verify → Merge → Harvest**, with two orchestration primitives kept deliberately separate:
- **Step files** (the conductor) — the human-gated lifecycle.
- **`workflows/port-to-template.js`** (one instrument) — a deterministic, produce-only `Workflow` engine the Produce step fans out; its output is treated as **unverified**.

## The hard-won guardrails, baked in
- **Trust bytes, not reports** — the only merge gate is an independent, *produce-blind* fresh subagent that checks the **pushed bytes** (`git show` + re-run the exploit/test). The engine's "I fixed it" carries zero weight. (`checklists/merge-gate.md`, `steps/step-05-verify.md`)
- **Never resume a half-finished produce run**; **fail-closed selector** (no silent "run all"); small batches.
- **`main` is append-only**; force-push/hard-reset routed to the user; poll checks, never `--admin`.
- **Wave scheduling** from a DAG + collision graph — parallel within a wave, serial only where the migration chain / dependencies force it (`references/collision-recipes.md`).
- **Contribution criteria** — *does it make the next product faster, or improve the whole fleet?* Strip to the pattern, not the instance; template = scaffold, not library.
- **Definition of done** includes the harvest issue (re-apply by hand) + a tracking issue per deferral.

## Notes
- Project-local skill (not a plugin); distributed via `upstream-sync`. `CLAUDE.md` gains a "Contributing back to the template" source-of-truth pointer.
- The generic engine **supersedes** any product-local `port-to-template.js` divergent copy.
- Auto-detects template-vs-product cwd (`scripts/detect-context.sh`) via remote/`package.json`/`.template-cleanup` — never folder name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
