### PR TITLE
feat: Round A drop-in tier — ui/hooks primitives + lib helpers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,8 @@
         "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-toast": "^1.2.15",
+        "@radix-ui/react-toggle": "^1.1.10",
+        "@radix-ui/react-toggle-group": "^1.1.11",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@react-email/components": "^1.0.12",
         "@react-email/render": "^2.0.6",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-toast": "^1.2.15",
+    "@radix-ui/react-toggle": "^1.1.10",
+    "@radix-ui/react-toggle-group": "^1.1.11",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@react-email/components": "^1.0.12",
     "@react-email/render": "^2.0.6",

--- a/src/app/[locale]/(unauth)/(center)/verify-email/page.tsx
+++ b/src/app/[locale]/(unauth)/(center)/verify-email/page.tsx
@@ -8,36 +8,13 @@ import { useEffect, useState } from 'react';
 
 import { useToast } from '@/hooks/use-toast';
 import { createClient } from '@/libs/supabase/client';
+import {
+  COOLDOWN_DURATION,
+  getRemainingCooldown,
+  setCooldownExpiry,
+} from '@/libs/utils/auth-cooldown';
 
-const COOLDOWN_DURATION = 60; // 60 seconds
-
-function getCooldownKey(email: string): string {
-  return `email_resend_cooldown_${email}`;
-}
-
-function getCooldownExpiry(email: string): number | null {
-  if (typeof window === 'undefined') {
-    return null;
-  }
-  const stored = localStorage.getItem(getCooldownKey(email));
-  return stored ? Number.parseInt(stored, 10) : null;
-}
-
-function setCooldownExpiry(email: string, expiry: number): void {
-  if (typeof window === 'undefined') {
-    return;
-  }
-  localStorage.setItem(getCooldownKey(email), expiry.toString());
-}
-
-function getRemainingCooldown(email: string): number {
-  const expiry = getCooldownExpiry(email);
-  if (!expiry) {
-    return 0;
-  }
-  const remaining = Math.ceil((expiry - Date.now()) / 1000);
-  return remaining > 0 ? remaining : 0;
-}
+const COOLDOWN_PREFIX = 'email_resend_cooldown';
 
 type ResendStatus = 'idle' | 'loading' | 'success' | 'cooldown';
 
@@ -59,7 +36,7 @@ export default function VerifyEmailPage() {
     const emailParam = searchParams.get('email');
     if (emailParam) {
       setEmail(emailParam);
-      const remaining = getRemainingCooldown(emailParam);
+      const remaining = getRemainingCooldown(COOLDOWN_PREFIX, emailParam);
       if (remaining > 0) {
         setCooldownSeconds(remaining);
         setResendStatus('cooldown');
@@ -71,7 +48,7 @@ export default function VerifyEmailPage() {
       supabase.auth.getUser().then(({ data: { user } }) => {
         if (user?.email) {
           setEmail(user.email);
-          const remaining = getRemainingCooldown(user.email);
+          const remaining = getRemainingCooldown(COOLDOWN_PREFIX, user.email);
           if (remaining > 0) {
             setCooldownSeconds(remaining);
             setResendStatus('cooldown');
@@ -91,7 +68,7 @@ export default function VerifyEmailPage() {
   useEffect(() => {
     if (resendStatus === 'cooldown' && cooldownSeconds > 0) {
       const interval = setInterval(() => {
-        const remaining = getRemainingCooldown(email);
+        const remaining = getRemainingCooldown(COOLDOWN_PREFIX, email);
         setCooldownSeconds(remaining);
         if (remaining <= 0) {
           setResendStatus('idle');
@@ -139,7 +116,7 @@ export default function VerifyEmailPage() {
       // After 2 seconds, switch to cooldown
       setTimeout(() => {
         const expiryTime = Date.now() + COOLDOWN_DURATION * 1000;
-        setCooldownExpiry(email, expiryTime);
+        setCooldownExpiry(COOLDOWN_PREFIX, email, expiryTime);
         setCooldownSeconds(COOLDOWN_DURATION);
         setResendStatus('cooldown');
       }, 2000);

--- a/src/app/[locale]/(unauth)/blog/[category]/[slug]/loading.tsx
+++ b/src/app/[locale]/(unauth)/blog/[category]/[slug]/loading.tsx
@@ -1,0 +1,52 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function BlogArticleLoading() {
+  return (
+    <main className="container mx-auto max-w-3xl px-4 pb-20 pt-28 sm:pt-32">
+      {/* Back link */}
+      <Skeleton className="mb-6 h-5 w-32" />
+
+      {/* Article header */}
+      <header className="mb-10 space-y-4">
+        <Skeleton className="h-10 w-full max-w-xl" />
+        <Skeleton className="h-10 w-3/4" />
+        <div className="flex items-center gap-3 pt-2">
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-4 w-20" />
+        </div>
+      </header>
+
+      {/* Article body — paragraphs */}
+      <div className="space-y-6">
+        {Array.from({ length: 6 }).map((_, paraIdx) => (
+          // eslint-disable-next-line react/no-array-index-key -- static placeholder list; index is a stable key
+          <div key={paraIdx} className="space-y-2">
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-[95%]" />
+            <Skeleton className="h-4 w-[92%]" />
+            <Skeleton className="h-4 w-[88%]" />
+            <Skeleton className="h-4 w-[78%]" />
+          </div>
+        ))}
+      </div>
+
+      {/* Related posts */}
+      <section className="mt-16 space-y-6">
+        <Skeleton className="h-6 w-40" />
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div
+              // eslint-disable-next-line react/no-array-index-key -- static placeholder list; index is a stable key
+              key={i}
+              className="space-y-3 rounded-lg border border-border p-6"
+            >
+              <Skeleton className="h-5 w-3/4" />
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-5/6" />
+            </div>
+          ))}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/[locale]/(unauth)/blog/[category]/loading.tsx
+++ b/src/app/[locale]/(unauth)/blog/[category]/loading.tsx
@@ -1,0 +1,36 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function BlogCategoryLoading() {
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="container mx-auto max-w-5xl px-4 py-12">
+        {/* Breadcrumb */}
+        <Skeleton className="mb-4 h-5 w-40" />
+
+        {/* Category header */}
+        <header className="mb-8 max-w-2xl space-y-3">
+          <Skeleton className="h-10 w-64" />
+          <Skeleton className="h-6 w-full max-w-md" />
+        </header>
+
+        {/* Article grid */}
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div
+              // eslint-disable-next-line react/no-array-index-key -- static placeholder list; index is a stable key
+              key={i}
+              className="space-y-3 rounded-lg border border-border p-6"
+            >
+              <Skeleton className="h-5 w-3/4" />
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-5/6" />
+              <div className="mt-4">
+                <Skeleton className="h-4 w-24" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/[locale]/(unauth)/blog/[category]/page.tsx
+++ b/src/app/[locale]/(unauth)/blog/[category]/page.tsx
@@ -7,7 +7,7 @@ import {
   getCategoryBySlug,
   getPagesByCategory,
 } from '@/libs/pseo/data';
-import { getBaseUrl } from '@/utils/Helpers';
+import { getBaseUrl, getI18nPath } from '@/utils/Helpers';
 
 type CategoryPageProps = {
   params: Promise<{
@@ -20,7 +20,9 @@ export async function generateStaticParams() {
   return getAllCategoryParams();
 }
 
-export async function generateMetadata(props: CategoryPageProps): Promise<Metadata> {
+export async function generateMetadata(
+  props: CategoryPageProps,
+): Promise<Metadata> {
   const { locale, category: categorySlug } = await props.params;
   const category = await getCategoryBySlug(categorySlug);
 
@@ -34,7 +36,7 @@ export async function generateMetadata(props: CategoryPageProps): Promise<Metada
     title: category.name,
     description: category.description,
     alternates: {
-      canonical: `${baseUrl}/${locale}/blog/${categorySlug}`,
+      canonical: `${baseUrl}${getI18nPath(`/blog/${categorySlug}`, locale)}`,
     },
   };
 }
@@ -64,8 +66,12 @@ export default async function CategoryPage(props: CategoryPageProps) {
             <span className="mx-2">/</span>
             <span className="text-foreground">{category.name}</span>
           </nav>
-          <h1 className="mb-3 text-4xl font-bold text-foreground">{category.name}</h1>
-          <p className="text-lg text-muted-foreground">{category.description}</p>
+          <h1 className="mb-3 text-4xl font-bold text-foreground">
+            {category.name}
+          </h1>
+          <p className="text-lg text-muted-foreground">
+            {category.description}
+          </p>
         </header>
 
         <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
@@ -92,7 +98,9 @@ export default async function CategoryPage(props: CategoryPageProps) {
 
         {pages.length === 0 && (
           <div className="py-16 text-center">
-            <p className="text-muted-foreground">No posts in this category yet.</p>
+            <p className="text-muted-foreground">
+              No posts in this category yet.
+            </p>
           </div>
         )}
       </div>

--- a/src/app/[locale]/(unauth)/blog/loading.tsx
+++ b/src/app/[locale]/(unauth)/blog/loading.tsx
@@ -1,0 +1,50 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function BlogIndexLoading() {
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="container mx-auto max-w-5xl px-4 py-12">
+        {/* Breadcrumb */}
+        <Skeleton className="mb-6 h-5 w-24" />
+
+        {/* Page header */}
+        <header className="mb-12 max-w-2xl space-y-3">
+          <Skeleton className="h-10 w-32" />
+          <Skeleton className="h-6 w-full max-w-lg" />
+        </header>
+
+        {/* Category sections */}
+        <div className="space-y-16">
+          {Array.from({ length: 2 }).map((_, sectionIdx) => (
+            // eslint-disable-next-line react/no-array-index-key -- static placeholder list; index is a stable key
+            <section key={sectionIdx}>
+              <div className="mb-6 flex items-baseline justify-between">
+                <div className="max-w-2xl space-y-2">
+                  <Skeleton className="h-8 w-48" />
+                  <Skeleton className="h-5 w-80" />
+                </div>
+                <Skeleton className="h-5 w-20" />
+              </div>
+              <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <div
+                    // eslint-disable-next-line react/no-array-index-key -- static placeholder list; index is a stable key
+                    key={i}
+                    className="space-y-3 rounded-lg border border-border p-6"
+                  >
+                    <Skeleton className="h-5 w-3/4" />
+                    <Skeleton className="h-4 w-full" />
+                    <Skeleton className="h-4 w-5/6" />
+                    <div className="mt-4">
+                      <Skeleton className="h-4 w-24" />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/[locale]/(unauth)/blog/page.test.ts
+++ b/src/app/[locale]/(unauth)/blog/page.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { generateMetadata } from './page';
+
+vi.mock('@/libs/pseo/data', () => ({
+  loadCategories: vi.fn(async () => []),
+  getPagesByCategory: vi.fn(async () => []),
+}));
+
+describe('blog index canonical', () => {
+  const originalAppUrl = process.env.NEXT_PUBLIC_APP_URL;
+
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_APP_URL = 'https://example.com';
+  });
+
+  afterEach(() => {
+    process.env.NEXT_PUBLIC_APP_URL = originalAppUrl;
+  });
+
+  it('omits the locale segment for the default locale (matches sitemap)', async () => {
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ locale: 'en' }),
+    });
+
+    expect(metadata.alternates?.canonical).toBe('https://example.com/blog');
+  });
+
+  it('prefixes the locale segment for a non-default locale', async () => {
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ locale: 'hi' }),
+    });
+
+    expect(metadata.alternates?.canonical).toBe('https://example.com/hi/blog');
+  });
+});

--- a/src/app/[locale]/(unauth)/blog/page.tsx
+++ b/src/app/[locale]/(unauth)/blog/page.tsx
@@ -2,13 +2,15 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 
 import { getPagesByCategory, loadCategories } from '@/libs/pseo/data';
-import { getBaseUrl } from '@/utils/Helpers';
+import { getBaseUrl, getI18nPath } from '@/utils/Helpers';
 
 type BlogPageProps = {
   params: Promise<{ locale: string }>;
 };
 
-export async function generateMetadata(props: BlogPageProps): Promise<Metadata> {
+export async function generateMetadata(
+  props: BlogPageProps,
+): Promise<Metadata> {
   const { locale } = await props.params;
   const baseUrl = getBaseUrl();
 
@@ -16,7 +18,7 @@ export async function generateMetadata(props: BlogPageProps): Promise<Metadata> 
     title: 'Blog',
     description: 'Browse our collection of posts across various topics.',
     alternates: {
-      canonical: `${baseUrl}/${locale}/blog`,
+      canonical: `${baseUrl}${getI18nPath('/blog', locale)}`,
     },
   };
 }
@@ -55,8 +57,12 @@ export default async function BlogIndexPage(props: BlogPageProps) {
             <section key={category.id}>
               <div className="mb-6 flex items-baseline justify-between">
                 <div>
-                  <h2 className="text-2xl font-bold text-foreground">{category.name}</h2>
-                  <p className="mt-1 text-muted-foreground">{category.description}</p>
+                  <h2 className="text-2xl font-bold text-foreground">
+                    {category.name}
+                  </h2>
+                  <p className="mt-1 text-muted-foreground">
+                    {category.description}
+                  </p>
                 </div>
                 <Link
                   href={`/${locale}/blog/${category.slug}`}

--- a/src/app/api/inngest/route.ts
+++ b/src/app/api/inngest/route.ts
@@ -6,6 +6,7 @@ import {
   processSingleTask,
   scheduledTasksCron,
 } from '@/libs/inngest/functions/scheduled-tasks';
+import { tokenRefreshFunction } from '@/libs/inngest/functions/token-refresh';
 import { trialPromotionExpiryWarningsFunction } from '@/libs/inngest/functions/trial-promotion-expiry-warnings';
 
 // Register functions in production (real cloud env) and local dev (Inngest Dev
@@ -28,6 +29,7 @@ export const { GET, POST, PUT } = serve({
         processSingleTask,
         forceExpireTrialsAndPromotionsFunction,
         trialPromotionExpiryWarningsFunction,
+        tokenRefreshFunction,
       ]
     : [],
 });

--- a/src/components/layout/page-header.tsx
+++ b/src/components/layout/page-header.tsx
@@ -1,0 +1,36 @@
+import type { LucideIcon } from 'lucide-react';
+import type { ReactNode } from 'react';
+
+import { cn } from '@/utils/Helpers';
+
+type PageHeaderProps = {
+  icon: LucideIcon;
+  title: string;
+  description: ReactNode;
+  /** Optional right-aligned action (e.g., a button) */
+  action?: ReactNode;
+  /** Extra classes for the icon (e.g., rotation) */
+  iconClassName?: string;
+  /** Optional content below the title row (e.g., status badges) */
+  children?: ReactNode;
+};
+
+export function PageHeader({ icon: Icon, title, description, action, iconClassName, children }: PageHeaderProps) {
+  return (
+    <header className="flex flex-col gap-2 py-2">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+        <div className="flex items-center gap-3">
+          <div className="flex size-10 items-center justify-center rounded-xl bg-primary/10">
+            <Icon className={cn('size-5 text-primary', iconClassName)} />
+          </div>
+          <div>
+            <h1 className="text-2xl font-semibold tracking-tight text-foreground">{title}</h1>
+            <p className="text-sm text-muted-foreground">{description}</p>
+          </div>
+        </div>
+        {action && <div className="flex justify-center sm:block sm:shrink-0">{action}</div>}
+      </div>
+      {children}
+    </header>
+  );
+}

--- a/src/components/legal/legal-toc.tsx
+++ b/src/components/legal/legal-toc.tsx
@@ -1,0 +1,52 @@
+import { cn } from '@/utils/Helpers';
+
+type LegalSection = {
+  id: string;
+  label: string;
+};
+
+type LegalTableOfContentsProps = {
+  sections: LegalSection[];
+  className?: string;
+  title?: string;
+};
+
+/**
+ * "On this page" anchor navigation for legal pages (privacy, terms).
+ * Server component — plain anchor links, no client JS. Wrapped in `not-prose`
+ * so it renders consistently even when placed alongside Tailwind `prose` content.
+ */
+export function LegalTableOfContents({
+  sections,
+  className,
+  title = 'On this page',
+}: LegalTableOfContentsProps) {
+  return (
+    <nav
+      aria-label={title}
+      className={cn(
+        'not-prose rounded-xl border border-border bg-muted/30 p-5 sm:p-6',
+        className,
+      )}
+    >
+      <p className="mb-4 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        {title}
+      </p>
+      <ol className="grid gap-x-6 gap-y-2.5 sm:grid-cols-2">
+        {sections.map((section, index) => (
+          <li key={section.id}>
+            <a
+              href={`#${section.id}`}
+              className="group flex items-baseline gap-2.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+            >
+              <span className="w-4 shrink-0 text-right text-xs tabular-nums text-muted-foreground/60 transition-colors group-hover:text-foreground/70">
+                {index + 1}
+              </span>
+              <span>{section.label}</span>
+            </a>
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+}

--- a/src/components/ui/close-button.tsx
+++ b/src/components/ui/close-button.tsx
@@ -1,0 +1,21 @@
+import { X } from 'lucide-react';
+
+import { cn } from '@/utils/Helpers';
+
+type CloseButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
+
+export function CloseButton({ className, ...props }: CloseButtonProps) {
+  return (
+    <button
+      type="button"
+      className={cn(
+        'flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        className,
+      )}
+      {...props}
+    >
+      <X className="size-4" />
+      <span className="sr-only">Close</span>
+    </button>
+  );
+}

--- a/src/components/ui/toggle-group.tsx
+++ b/src/components/ui/toggle-group.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import * as ToggleGroupPrimitive from '@radix-ui/react-toggle-group';
+import type { VariantProps } from 'class-variance-authority';
+import * as React from 'react';
+
+import { toggleVariants } from '@/components/ui/toggle-variants';
+import { cn } from '@/utils/Helpers';
+
+const ToggleGroupContext = React.createContext<
+  VariantProps<typeof toggleVariants>
+>({
+  size: 'default',
+  variant: 'default',
+});
+
+type ToggleGroupProps = React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Root>
+  & VariantProps<typeof toggleVariants>;
+
+const ToggleGroup = ({ ref, className, variant, size, children, ...props }: ToggleGroupProps & { ref?: React.RefObject<React.ElementRef<typeof ToggleGroupPrimitive.Root> | null> }) => (
+  <ToggleGroupPrimitive.Root
+    ref={ref}
+    className={cn('flex items-center justify-center gap-1', className)}
+    {...props}
+  >
+    <ToggleGroupContext value={{ variant, size }}>
+      {children}
+    </ToggleGroupContext>
+  </ToggleGroupPrimitive.Root>
+);
+
+ToggleGroup.displayName = ToggleGroupPrimitive.Root.displayName;
+
+type ToggleGroupItemProps = React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Item>
+  & VariantProps<typeof toggleVariants>;
+
+const ToggleGroupItem = ({ ref, className, children, variant, size, ...props }: ToggleGroupItemProps & { ref?: React.RefObject<React.ElementRef<typeof ToggleGroupPrimitive.Item> | null> }) => {
+  const context = React.use(ToggleGroupContext);
+
+  return (
+    <ToggleGroupPrimitive.Item
+      ref={ref}
+      className={cn(
+        toggleVariants({
+          variant: context.variant || variant,
+          size: context.size || size,
+        }),
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </ToggleGroupPrimitive.Item>
+  );
+};
+
+ToggleGroupItem.displayName = ToggleGroupPrimitive.Item.displayName;
+
+export { ToggleGroup, ToggleGroupItem };

--- a/src/components/ui/toggle-variants.ts
+++ b/src/components/ui/toggle-variants.ts
@@ -1,0 +1,22 @@
+import { cva } from 'class-variance-authority';
+
+export const toggleVariants = cva(
+  'inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 gap-2',
+  {
+    variants: {
+      variant: {
+        default: 'bg-transparent',
+        outline: 'border border-input bg-transparent hover:bg-accent hover:text-accent-foreground',
+      },
+      size: {
+        default: 'h-10 px-3 min-w-10',
+        sm: 'h-9 px-2.5 min-w-9',
+        lg: 'h-11 px-5 min-w-11',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  },
+);

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import * as TogglePrimitive from '@radix-ui/react-toggle';
+import type { VariantProps } from 'class-variance-authority';
+import * as React from 'react';
+
+import { toggleVariants } from '@/components/ui/toggle-variants';
+import { cn } from '@/utils/Helpers';
+
+const Toggle = ({ ref, className, variant, size, ...props }: React.ComponentPropsWithoutRef<typeof TogglePrimitive.Root>
+  & VariantProps<typeof toggleVariants> & { ref?: React.RefObject<React.ElementRef<typeof TogglePrimitive.Root> | null> }) => (
+  <TogglePrimitive.Root
+    ref={ref}
+    className={cn(toggleVariants({ variant, size, className }))}
+    {...props}
+  />
+);
+
+Toggle.displayName = TogglePrimitive.Root.displayName;
+
+export { Toggle };

--- a/src/libs/analytics/__tests__/server.test.ts
+++ b/src/libs/analytics/__tests__/server.test.ts
@@ -8,7 +8,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { shutdownServerAnalytics, trackEventServer } from '../server';
 
-vi.mock('@/libs/Logger', () => ({ logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() } }));
+vi.mock('@/libs/Logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
 
 vi.mock('posthog-node');
 
@@ -161,6 +163,55 @@ describe('trackEventServer', () => {
         step_name: 'preferences',
       }),
     });
+  });
+
+  it('forwards personSet as $set on capture', async () => {
+    mockCapture.mockClear();
+    mockCapture.mockImplementation(() => {});
+
+    await trackEventServer(
+      'signup_completed',
+      { method: 'email' },
+      'user-123',
+      { personSet: { plan: 'pro' } },
+    );
+
+    expect(mockCapture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        distinctId: 'user-123',
+        $set: { plan: 'pro' },
+      }),
+    );
+  });
+
+  it('forwards personSetOnce as $set_once on capture', async () => {
+    mockCapture.mockClear();
+    mockCapture.mockImplementation(() => {});
+
+    await trackEventServer(
+      'signup_completed',
+      { method: 'email' },
+      'user-123',
+      { personSetOnce: { first_seen: '2026-01-01' } },
+    );
+
+    expect(mockCapture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        $set_once: { first_seen: '2026-01-01' },
+      }),
+    );
+  });
+
+  it('omits $set/$set_once when no options are passed', async () => {
+    mockCapture.mockClear();
+    mockCapture.mockImplementation(() => {});
+
+    await trackEventServer('signup_completed', { method: 'email' }, 'user-123');
+
+    const payload = mockCapture.mock.calls[0]?.[0];
+
+    expect(payload).not.toHaveProperty('$set');
+    expect(payload).not.toHaveProperty('$set_once');
   });
 
   it('tracks error events with correct properties', async () => {

--- a/src/libs/analytics/__tests__/server.test.ts
+++ b/src/libs/analytics/__tests__/server.test.ts
@@ -179,7 +179,7 @@ describe('trackEventServer', () => {
     expect(mockCapture).toHaveBeenCalledWith(
       expect.objectContaining({
         distinctId: 'user-123',
-        $set: { plan: 'pro' },
+        properties: expect.objectContaining({ $set: { plan: 'pro' } }),
       }),
     );
   });
@@ -197,7 +197,7 @@ describe('trackEventServer', () => {
 
     expect(mockCapture).toHaveBeenCalledWith(
       expect.objectContaining({
-        $set_once: { first_seen: '2026-01-01' },
+        properties: expect.objectContaining({ $set_once: { first_seen: '2026-01-01' } }),
       }),
     );
   });
@@ -210,8 +210,8 @@ describe('trackEventServer', () => {
 
     const payload = mockCapture.mock.calls[0]?.[0];
 
-    expect(payload).not.toHaveProperty('$set');
-    expect(payload).not.toHaveProperty('$set_once');
+    expect(payload?.properties).not.toHaveProperty('$set');
+    expect(payload?.properties).not.toHaveProperty('$set_once');
   });
 
   it('tracks error events with correct properties', async () => {

--- a/src/libs/analytics/server.ts
+++ b/src/libs/analytics/server.ts
@@ -99,6 +99,9 @@ export async function trackEventServer<T extends EventName>(
     ...properties,
     timestamp: new Date().toISOString(),
     source: 'server' as const,
+    // posthog-node reads $set/$set_once from INSIDE properties (unlike posthog-js).
+    ...(options?.personSet && { $set: options.personSet }),
+    ...(options?.personSetOnce && { $set_once: options.personSetOnce }),
   };
 
   try {
@@ -106,8 +109,6 @@ export async function trackEventServer<T extends EventName>(
       distinctId: userId || 'anonymous',
       event: eventName,
       properties: enrichedProperties,
-      ...(options?.personSet && { $set: options.personSet }),
-      ...(options?.personSetOnce && { $set_once: options.personSetOnce }),
     });
 
     // Important: Flush events in serverless environments

--- a/src/libs/analytics/server.ts
+++ b/src/libs/analytics/server.ts
@@ -23,7 +23,8 @@ function getServerAnalytics(): PostHog | null {
   }
 
   const apiKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
-  const apiHost = process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://us.i.posthog.com';
+  const apiHost
+    = process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://us.i.posthog.com';
 
   if (!apiKey) {
     if (process.env.NODE_ENV === 'development') {
@@ -40,28 +41,43 @@ function getServerAnalytics(): PostHog | null {
 }
 
 /**
+ * Options for server-side event tracking.
+ */
+export type TrackServerOptions = {
+  /** PostHog $set — update person properties (overwrite). */
+  personSet?: Record<string, unknown>;
+  /** PostHog $set_once — set person properties only if not already set. */
+  personSetOnce?: Record<string, unknown>;
+};
+
+/**
  * Track event from server-side (API routes, server components)
  * Type-safe with automatic timestamp and source tracking
  *
  * @param eventName - Name of the event (type-checked)
  * @param properties - Event properties (typed per event)
  * @param userId - User ID for identification (optional)
+ * @param options - Optional $set/$set_once for person properties
  *
  * @example
  * ```tsx
  * // In an API route
  * await trackEventServer('signup_completed', { method: 'email' }, user.id)
  *
- * // In a server component
- * await trackEventServer('profile_updated', {
- *   fields_updated: ['name', 'avatar']
- * }, user.id)
+ * // With person property updates
+ * await trackEventServer(
+ *   'profile_updated',
+ *   { fields_updated: ['name', 'avatar'] },
+ *   user.id,
+ *   { personSet: { name: 'Ada', plan: 'pro' } },
+ * )
  * ```
  */
 export async function trackEventServer<T extends EventName>(
   eventName: T,
   properties: EventPropertiesMap[T],
   userId?: string,
+  options?: TrackServerOptions,
 ): Promise<void> {
   const client = getServerAnalytics();
 
@@ -86,26 +102,22 @@ export async function trackEventServer<T extends EventName>(
   };
 
   try {
-    if (userId) {
-      client.capture({
-        distinctId: userId,
-        event: eventName,
-        properties: enrichedProperties,
-      });
-    } else {
-      // Track without user ID (anonymous)
-      client.capture({
-        distinctId: 'anonymous',
-        event: eventName,
-        properties: enrichedProperties,
-      });
-    }
+    client.capture({
+      distinctId: userId || 'anonymous',
+      event: eventName,
+      properties: enrichedProperties,
+      ...(options?.personSet && { $set: options.personSet }),
+      ...(options?.personSetOnce && { $set_once: options.personSetOnce }),
+    });
 
     // Important: Flush events in serverless environments
     // This ensures events are sent before function terminates
     await client.flush();
   } catch (error) {
-    logger.error({ error, eventName }, '[Analytics Server] Failed to track event');
+    logger.error(
+      { error, eventName },
+      '[Analytics Server] Failed to track event',
+    );
     // Don't throw - analytics should never break the app
   }
 }

--- a/src/libs/hooks/use-debounce.ts
+++ b/src/libs/hooks/use-debounce.ts
@@ -1,0 +1,18 @@
+import * as React from 'react';
+
+export const useDebounce = <T>(value: T, delay = 500) => {
+  const [debouncedValue, setDebouncedValue] = React.useState(value);
+
+  React.useEffect(() => {
+    const handler: NodeJS.Timeout = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    // Cancel the timeout if value changes (also on delay change or unmount)
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+};

--- a/src/libs/hooks/use-is-mobile.ts
+++ b/src/libs/hooks/use-is-mobile.ts
@@ -1,0 +1,17 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export function useIsMobile(breakpoint = 768): boolean {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const mq = window.matchMedia(`(max-width: ${breakpoint - 1}px)`);
+    setIsMobile(mq.matches);
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, [breakpoint]);
+
+  return isMobile;
+}

--- a/src/libs/hooks/use-typewriter-placeholder.test.tsx
+++ b/src/libs/hooks/use-typewriter-placeholder.test.tsx
@@ -1,0 +1,81 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useTypewriterPlaceholder } from './use-typewriter-placeholder';
+
+describe('useTypewriterPlaceholder', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns an empty string when disabled', () => {
+    const { result } = renderHook(() =>
+      useTypewriterPlaceholder({
+        prefix: 'Write ',
+        suffixes: ['a post'],
+        enabled: false,
+      }),
+    );
+
+    expect(result.current).toBe('');
+  });
+
+  it('types the prefix followed by the first suffix character-by-character', () => {
+    const { result } = renderHook(() =>
+      useTypewriterPlaceholder({
+        prefix: 'Write ',
+        suffixes: ['ab'],
+        typingSpeed: 10,
+      }),
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(10);
+    });
+
+    expect(result.current).toBe('Write a');
+
+    act(() => {
+      vi.advanceTimersByTime(10);
+    });
+
+    expect(result.current).toBe('Write ab');
+  });
+
+  it('erases then advances to the next suffix', () => {
+    const { result } = renderHook(() =>
+      useTypewriterPlaceholder({
+        prefix: 'Do ',
+        suffixes: ['x', 'y'],
+        typingSpeed: 10,
+        erasingSpeed: 10,
+        pauseDuration: 100,
+      }),
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(10);
+    });
+
+    expect(result.current).toBe('Do x');
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    act(() => {
+      vi.advanceTimersByTime(10);
+    });
+
+    expect(result.current).toBe('Do ');
+
+    act(() => {
+      vi.advanceTimersByTime(10);
+    });
+
+    expect(result.current).toBe('Do y');
+  });
+});

--- a/src/libs/hooks/use-typewriter-placeholder.ts
+++ b/src/libs/hooks/use-typewriter-placeholder.ts
@@ -1,0 +1,69 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+type UseTypewriterPlaceholderOptions = {
+  prefix: string;
+  suffixes: string[];
+  typingSpeed?: number;
+  erasingSpeed?: number;
+  pauseDuration?: number;
+  enabled?: boolean;
+};
+
+export function useTypewriterPlaceholder({
+  prefix,
+  suffixes,
+  typingSpeed = 30,
+  erasingSpeed = 15,
+  pauseDuration = 2000,
+  enabled = true,
+}: UseTypewriterPlaceholderOptions): string {
+  const [suffixIndex, setSuffixIndex] = useState(0);
+  const [displayed, setDisplayed] = useState('');
+  const [isTyping, setIsTyping] = useState(true);
+  const charIndexRef = useRef(0);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    const currentSuffix = suffixes[suffixIndex]!;
+
+    if (isTyping) {
+      if (charIndexRef.current < currentSuffix.length) {
+        const timeout = setTimeout(() => {
+          setDisplayed(
+            prefix + currentSuffix.slice(0, charIndexRef.current + 1),
+          );
+          charIndexRef.current += 1;
+        }, typingSpeed);
+        return () => clearTimeout(timeout);
+      } else {
+        const timeout = setTimeout(setIsTyping, pauseDuration, false);
+        return () => clearTimeout(timeout);
+      }
+    } else {
+      if (charIndexRef.current > 0) {
+        const timeout = setTimeout(() => {
+          charIndexRef.current -= 1;
+          setDisplayed(
+            prefix + currentSuffix.slice(0, charIndexRef.current),
+          );
+        }, erasingSpeed);
+        return () => clearTimeout(timeout);
+      } else {
+        setSuffixIndex(prev => (prev + 1) % suffixes.length);
+        setIsTyping(true);
+        return undefined;
+      }
+    }
+  }, [displayed, isTyping, suffixIndex, prefix, suffixes, typingSpeed, erasingSpeed, pauseDuration, enabled]);
+
+  if (!enabled) {
+    return '';
+  }
+
+  return displayed;
+}

--- a/src/libs/inngest/functions/token-refresh.test.ts
+++ b/src/libs/inngest/functions/token-refresh.test.ts
@@ -1,0 +1,107 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Schema/env modules read DB_SCHEMA at import time; this worktree has no
+// .env.local, so set it before any import that pulls them in.
+vi.hoisted(() => {
+  process.env.DB_SCHEMA ??= 'vt_saas';
+  process.env.NEXT_PUBLIC_DB_SCHEMA ??= 'vt_saas';
+});
+
+// Rows returned by the connections SELECT; each test sets this.
+let selectRows: Array<Record<string, unknown>> = [];
+const updateSpy = vi.fn((_updates: Record<string, string>) => ({
+  eq: vi.fn(() => Promise.resolve({ error: null })),
+}));
+
+vi.mock('@/libs/supabase/admin', () => ({
+  createAdminClient: () => ({
+    from: () => ({
+      // .select(...).gt(...).lt(...) chain resolves to the fixture rows.
+      select: () => ({
+        gt: () => ({
+          lt: () => Promise.resolve({ data: selectRows, error: null }),
+        }),
+      }),
+      update: updateSpy,
+    }),
+  }),
+}));
+
+const refreshTokenMock = vi.fn();
+vi.mock('@/libs/platforms/oauth-provider', () => ({
+  getOAuthProvider: (id: string) =>
+    id === 'my-provider' ? { id, refreshToken: refreshTokenMock } : null,
+}));
+
+vi.mock('@/libs/crypto/token-encryption', () => ({
+  decryptToken: (t: string) => `dec:${t}`,
+  encryptToken: (t: string) => `enc:${t}`,
+}));
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+}));
+
+const mockLogger = { info: vi.fn(), error: vi.fn() };
+
+describe('refreshExpiringTokens', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    selectRows = [];
+    refreshTokenMock.mockReset();
+  });
+
+  it('skips a connection with no refresh_token and never updates the row', async () => {
+    selectRows = [
+      { id: 'c1', user_id: 'u1', provider: 'my-provider', refresh_token: null },
+    ];
+    const { refreshExpiringTokens } = await import('./token-refresh');
+
+    const result = await refreshExpiringTokens(mockLogger);
+
+    expect(result).toEqual({ refreshed: 0, skipped: 1, errors: 0 });
+    expect(updateSpy).not.toHaveBeenCalled();
+    expect(refreshTokenMock).not.toHaveBeenCalled();
+  });
+
+  it('does NOT overwrite token_expires_at when the provider refresh fails', async () => {
+    selectRows = [
+      { id: 'c1', user_id: 'u1', provider: 'my-provider', refresh_token: 'r1' },
+    ];
+    refreshTokenMock.mockRejectedValue(new Error('transient 5xx'));
+    const { refreshExpiringTokens } = await import('./token-refresh');
+    const Sentry = await import('@sentry/nextjs');
+
+    const result = await refreshExpiringTokens(mockLogger);
+
+    expect(result).toEqual({ refreshed: 0, skipped: 0, errors: 1 });
+    // The whole point: a transient failure must leave the stored row untouched.
+    expect(updateSpy).not.toHaveBeenCalled();
+    expect(vi.mocked(Sentry.captureException)).toHaveBeenCalledOnce();
+  });
+
+  it('decrypts, refreshes, re-encrypts and updates the row on success', async () => {
+    selectRows = [
+      { id: 'c1', user_id: 'u1', provider: 'my-provider', refresh_token: 'r1' },
+    ];
+    refreshTokenMock.mockResolvedValue({
+      access_token: 'new-access',
+      refresh_token: 'new-refresh',
+      expires_in: 3600,
+    });
+    const { refreshExpiringTokens } = await import('./token-refresh');
+
+    const result = await refreshExpiringTokens(mockLogger);
+
+    expect(result).toEqual({ refreshed: 1, skipped: 0, errors: 0 });
+    expect(refreshTokenMock).toHaveBeenCalledWith('dec:r1');
+    expect(updateSpy).toHaveBeenCalledOnce();
+
+    const updates = updateSpy.mock.calls[0]![0];
+
+    expect(updates.access_token).toBe('enc:new-access');
+    expect(updates.refresh_token).toBe('enc:new-refresh');
+    expect(updates.token_expires_at).toBeDefined();
+  });
+});

--- a/src/libs/inngest/functions/token-refresh.ts
+++ b/src/libs/inngest/functions/token-refresh.ts
@@ -1,0 +1,146 @@
+import * as Sentry from '@sentry/nextjs';
+
+import { decryptToken, encryptToken } from '@/libs/crypto/token-encryption';
+import { getOAuthProvider } from '@/libs/platforms/oauth-provider';
+import { createAdminClient } from '@/libs/supabase/admin';
+
+import { inngest } from '../client';
+
+// Proactive refresh: pick up tokens expiring within 30 days.
+// After refresh, a long-lived token (e.g. 60-day expiry) falls outside this
+// window and won't match again until 30 days before the new expiry —
+// self-regulating. Short-lived tokens stay in-window and refresh every cycle.
+const REFRESH_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+
+type Logger = {
+  info: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+};
+
+/**
+ * Cron body — extracted as a named export so tests can exercise it directly with
+ * a plain logger double (matches the template's other inngest functions).
+ *
+ * Refreshes OAuth tokens in `platform_connections` that expire within the
+ * refresh window, going through the `OAuthProvider` seam (`refreshToken`) so any
+ * provider drops in with no change here.
+ *
+ * @internal
+ */
+export async function refreshExpiringTokens(logger: Logger): Promise<{
+  refreshed: number;
+  skipped: number;
+  errors: number;
+}> {
+  const supabase = createAdminClient();
+  const now = new Date();
+  const windowEnd = new Date(now.getTime() + REFRESH_WINDOW_MS);
+
+  // Connections whose tokens expire within the refresh window but aren't yet
+  // expired.
+  const { data: connections, error: fetchError } = await supabase
+    .from('platform_connections')
+    .select('id, user_id, provider, refresh_token, token_expires_at')
+    .gt('token_expires_at', now.toISOString())
+    .lt('token_expires_at', windowEnd.toISOString());
+
+  if (fetchError) {
+    logger.error('token-refresh: failed to fetch connections', {
+      error: fetchError.message,
+    });
+    return { refreshed: 0, skipped: 0, errors: 0 };
+  }
+
+  let refreshed = 0;
+  let skipped = 0;
+  let errors = 0;
+
+  for (const conn of connections ?? []) {
+    const { id, user_id, provider: providerId, refresh_token } = conn;
+
+    // No refresh token — there's nothing to refresh, so just skip. The token
+    // will expire naturally at its scheduled time and the UI will surface
+    // "Reconnect" then. Never overwrite token_expires_at here: doing so removes
+    // the row from the SELECT window and locks the user out up to 30 days early.
+    if (!refresh_token) {
+      logger.info(
+        `[token-refresh] No refresh token for ${providerId} user ${user_id} — skipping (will expire naturally)`,
+      );
+      skipped++;
+      continue;
+    }
+
+    const provider = getOAuthProvider(providerId);
+    if (!provider) {
+      logger.error(
+        `[token-refresh] Unknown provider "${providerId}" for user ${user_id} — skipping`,
+      );
+      skipped++;
+      continue;
+    }
+
+    try {
+      // decrypt → refresh → re-encrypt → update; only touch the DB on success.
+      const decryptedRefreshToken = decryptToken(refresh_token);
+      const tokenResponse = await provider.refreshToken(decryptedRefreshToken);
+
+      const newExpiresAt = new Date(
+        now.getTime() + tokenResponse.expires_in * 1000,
+      ).toISOString();
+
+      const updates: Record<string, string> = {
+        access_token: encryptToken(tokenResponse.access_token),
+        token_expires_at: newExpiresAt,
+        updated_at: now.toISOString(),
+      };
+      // Providers may or may not rotate the refresh token — only update it when
+      // a new one is returned.
+      if (tokenResponse.refresh_token) {
+        updates.refresh_token = encryptToken(tokenResponse.refresh_token);
+      }
+
+      const { error: updateError } = await supabase
+        .from('platform_connections')
+        .update(updates)
+        .eq('id', id);
+
+      if (updateError) {
+        throw new Error(`DB update failed: ${updateError.message}`);
+      }
+
+      logger.info(`[token-refresh] Refreshed ${providerId} token for user ${user_id}`);
+      refreshed++;
+    } catch (err) {
+      Sentry.captureException(err, {
+        contexts: { tokenRefresh: { provider: providerId, userId: user_id, connectionId: id } },
+      });
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error(
+        `[token-refresh] Failed to refresh ${providerId} token for user ${user_id}: ${message}`,
+      );
+
+      // Do NOT overwrite token_expires_at on failure. Leaving the timestamp
+      // alone keeps the row in the SELECT window so the cron retries every cycle
+      // until the refresh succeeds or the token reaches its natural expiry — a
+      // single transient error (network blip, 5xx, rate limit) must not
+      // permanently kill the connection.
+      errors++;
+    }
+  }
+
+  logger.info(`[token-refresh] done — refreshed=${refreshed} skipped=${skipped} errors=${errors}`);
+  return { refreshed, skipped, errors };
+}
+
+/**
+ * Cron: proactively refreshes OAuth tokens in `platform_connections` that are
+ * within 30 days of expiry, before they lapse. Runs every 30 minutes.
+ */
+export const tokenRefreshFunction = inngest.createFunction(
+  {
+    id: 'token-refresh',
+    name: 'Token Refresh',
+    triggers: [{ cron: '*/30 * * * *' }],
+  },
+  async ({ logger }) => refreshExpiringTokens(logger),
+);

--- a/src/libs/keyboard/use-keyboard-shortcuts.test.ts
+++ b/src/libs/keyboard/use-keyboard-shortcuts.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { isShortcutActiveOnPath } from './use-keyboard-shortcuts';
+
+describe('isShortcutActiveOnPath', () => {
+  it('activates everywhere when activePaths is undefined', () => {
+    expect(isShortcutActiveOnPath(undefined, '/anything')).toBe(true);
+  });
+
+  it('matches exact path and true sub-paths without a trailing slash', () => {
+    expect(isShortcutActiveOnPath(['/posts'], '/posts')).toBe(true);
+    expect(isShortcutActiveOnPath(['/posts'], '/posts/123')).toBe(true);
+  });
+
+  it('does not false-match a sibling path with a shared prefix', () => {
+    expect(isShortcutActiveOnPath(['/posts'], '/postsettings')).toBe(false);
+  });
+
+  it('scopes a trailing-slash path to sub-paths only', () => {
+    // '/posts/' vs '/posts' boundary: the trailing slash excludes the list page.
+    expect(isShortcutActiveOnPath(['/posts/'], '/posts/123')).toBe(true);
+    expect(isShortcutActiveOnPath(['/posts/'], '/posts')).toBe(false);
+  });
+});

--- a/src/libs/keyboard/use-keyboard-shortcuts.ts
+++ b/src/libs/keyboard/use-keyboard-shortcuts.ts
@@ -49,7 +49,8 @@ export function useKeyboardShortcuts(
 
   useEffect(() => {
     const handleKeydown = (e: KeyboardEvent) => {
-      const { isCommandPaletteOpen, actionHandlers } = useKeyboardShortcutStore.getState();
+      const { isCommandPaletteOpen, actionHandlers }
+        = useKeyboardShortcutStore.getState();
 
       // When command palette is open, let it handle all keys
       if (isCommandPaletteOpen) {
@@ -92,7 +93,9 @@ export function useKeyboardShortcuts(
           }
 
           const keyMatch = e.key.toLowerCase() === shortcut.keyPattern.key;
-          const shiftMatch = shortcut.keyPattern.shift ? e.shiftKey : !e.shiftKey;
+          const shiftMatch = shortcut.keyPattern.shift
+            ? e.shiftKey
+            : !e.shiftKey;
 
           if (keyMatch && shiftMatch) {
             // Skip non-editable-safe combos when in editable field
@@ -104,7 +107,11 @@ export function useKeyboardShortcuts(
             }
 
             e.preventDefault();
-            executeAction(shortcut.id, staticHandlersRef.current, actionHandlers);
+            executeAction(
+              shortcut.id,
+              staticHandlersRef.current,
+              actionHandlers,
+            );
             return;
           }
         }
@@ -155,11 +162,23 @@ export function useKeyboardShortcuts(
   }, [pathname]);
 }
 
-function isShortcutActiveOnPath(activePaths: string[] | undefined, cleanPath: string): boolean {
+export function isShortcutActiveOnPath(
+  activePaths: string[] | undefined,
+  cleanPath: string,
+): boolean {
   if (!activePaths) {
     return true;
   }
-  return activePaths.some(p => cleanPath === p || cleanPath.startsWith(`${p}/`));
+  return activePaths.some((p) => {
+    // A trailing slash marks "sub-paths only" — e.g. '/posts/' matches the
+    // detail page '/posts/123' but not the '/posts' list.
+    if (p.endsWith('/')) {
+      return cleanPath.startsWith(p);
+    }
+    // Exact match or a true sub-path. The `${p}/` boundary prevents a bare
+    // `startsWith(p)` from letting '/dashboard' match '/dashboards'.
+    return cleanPath === p || cleanPath.startsWith(`${p}/`);
+  });
 }
 
 function executeAction(

--- a/src/libs/platforms/connection-health.test.ts
+++ b/src/libs/platforms/connection-health.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+
+import { canPublish, EXPIRING_SOON_DAYS, getConnectionHealth } from './connection-health';
+import type { PlatformConnectionSafe } from './types';
+
+const NOW = new Date('2026-06-23T12:00:00Z');
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function conn(tokenExpiresAt: string | null): PlatformConnectionSafe {
+  return {
+    id: 'c1',
+    userId: 'u1',
+    provider: 'my-provider',
+    tokenExpiresAt,
+    providerAccountId: 'acct-sub',
+    username: 'jane',
+    displayName: 'Jane Doe',
+    profilePictureUrl: null,
+    status: 'connected',
+    createdAt: NOW.toISOString(),
+    updatedAt: NOW.toISOString(),
+  };
+}
+
+function isoIn(ms: number): string {
+  return new Date(NOW.getTime() + ms).toISOString();
+}
+
+describe('getConnectionHealth', () => {
+  it('no connection → disconnected', () => {
+    expect(getConnectionHealth(undefined, NOW)).toEqual({
+      status: 'disconnected',
+      expiresAt: null,
+      daysRemaining: null,
+    });
+  });
+
+  it('connection with null expiry → connected', () => {
+    const health = getConnectionHealth(conn(null), NOW);
+
+    expect(health.status).toBe('connected');
+    expect(health.expiresAt).toBeNull();
+    expect(health.daysRemaining).toBeNull();
+  });
+
+  it('expiry far out (+30d) → connected', () => {
+    expect(getConnectionHealth(conn(isoIn(30 * DAY_MS)), NOW).status).toBe('connected');
+  });
+
+  it('expiry just outside the window (+8d) → connected', () => {
+    expect(getConnectionHealth(conn(isoIn(8 * DAY_MS)), NOW).status).toBe('connected');
+  });
+
+  it('expiry at the window edge (+7d) → expiring_soon', () => {
+    const health = getConnectionHealth(conn(isoIn(EXPIRING_SOON_DAYS * DAY_MS)), NOW);
+
+    expect(health.status).toBe('expiring_soon');
+    expect(health.daysRemaining).toBe(7);
+  });
+
+  it('expiry tomorrow (+1d) → expiring_soon', () => {
+    expect(getConnectionHealth(conn(isoIn(1 * DAY_MS)), NOW).status).toBe('expiring_soon');
+  });
+
+  it('just expired (−1ms) → expired', () => {
+    expect(getConnectionHealth(conn(isoIn(-1)), NOW).status).toBe('expired');
+  });
+
+  it('long expired (−5d) → expired', () => {
+    const health = getConnectionHealth(conn(isoIn(-5 * DAY_MS)), NOW);
+
+    expect(health.status).toBe('expired');
+    expect(health.expiresAt).toBeInstanceOf(Date);
+  });
+});
+
+describe('canPublish', () => {
+  it('true for connected and expiring_soon', () => {
+    expect(canPublish('connected')).toBe(true);
+    expect(canPublish('expiring_soon')).toBe(true);
+  });
+
+  it('false for expired and disconnected', () => {
+    expect(canPublish('expired')).toBe(false);
+    expect(canPublish('disconnected')).toBe(false);
+  });
+});

--- a/src/libs/platforms/connection-health.ts
+++ b/src/libs/platforms/connection-health.ts
@@ -1,0 +1,59 @@
+import type { PlatformConnectionSafe, PlatformConnectionStatus } from './types';
+
+// A connection is "expiring soon" once it's within this many days of its token
+// expiry. Tune per provider; keep it aligned with any reconnect-nudge cadence so
+// the in-app signal and the email agree.
+export const EXPIRING_SOON_DAYS = 7;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export type ConnectionHealth = {
+  status: PlatformConnectionStatus;
+  expiresAt: Date | null;
+  daysRemaining: number | null;
+};
+
+/**
+ * Single source of truth for a platform connection's health. Pure (no React, no
+ * fetch) so it's unit-testable and usable from both client hooks and server code.
+ * `now` is injectable for deterministic tests.
+ *
+ * - no connection            → `disconnected`
+ * - connected, no expiry set  → `connected` (we only flag expiry when a timestamp
+ *                               exists)
+ * - expired (<= now)          → `expired`
+ * - expires within the window → `expiring_soon`
+ * - otherwise                 → `connected`
+ */
+export function getConnectionHealth(
+  connection: PlatformConnectionSafe | undefined,
+  now: Date = new Date(),
+): ConnectionHealth {
+  if (!connection) {
+    return { status: 'disconnected', expiresAt: null, daysRemaining: null };
+  }
+  if (!connection.tokenExpiresAt) {
+    return { status: 'connected', expiresAt: null, daysRemaining: null };
+  }
+
+  const expiresAt = new Date(connection.tokenExpiresAt);
+  const msRemaining = expiresAt.getTime() - now.getTime();
+  const daysRemaining = Math.ceil(msRemaining / DAY_MS);
+
+  if (msRemaining <= 0) {
+    return { status: 'expired', expiresAt, daysRemaining };
+  }
+  if (daysRemaining <= EXPIRING_SOON_DAYS) {
+    return { status: 'expiring_soon', expiresAt, daysRemaining };
+  }
+  return { status: 'connected', expiresAt, daysRemaining };
+}
+
+/**
+ * Whether a post can be published/scheduled to a connection in this state.
+ * `expiring_soon` is still usable — the token is valid, just nearing expiry.
+ * The single predicate for action gates (Post Now, Schedule).
+ */
+export function canPublish(status: PlatformConnectionStatus): boolean {
+  return status === 'connected' || status === 'expiring_soon';
+}

--- a/src/libs/platforms/types.ts
+++ b/src/libs/platforms/types.ts
@@ -9,7 +9,8 @@
 // Free-text provider id (single-provider today, extensible to many).
 export type PlatformType = string;
 
-export type PlatformConnectionStatus = 'connected' | 'expired' | 'disconnected';
+export type PlatformConnectionStatus
+  = 'connected' | 'expiring_soon' | 'expired' | 'disconnected';
 
 export type PlatformConnection = {
   id: string;
@@ -28,7 +29,10 @@ export type PlatformConnection = {
 };
 
 // Safe read model — never exposes tokens.
-export type PlatformConnectionSafe = Omit<PlatformConnection, 'accessToken' | 'refreshToken'>;
+export type PlatformConnectionSafe = Omit<
+  PlatformConnection,
+  'accessToken' | 'refreshToken'
+>;
 
 export type OAuthTokenResponse = {
   access_token: string;

--- a/src/libs/search/perplexity.test.ts
+++ b/src/libs/search/perplexity.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { SearchResult } from './types';
+
+// Mock the Env module before importing perplexity
+vi.mock('@/libs/Env', () => ({
+  Env: {
+    PERPLEXITY_API_KEY: undefined as string | undefined,
+  },
+}));
+
+// Mock the logger module so tests can assert on its methods
+vi.mock('@/libs/Logger', () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+describe('perplexity searchWeb', () => {
+  let searchWeb: typeof import('./perplexity').searchWeb;
+  let mockEnv: { PERPLEXITY_API_KEY: string | undefined };
+
+  beforeEach(async () => {
+    // Get reference to the mocked Env
+    const envModule = await import('@/libs/Env');
+    mockEnv = envModule.Env as unknown as { PERPLEXITY_API_KEY: string | undefined };
+
+    // Re-import perplexity to get fresh module
+    const perplexityModule = await import('./perplexity');
+    searchWeb = perplexityModule.searchWeb;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns empty array when PERPLEXITY_API_KEY is not set', async () => {
+    mockEnv.PERPLEXITY_API_KEY = undefined;
+
+    const results = await searchWeb('test query');
+
+    expect(results).toEqual([]);
+  });
+
+  it('returns empty array when PERPLEXITY_API_KEY is empty string', async () => {
+    mockEnv.PERPLEXITY_API_KEY = '';
+
+    const results = await searchWeb('test query');
+
+    expect(results).toEqual([]);
+  });
+
+  it('calls Perplexity API with correct URL, headers, and body when key is set', async () => {
+    mockEnv.PERPLEXITY_API_KEY = 'pplx-test-key';
+
+    const mockResponse: { results: Array<{ title: string; url: string; snippet: string }> } = {
+      results: [
+        {
+          title: 'Test Article',
+          url: 'https://example.com/article',
+          snippet: 'This is a test article about AI trends.',
+        },
+        {
+          title: 'Another Article',
+          url: 'https://example.com/another',
+          snippet: 'Another article about leadership.',
+        },
+      ],
+    };
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify(mockResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const results = await searchWeb('AI trends 2026', { maxResults: 5 });
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://api.perplexity.ai/search',
+      expect.objectContaining({
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer pplx-test-key',
+        },
+        body: JSON.stringify({
+          query: 'AI trends 2026',
+          max_results: 5,
+        }),
+      }),
+    );
+
+    expect(results).toHaveLength(2);
+    expect(results[0]).toEqual({
+      title: 'Test Article',
+      url: 'https://example.com/article',
+      content: 'This is a test article about AI trends.',
+    });
+  });
+
+  it('maps snippet to content in results', async () => {
+    mockEnv.PERPLEXITY_API_KEY = 'pplx-test-key';
+
+    const mockResponse = {
+      results: [
+        {
+          title: 'Article',
+          url: 'https://example.com',
+          snippet: 'The snippet text.',
+        },
+      ],
+    };
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify(mockResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const results = await searchWeb('test');
+
+    expect(results[0]!.content).toBe('The snippet text.');
+  });
+
+  it('uses correct defaults when no options provided', async () => {
+    mockEnv.PERPLEXITY_API_KEY = 'pplx-test-key';
+
+    const mockResponse = { results: [] };
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify(mockResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await searchWeb('test query');
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://api.perplexity.ai/search',
+      expect.objectContaining({
+        body: JSON.stringify({
+          query: 'test query',
+          max_results: 5,
+        }),
+      }),
+    );
+  });
+
+  it('returns empty array on fetch error', async () => {
+    mockEnv.PERPLEXITY_API_KEY = 'pplx-test-key';
+
+    vi.spyOn(globalThis, 'fetch').mockRejectedValueOnce(new Error('Network error'));
+    const { logger } = await import('@/libs/Logger');
+
+    const results = await searchWeb('test query');
+
+    expect(results).toEqual([]);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ error: expect.any(Error) }),
+      'Perplexity search failed',
+    );
+  });
+
+  it('returns empty array on non-OK response', async () => {
+    mockEnv.PERPLEXITY_API_KEY = 'pplx-test-key';
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('Internal Server Error', { status: 500 }),
+    );
+    const { logger } = await import('@/libs/Logger');
+
+    const results: SearchResult[] = await searchWeb('test query');
+
+    expect(results).toEqual([]);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 500 }),
+      'Perplexity API error',
+    );
+  });
+});

--- a/src/libs/search/tavily.test.ts
+++ b/src/libs/search/tavily.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { SearchResult } from './types';
+
+// Mock the Env module before importing tavily
+vi.mock('@/libs/Env', () => ({
+  Env: {
+    TAVILY_API_KEY: undefined as string | undefined,
+  },
+}));
+
+// Mock the logger module so tests can assert on its methods
+vi.mock('@/libs/Logger', () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+describe('tavily searchWeb', () => {
+  let searchWeb: typeof import('./tavily').searchWeb;
+  let mockEnv: { TAVILY_API_KEY: string | undefined };
+
+  beforeEach(async () => {
+    // Get reference to the mocked Env
+    const envModule = await import('@/libs/Env');
+    mockEnv = envModule.Env as unknown as { TAVILY_API_KEY: string | undefined };
+
+    // Re-import tavily to get fresh module
+    const tavilyModule = await import('./tavily');
+    searchWeb = tavilyModule.searchWeb;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns empty array when TAVILY_API_KEY is not set', async () => {
+    mockEnv.TAVILY_API_KEY = undefined;
+
+    const results = await searchWeb('test query');
+
+    expect(results).toEqual([]);
+  });
+
+  it('returns empty array when TAVILY_API_KEY is empty string', async () => {
+    mockEnv.TAVILY_API_KEY = '';
+
+    const results = await searchWeb('test query');
+
+    expect(results).toEqual([]);
+  });
+
+  it('calls Tavily API with correct request body when key is set', async () => {
+    mockEnv.TAVILY_API_KEY = 'tvly-test-key';
+
+    const mockResponse: { results: SearchResult[] } = {
+      results: [
+        {
+          title: 'Test Article',
+          url: 'https://example.com/article',
+          content: 'This is a test article about AI trends.',
+          score: 0.95,
+        },
+        {
+          title: 'Another Article',
+          url: 'https://example.com/another',
+          content: 'Another article about leadership.',
+          score: 0.88,
+        },
+      ],
+    };
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify(mockResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const results = await searchWeb('AI trends 2026', { maxResults: 5, topic: 'news' });
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://api.tavily.com/search',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          api_key: 'tvly-test-key',
+          query: 'AI trends 2026',
+          max_results: 5,
+          topic: 'news',
+        }),
+      }),
+    );
+
+    expect(results).toHaveLength(2);
+    expect(results[0]).toEqual({
+      title: 'Test Article',
+      url: 'https://example.com/article',
+      content: 'This is a test article about AI trends.',
+      score: 0.95,
+    });
+  });
+
+  it('uses default options when none provided', async () => {
+    mockEnv.TAVILY_API_KEY = 'tvly-test-key';
+
+    const mockResponse = { results: [] };
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify(mockResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await searchWeb('test query');
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://api.tavily.com/search',
+      expect.objectContaining({
+        body: JSON.stringify({
+          api_key: 'tvly-test-key',
+          query: 'test query',
+          max_results: 5,
+          topic: 'general',
+        }),
+      }),
+    );
+  });
+
+  it('returns empty array on fetch error', async () => {
+    mockEnv.TAVILY_API_KEY = 'tvly-test-key';
+
+    vi.spyOn(globalThis, 'fetch').mockRejectedValueOnce(new Error('Network error'));
+    const { logger } = await import('@/libs/Logger');
+
+    const results = await searchWeb('test query');
+
+    expect(results).toEqual([]);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ error: expect.any(Error) }),
+      'Tavily search failed',
+    );
+  });
+
+  it('returns empty array on non-OK response', async () => {
+    mockEnv.TAVILY_API_KEY = 'tvly-test-key';
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('Internal Server Error', { status: 500 }),
+    );
+    const { logger } = await import('@/libs/Logger');
+
+    const results = await searchWeb('test query');
+
+    expect(results).toEqual([]);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 500 }),
+      'Tavily API error',
+    );
+  });
+});

--- a/src/libs/utils/__tests__/auth-cooldown.test.ts
+++ b/src/libs/utils/__tests__/auth-cooldown.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  COOLDOWN_DURATION,
+  getCooldownExpiry,
+  getCooldownKey,
+  getRemainingCooldown,
+  setCooldownExpiry,
+} from '../auth-cooldown';
+
+const PREFIX = 'email_resend_cooldown';
+const EMAIL = 'user@example.com';
+
+describe('auth-cooldown', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('builds a prefix-scoped storage key', () => {
+    expect(getCooldownKey(PREFIX, EMAIL)).toBe(`${PREFIX}_${EMAIL}`);
+  });
+
+  it('returns null expiry when nothing is stored', () => {
+    expect(getCooldownExpiry(PREFIX, EMAIL)).toBeNull();
+  });
+
+  it('persists and reads back the expiry timestamp', () => {
+    const expiry = Date.now() + COOLDOWN_DURATION * 1000;
+    setCooldownExpiry(PREFIX, EMAIL, expiry);
+
+    expect(getCooldownExpiry(PREFIX, EMAIL)).toBe(expiry);
+  });
+
+  it('reports remaining seconds until expiry', () => {
+    setCooldownExpiry(PREFIX, EMAIL, Date.now() + COOLDOWN_DURATION * 1000);
+
+    expect(getRemainingCooldown(PREFIX, EMAIL)).toBe(COOLDOWN_DURATION);
+  });
+
+  it('returns 0 once the cooldown has elapsed', () => {
+    setCooldownExpiry(PREFIX, EMAIL, Date.now() + 5000);
+    vi.advanceTimersByTime(6000);
+
+    expect(getRemainingCooldown(PREFIX, EMAIL)).toBe(0);
+  });
+
+  it('isolates cooldowns across different prefixes', () => {
+    setCooldownExpiry(PREFIX, EMAIL, Date.now() + COOLDOWN_DURATION * 1000);
+
+    expect(getRemainingCooldown('password_reset_cooldown', EMAIL)).toBe(0);
+  });
+});

--- a/src/libs/utils/__tests__/display-name.test.ts
+++ b/src/libs/utils/__tests__/display-name.test.ts
@@ -1,0 +1,55 @@
+import type { User } from '@supabase/supabase-js';
+import { describe, expect, it } from 'vitest';
+
+import { getDisplayName } from '../display-name';
+
+function mockUser(overrides: Partial<User> = {}): User {
+  return {
+    id: 'user-1',
+    aud: 'authenticated',
+    email: 'ada@example.com',
+    user_metadata: {},
+    app_metadata: {},
+    created_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  } as User;
+}
+
+describe('getDisplayName', () => {
+  it('returns profile.displayName when present', () => {
+    const user = mockUser();
+
+    expect(getDisplayName(user, { displayName: 'From Profile' })).toBe('From Profile');
+  });
+
+  it('falls back to email prefix when profile name is missing', () => {
+    const user = mockUser();
+
+    expect(getDisplayName(user, { displayName: null })).toBe('ada');
+    expect(getDisplayName(user, null)).toBe('ada');
+    expect(getDisplayName(user)).toBe('ada');
+  });
+
+  it('returns empty string when user is null', () => {
+    expect(getDisplayName(null)).toBe('');
+    expect(getDisplayName(undefined)).toBe('');
+  });
+
+  it('returns empty string when user has no email and no profile', () => {
+    const user = mockUser({ email: undefined });
+
+    expect(getDisplayName(user)).toBe('');
+  });
+
+  it('ignores empty-string profile name and falls through to email prefix', () => {
+    const user = mockUser();
+
+    expect(getDisplayName(user, { displayName: '' })).toBe('ada');
+  });
+
+  it('does not read user_metadata.full_name', () => {
+    const user = mockUser({ user_metadata: { full_name: 'From Metadata' } });
+
+    expect(getDisplayName(user)).toBe('ada');
+  });
+});

--- a/src/libs/utils/auth-cooldown.ts
+++ b/src/libs/utils/auth-cooldown.ts
@@ -1,0 +1,31 @@
+const COOLDOWN_DURATION = 60;
+
+export { COOLDOWN_DURATION };
+
+export function getCooldownKey(prefix: string, email: string): string {
+  return `${prefix}_${email}`;
+}
+
+export function getCooldownExpiry(prefix: string, email: string): number | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  const stored = localStorage.getItem(getCooldownKey(prefix, email));
+  return stored ? Number.parseInt(stored, 10) : null;
+}
+
+export function setCooldownExpiry(prefix: string, email: string, expiry: number): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  localStorage.setItem(getCooldownKey(prefix, email), expiry.toString());
+}
+
+export function getRemainingCooldown(prefix: string, email: string): number {
+  const expiry = getCooldownExpiry(prefix, email);
+  if (!expiry) {
+    return 0;
+  }
+  const remaining = Math.ceil((expiry - Date.now()) / 1000);
+  return remaining > 0 ? remaining : 0;
+}

--- a/src/libs/utils/display-name.ts
+++ b/src/libs/utils/display-name.ts
@@ -1,0 +1,22 @@
+import type { User } from '@supabase/supabase-js';
+
+/**
+ * Resolve the display name for a user.
+ *
+ * Precedence:
+ *   1. profile.displayName (canonical — set via onboarding or settings)
+ *   2. Email prefix (anonymous fallback for users who haven't set a name)
+ *   3. Empty string
+ */
+export function getDisplayName(
+  user: User | null | undefined,
+  profile?: { displayName?: string | null } | null,
+): string {
+  if (profile?.displayName) {
+    return profile.displayName;
+  }
+  if (user?.email) {
+    return user.email.split('@')[0] ?? '';
+  }
+  return '';
+}


### PR DESCRIPTION
## Round A · Drop-in tier — ContentFlow → template upstream contribution

15 generic drop-in improvements harvested from ContentFlow.

**UI/hooks primitives (8):** `ui/toggle`+`toggle-group`, `ui/close-button`, `use-is-mobile`, `use-debounce`, `layout/page-header` (with `iconClassName`, #250), `use-typewriter-placeholder`, `legal/legal-toc`, plus `search/{perplexity,tavily}` provider unit tests (13 tests for previously-untested shared infra).

**Lib/feature (7):**
- `feat(platforms)` connection-health — pure `{disconnected,expired,expiring_soon,connected}` + `canPublish()` derivation (adds `expiring_soon` to the status union).
- `refactor(auth)` extract the inlined verify-email resend cooldown into a reusable prefix-param util.
- `fix(keyboard)` trailing-slash path scoping for route-scoped shortcuts (+ export + test).
- `feat(analytics)` `personSet`/`personSetOnce` on `trackEventServer` (server-side person properties).
- `fix(blog)` i18n canonical fix (default locale emits `/blog` not `/en/blog`, matching sitemap) + route loading skeletons.
- `feat(utils)` `getDisplayName` resolver.
- `feat(inngest)` OAuth token-refresh cron (#345-1) — refreshes tokens expiring ~30d; **never clobbers the stored expiry on a transient failure**; skips connections without a refresh_token.

### Verification
- **Independent byte-gate** (fresh, produce-blind): 15/15 PASS (7 logic-bearing test-re-run, incl. the oauth-cron never-clobber-expiry invariant).
- **`/code-review`** (high): 1 HIGH found + fixed — `trackEventServer` placed `$set`/`$set_once` at the capture top level where `posthog-node` silently drops them; now nested inside `properties` (the byte-gate's mocked test gave a false positive; fixed + test corrected). Everything else clean.
- CI locally green: check-types, lint (0 errors), 1535 unit tests (+50 new), production build. Lockfile synced for the new radix deps.

Refs: #250 (page-header iconClassName), #345 (item 1, token-refresh cron).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
