### PR TITLE
feat: Round A infra tier — pool/sentry/site-config + CI trim

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,7 +8,11 @@ name: Claude Code Review
 # the orphaned final result.
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+    # `synchronize` intentionally omitted: reviewing on every push to a PR ran a
+    # full agent review per push — the largest slice of this workflow's minutes.
+    # We review on open / ready-for-review / reopen instead. Re-review on demand
+    # by commenting `@claude review` on the PR (handled by claude.yml).
+    types: [opened, ready_for_review, reopened]
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"
@@ -16,6 +20,13 @@ on:
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
   workflow_dispatch:
+
+# Cancel an in-flight review if the PR is reopened / re-readied again quickly.
+# With `synchronize` removed above, reviews fire ~once per PR, so this mainly
+# guards rapid reopen/ready-toggling — cheap insurance, not a big lever.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   claude-review:
@@ -55,7 +66,7 @@ jobs:
           # checks with the code under review).
           additional_permissions: |
             actions: read
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
           plugins: code-review@claude-code-plugins
           # `--comment` posts line-level findings live during the session. The
           # plugin's final *summary* rides the session's last result, which the
@@ -63,7 +74,7 @@ jobs:
           # call — so a clean diff can post NOTHING (upstream, still open:
           # anthropics/claude-code-action#1087 / #1054). The "Ensure review is
           # never silent" step below backstops that so a result always appears.
-          prompt: '/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: "/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -66,7 +66,7 @@ jobs:
           # checks with the code under review).
           additional_permissions: |
             actions: read
-          plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: code-review@claude-code-plugins
           # `--comment` posts line-level findings live during the session. The
           # plugin's final *summary* rides the session's last result, which the
@@ -74,7 +74,7 @@ jobs:
           # call — so a clean diff can post NOTHING (upstream, still open:
           # anthropics/claude-code-action#1087 / #1054). The "Ensure review is
           # never silent" step below backstops that so a result always appears.
-          prompt: "/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
+          prompt: '/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -12,7 +12,7 @@ Sentry.init({
   spotlight: process.env.NODE_ENV === 'development',
 
   // Adjust this value in production, or use tracesSampler for greater control
-  tracesSampleRate: 1,
+  tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 1,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,

--- a/src/components/analytics/UserIdentifier.tsx
+++ b/src/components/analytics/UserIdentifier.tsx
@@ -5,6 +5,7 @@
 
 'use client';
 
+import * as Sentry from '@sentry/nextjs';
 import { useEffect } from 'react';
 
 import { identifyUser, resetUser } from '@/libs/analytics';
@@ -21,6 +22,7 @@ export function UserIdentifier() {
           email: user.email,
           createdAt: new Date(user.created_at),
         });
+        Sentry.setUser({ id: user.id });
       }
     });
 
@@ -33,8 +35,10 @@ export function UserIdentifier() {
           email: session.user.email,
           createdAt: new Date(session.user.created_at),
         });
+        Sentry.setUser({ id: session.user.id });
       } else if (event === 'SIGNED_OUT') {
         resetUser();
+        Sentry.setUser(null);
       }
     });
 

--- a/src/components/analytics/__tests__/UserIdentifier.test.tsx
+++ b/src/components/analytics/__tests__/UserIdentifier.test.tsx
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/nextjs';
 import { render, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -8,6 +9,9 @@ import { UserIdentifier } from '../UserIdentifier';
 
 vi.mock('@/libs/analytics');
 vi.mock('@/libs/supabase/client');
+vi.mock('@sentry/nextjs', () => ({
+  setUser: vi.fn(),
+}));
 
 describe('UserIdentifier', () => {
   const mockUser = {
@@ -25,7 +29,9 @@ describe('UserIdentifier', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.spyOn(supabaseClient, 'createClient').mockReturnValue(mockSupabase as any);
+    vi.spyOn(supabaseClient, 'createClient').mockReturnValue(
+      mockSupabase as any,
+    );
   });
 
   it('identifies user when user exists on mount', async () => {
@@ -48,6 +54,8 @@ describe('UserIdentifier', () => {
         createdAt: new Date(mockUser.created_at),
       });
     });
+
+    expect(Sentry.setUser).toHaveBeenCalledWith({ id: mockUser.id });
   });
 
   it('does not identify when no user exists', async () => {
@@ -98,6 +106,8 @@ describe('UserIdentifier', () => {
         createdAt: new Date(mockUser.created_at),
       });
     });
+
+    expect(Sentry.setUser).toHaveBeenCalledWith({ id: mockUser.id });
   });
 
   it('resets user on SIGNED_OUT event', async () => {
@@ -124,6 +134,8 @@ describe('UserIdentifier', () => {
     await waitFor(() => {
       expect(resetSpy).toHaveBeenCalled();
     });
+
+    expect(Sentry.setUser).toHaveBeenCalledWith(null);
   });
 
   it('unsubscribes from auth changes on unmount', () => {

--- a/src/config/site-config.ts
+++ b/src/config/site-config.ts
@@ -1,0 +1,52 @@
+/**
+ * Site Config — single source of truth for brand + legal placeholders.
+ *
+ * Forks: edit ONLY this file to rebrand. Scattered constants
+ * (`src/utils/AppConfig.ts`, `src/libs/seo/constants.ts`) derive their brand
+ * values from here, so the product name lives in exactly one place.
+ *
+ * Values below are NEUTRAL placeholders that preserve the template's default
+ * branding — replace them with your product's real details after forking.
+ */
+
+export type SiteConfig = {
+  brand: {
+    name: string;
+    tagline: string;
+    logo: {
+      nav: string;
+      og: string;
+    };
+    /** Social handles/URLs keyed by platform, e.g. `{ x: 'https://x.com/...' }`. */
+    social: Record<string, string>;
+    supportEmail: string;
+  };
+  /** Placeholders for the future /terms + /privacy scaffold. */
+  legal: {
+    companyLegalName: string;
+    governingLaw: string;
+    effectiveDate: string;
+    supportEmail: string;
+  };
+};
+
+const brand = {
+  name: 'VT SaaS Template',
+  tagline: 'Build your SaaS faster',
+  logo: {
+    nav: '/logo.png',
+    og: '/logo-og.png',
+  },
+  social: {},
+  supportEmail: 'hello@example.com',
+} as const satisfies SiteConfig['brand'];
+
+export const SITE_CONFIG = {
+  brand,
+  legal: {
+    companyLegalName: 'Your Company, Inc.',
+    governingLaw: 'State of Delaware, USA',
+    effectiveDate: '2025-01-01',
+    supportEmail: brand.supportEmail,
+  },
+} as const satisfies SiteConfig;

--- a/src/libs/DB.ts
+++ b/src/libs/DB.ts
@@ -29,9 +29,15 @@ const globalForDb = globalThis as unknown as {
 if (process.env.NEXT_PHASE !== PHASE_PRODUCTION_BUILD && Env.DATABASE_URL) {
   // Check both pool AND drizzle instance exist (drizzle could be undefined if previous init failed)
   if (!globalForDb.pgPool || !globalForDb.pgDrizzle) {
+    // Per-Node-instance pool. Supabase Session Pooler / pgBouncer multiplexes
+    // across instances upstream, so this max is the local ceiling. Production
+    // gets a bit more headroom for bursty server-action traffic; dev / preview
+    // stays modest to avoid exhausting local Postgres on rapid hot-reloads.
     globalForDb.pgPool = new Pool({
       connectionString: Env.DATABASE_URL,
-      max: 1, // Limit to single connection for serverless/dev environments
+      max: process.env.NODE_ENV === 'production' ? 10 : 5,
+      idleTimeoutMillis: 10_000,
+      connectionTimeoutMillis: 5_000,
     });
 
     globalForDb.pgDrizzle = drizzlePg(globalForDb.pgPool, { schema });
@@ -47,7 +53,9 @@ if (process.env.NEXT_PHASE !== PHASE_PRODUCTION_BUILD && Env.DATABASE_URL) {
     globalForDb.pgliteClient = new PGlite();
     await globalForDb.pgliteClient.waitReady;
 
-    globalForDb.pgliteDrizzle = drizzlePglite(globalForDb.pgliteClient, { schema });
+    globalForDb.pgliteDrizzle = drizzlePglite(globalForDb.pgliteClient, {
+      schema,
+    });
     await migratePglite(globalForDb.pgliteDrizzle, {
       migrationsFolder: path.join(process.cwd(), 'migrations'),
     });

--- a/src/libs/seo/constants.ts
+++ b/src/libs/seo/constants.ts
@@ -5,7 +5,9 @@
  * Centralized for consistency across the application.
  */
 
-export const SITE_NAME = 'VT SaaS Template';
+import { SITE_CONFIG } from '@/config/site-config';
+
+export const SITE_NAME = SITE_CONFIG.brand.name;
 
 export const DEFAULT_OG_IMAGE = '/og-image.png';
 

--- a/src/utils/AppConfig.ts
+++ b/src/utils/AppConfig.ts
@@ -1,9 +1,11 @@
 import type { LocalePrefixMode } from 'next-intl/routing';
 
+import { SITE_CONFIG } from '@/config/site-config';
+
 const localePrefix: LocalePrefixMode = 'as-needed';
 
 export const AppConfig = {
-  name: 'VT SaaS Template',
+  name: SITE_CONFIG.brand.name,
   locales: [
     {
       id: 'en',


### PR DESCRIPTION
## Round A · Infra tier — ContentFlow → template upstream contribution

5 generic infra improvements harvested from ContentFlow back into the template.

| Change | Why |
|--------|-----|
| `perf(db)` — pg Pool: `max` prod 10 / dev 5 + idle/connection timeouts | Template's `max: 1` serialized all server-action DB traffic. PGlite + in-process migrate preserved. |
| `perf(sentry)` — `tracesSampleRate` prod 0.1 / dev 1 | Was hardcoded `1` → 100% trace sampling burns Sentry quota fleet-wide. |
| `feat(observability)` — `Sentry.setUser` on sign-in/out in `UserIdentifier` | Prod errors were anonymous/un-triageable. Alongside existing PostHog identify/reset; guarded so id is never stale. |
| `ci(review)` — drop `synchronize` trigger + add concurrency on `claude-code-review.yml` | Full agent review ran on every push — the biggest minute slice. Permissions preserved. |
| `feat(config)` — `src/config/site-config.ts` as single brand source of truth (#303) | Consolidates scattered brand constants; `SITE_NAME`/`AppConfig.name` now derive from it (additive, byte-identical). Includes legal placeholders for the upcoming /terms + /privacy scaffold. **Forks rebrand by editing one file.** |

### Verification
- **Independent byte-gate** (fresh, produce-blind): 5/5 PASS (`site-config` re-verified — check-types clean + brand tests pass, refactor is additive with no circular import).
- **`/code-review`** (high): **no findings** — all 5 correct and behavior-preserving.
- CI locally green: check-types, lint (0 errors), 1485 unit tests, production build.

No new required env vars. Refs: #303 (site-config design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
