### PR TITLE
feat: Round A opt-in tier — reconnect email, CSP, cookieless, confetti

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -93,6 +93,10 @@ EMAIL_REPLY_TO=support@yourdomain.com
 NEXT_PUBLIC_POSTHOG_KEY=phc_xxxxxxxx
 # PostHog API host (default: https://us.i.posthog.com)
 NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+# Opt-in cookieless mode (default: off). Set to "true" to run PostHog without any
+# cookies / localStorage — no consent banner required. Client-side identify()
+# becomes a no-op; send identified analytics server-side via trackEventServer().
+# NEXT_PUBLIC_POSTHOG_COOKIELESS=true
 
 # LangFuse (Optional - for LLM observability and cost tracking)
 # Get your keys from https://cloud.langfuse.com (sign up for free)

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -17,6 +17,27 @@ const bundleAnalyzer = withBundleAnalyzer({
   enabled: process.env.ANALYZE === 'true',
 });
 
+// CSP in Report-Only mode: it collects violations in the browser console
+// WITHOUT enforcing, so nothing in the UI can break. Inline scripts/eval from
+// your integrations require a soak before enforcing — watch the console (and
+// Sentry) for report-only violations, tighten the allowlist below, then flip to
+// an enforcing `Content-Security-Policy` header in a follow-up. Only the
+// template's actual integrations are allowlisted; add hosts as you adopt them.
+const cspReportOnly = [
+  'default-src \'self\'',
+  // 'unsafe-inline'/'unsafe-eval' are broad on purpose during the soak — narrow
+  // (e.g. to nonces/hashes) before you enforce.
+  'script-src \'self\' \'unsafe-inline\' \'unsafe-eval\' https://*.stripe.com https://js.stripe.com https://*.posthog.com https://*.sentry.io',
+  'style-src \'self\' \'unsafe-inline\' https://fonts.googleapis.com',
+  'img-src \'self\' data: blob: https:',
+  'font-src \'self\' data: https://fonts.gstatic.com',
+  'connect-src \'self\' https://*.supabase.co wss://*.supabase.co https://*.stripe.com https://*.posthog.com https://*.sentry.io',
+  'frame-src \'self\' https://*.stripe.com https://js.stripe.com',
+  'frame-ancestors \'none\'',
+  'base-uri \'self\'',
+  'form-action \'self\' https://*.stripe.com',
+].join('; ');
+
 const securityHeaders = [
   { key: 'X-DNS-Prefetch-Control', value: 'on' },
   { key: 'X-Frame-Options', value: 'DENY' },
@@ -26,6 +47,10 @@ const securityHeaders = [
   {
     key: 'Strict-Transport-Security',
     value: 'max-age=63072000; includeSubDomains; preload',
+  },
+  {
+    key: 'Content-Security-Policy-Report-Only',
+    value: cspReportOnly,
   },
 ];
 

--- a/src/libs/Env.ts
+++ b/src/libs/Env.ts
@@ -76,6 +76,11 @@ export const Env = createEnv({
     NEXT_PUBLIC_DB_SCHEMA: z.string().min(1),
     // Stripe publishable key — optional (billing disabled if unset).
     NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: z.string().optional(),
+    // Opt-in cookieless PostHog: when truthy, PostHog runs in `cookieless_mode`
+    // (no device storage / no consent banner) and client-side `identify()`
+    // becomes a no-op. Off by default — forks keep the standard cookie-based
+    // stance. See src/libs/analytics/providers/posthog.ts.
+    NEXT_PUBLIC_POSTHOG_COOKIELESS: z.string().optional(),
   },
   shared: {
     NODE_ENV: z.enum(['test', 'development', 'production']).optional(),
@@ -123,6 +128,7 @@ export const Env = createEnv({
     NEXT_PUBLIC_DB_SCHEMA: process.env.NEXT_PUBLIC_DB_SCHEMA,
     NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY:
       process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY,
+    NEXT_PUBLIC_POSTHOG_COOKIELESS: process.env.NEXT_PUBLIC_POSTHOG_COOKIELESS,
     NODE_ENV: process.env.NODE_ENV,
   },
 });

--- a/src/libs/analytics/providers/__tests__/posthog.test.ts
+++ b/src/libs/analytics/providers/__tests__/posthog.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { PostHogProvider } from '../posthog';
 
@@ -132,7 +132,10 @@ describe('PostHogProvider', () => {
       await provider.init({ apiKey: 'test', enabled: true });
 
       const eventName = 'signup_completed';
-      const properties = { method: 'email' as const, timestamp: '2024-01-01T00:00:00.000Z' };
+      const properties = {
+        method: 'email' as const,
+        timestamp: '2024-01-01T00:00:00.000Z',
+      };
 
       provider.track(eventName, properties);
 
@@ -149,6 +152,47 @@ describe('PostHogProvider', () => {
       provider.track('signup_completed', { method: 'email' });
 
       expect(mockPosthog.capture).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cookieless mode (opt-in)', () => {
+    const original = process.env.NEXT_PUBLIC_POSTHOG_COOKIELESS;
+
+    afterEach(() => {
+      process.env.NEXT_PUBLIC_POSTHOG_COOKIELESS = original;
+    });
+
+    it('enables cookieless_mode and drops disable_session_recording when flag is truthy', async () => {
+      process.env.NEXT_PUBLIC_POSTHOG_COOKIELESS = 'true';
+
+      await provider.init({ apiKey: 'test', enabled: true });
+
+      const config = mockPosthog.init.mock.calls[0]?.[1];
+
+      expect(config).toMatchObject({ cookieless_mode: 'always' });
+      expect(config).not.toHaveProperty('disable_session_recording');
+    });
+
+    it('makes identify a no-op under cookieless mode', async () => {
+      process.env.NEXT_PUBLIC_POSTHOG_COOKIELESS = '1';
+
+      await provider.init({ apiKey: 'test', enabled: true });
+      provider.identify('user-123', { email: 'test@example.com' });
+
+      expect(mockPosthog.identify).not.toHaveBeenCalled();
+    });
+
+    it('keeps cookie-based behavior when flag is unset', async () => {
+      delete process.env.NEXT_PUBLIC_POSTHOG_COOKIELESS;
+
+      await provider.init({ apiKey: 'test', enabled: true });
+      provider.identify('user-123');
+
+      const config = mockPosthog.init.mock.calls[0]?.[1];
+
+      expect(config).toMatchObject({ disable_session_recording: true });
+      expect(config).not.toHaveProperty('cookieless_mode');
+      expect(mockPosthog.identify).toHaveBeenCalledWith('user-123', undefined);
     });
   });
 

--- a/src/libs/analytics/providers/posthog.ts
+++ b/src/libs/analytics/providers/posthog.ts
@@ -6,11 +6,31 @@
 import type { PostHog } from 'posthog-js';
 
 import type { EventName, EventPropertiesMap } from '../events';
-import type { AnalyticsConfig, AnalyticsProvider, EventProperties, UserProperties } from '../types';
+import type {
+  AnalyticsConfig,
+  AnalyticsProvider,
+  EventProperties,
+  UserProperties,
+} from '../types';
+
+/**
+ * Opt-in cookieless mode. When truthy, PostHog is initialized with
+ * `cookieless_mode: 'always'` (no cookies / localStorage / sessionStorage, so no
+ * consent banner is required — ePrivacy Art. 5(3)), and client-side `identify()`
+ * becomes a no-op. Off by default, so forks keep the standard cookie-based
+ * stance. Identified product analytics must be sent server-side via
+ * `trackEventServer()` (see src/libs/analytics/server.ts).
+ */
+function isCookielessEnabled(): boolean {
+  const flag = process.env.NEXT_PUBLIC_POSTHOG_COOKIELESS;
+
+  return flag === 'true' || flag === '1';
+}
 
 export class PostHogProvider implements AnalyticsProvider {
   private initialized = false;
   private posthogInstance: PostHog | null = null;
+  private cookieless = false;
 
   async init(config: AnalyticsConfig): Promise<void> {
     if (typeof window === 'undefined') {
@@ -21,6 +41,8 @@ export class PostHogProvider implements AnalyticsProvider {
       return;
     }
 
+    this.cookieless = isCookielessEnabled();
+
     const { default: posthog } = await import('posthog-js');
     this.posthogInstance = posthog;
 
@@ -28,12 +50,16 @@ export class PostHogProvider implements AnalyticsProvider {
       api_host: config.apiHost || 'https://us.i.posthog.com',
       loaded: (_posthogInstance) => {
         if (process.env.NODE_ENV === 'development') {
-          // eslint-disable-next-line no-console
+          // eslint-disable-next-line no-console -- dev-only PostHog initialization log
           console.log('[Analytics] PostHog initialized');
         }
       },
       ip: false,
-      disable_session_recording: true,
+      // Cookieless mode counts anonymous users via a rotating server-side hash
+      // instead of device storage; session replay and surveys are unavailable.
+      ...(this.cookieless
+        ? { cookieless_mode: 'always' as const }
+        : { disable_session_recording: true }),
       autocapture: false,
       capture_pageview: false,
       capture_pageleave: true,
@@ -43,7 +69,18 @@ export class PostHogProvider implements AnalyticsProvider {
   }
 
   identify(userId: string, properties?: UserProperties): void {
-    if (typeof window === 'undefined' || !this.initialized || !this.posthogInstance) {
+    if (
+      typeof window === 'undefined'
+      || !this.initialized
+      || !this.posthogInstance
+    ) {
+      return;
+    }
+
+    // No-op under cookieless mode: `posthog.identify()` is disabled (and would
+    // warn) when no device storage is available. Identified analytics are sent
+    // server-side via `trackEventServer()`, keyed by the real user id.
+    if (this.cookieless) {
       return;
     }
 
@@ -54,7 +91,11 @@ export class PostHogProvider implements AnalyticsProvider {
     eventName: T,
     properties?: EventPropertiesMap[T] & EventProperties,
   ): void {
-    if (typeof window === 'undefined' || !this.initialized || !this.posthogInstance) {
+    if (
+      typeof window === 'undefined'
+      || !this.initialized
+      || !this.posthogInstance
+    ) {
       return;
     }
 
@@ -73,7 +114,11 @@ export class PostHogProvider implements AnalyticsProvider {
   }
 
   reset(): void {
-    if (typeof window === 'undefined' || !this.initialized || !this.posthogInstance) {
+    if (
+      typeof window === 'undefined'
+      || !this.initialized
+      || !this.posthogInstance
+    ) {
       return;
     }
 

--- a/src/libs/email/sendReconnectReminderEmail.tsx
+++ b/src/libs/email/sendReconnectReminderEmail.tsx
@@ -1,0 +1,67 @@
+import { render } from '@react-email/render';
+
+import { getBaseUrl } from '@/utils/Helpers';
+
+import { getLifecycleFromAddress } from './config';
+import { sendEmail } from './sendEmail';
+import { sendEmailAsync } from './sendEmailAsync';
+import type { ReconnectDaysRemaining } from './templates/ReconnectReminderEmail';
+import { ReconnectReminderEmail } from './templates/ReconnectReminderEmail';
+
+// Reconnect reminders are notification/nurture emails gated by connection
+// state — use the human-named lifecycle sender. All product/brand copy lives
+// in template props: appName comes from EMAIL_FROM_NAME, platform from the
+// caller, so the template stays provider-neutral.
+function appName(): string {
+  return process.env.EMAIL_FROM_NAME || 'VT SaaS Template';
+}
+
+function subjectForReconnect(
+  platform: string,
+  daysRemaining: ReconnectDaysRemaining,
+): string {
+  return daysRemaining <= 1
+    ? `Your ${platform} connection expires tomorrow`
+    : `Your ${platform} connection expires in ${daysRemaining} days`;
+}
+
+/**
+ * Send a reminder to reconnect an expiring OAuth connection (e.g. T-7 / T-1).
+ * Fire-and-forget — failures are logged but do not block the caller.
+ */
+export function sendReconnectReminderEmail(args: {
+  email: string;
+  name?: string;
+  platform: string;
+  daysRemaining: ReconnectDaysRemaining;
+}): void {
+  const { email, name, platform, daysRemaining } = args;
+  const appUrl = getBaseUrl();
+  const template = (
+    <ReconnectReminderEmail
+      recipientEmail={email}
+      recipientName={name}
+      appName={appName()}
+      appUrl={appUrl}
+      platform={platform}
+      daysRemaining={daysRemaining}
+    />
+  );
+
+  sendEmailAsync(
+    async () => {
+      const text = await render(template, { plainText: true });
+      return sendEmail(email, subjectForReconnect(platform, daysRemaining), template, {
+        from: getLifecycleFromAddress(),
+        text,
+        tags: [
+          { name: 'type', value: 'reconnect_reminder' },
+          { name: 'platform', value: platform },
+          { name: 'days_remaining', value: String(daysRemaining) },
+        ],
+        emailType: 'reconnect_reminder',
+      });
+    },
+    { emailType: 'reconnect_reminder', recipientHint: email },
+  );
+}

--- a/src/libs/email/templates/ReconnectReminderEmail.tsx
+++ b/src/libs/email/templates/ReconnectReminderEmail.tsx
@@ -1,0 +1,63 @@
+import type { ReconnectDaysRemaining, ReconnectReminderEmailData } from '../types';
+import {
+  EmailButton,
+  EmailHeading,
+  EmailLayout,
+  EmailText,
+} from './EmailLayout';
+import { safeGreeting } from './helpers';
+
+export type { ReconnectDaysRemaining } from '../types';
+
+type ReconnectReminderEmailProps = ReconnectReminderEmailData;
+
+/** Human phrase for the countdown, e.g. "tomorrow" or "in 7 days". */
+function whenLabel(daysRemaining: ReconnectDaysRemaining): string {
+  if (daysRemaining <= 1) {
+    return 'tomorrow';
+  }
+  return `in ${daysRemaining} days`;
+}
+
+function copy(platform: string, daysRemaining: ReconnectDaysRemaining) {
+  const when = whenLabel(daysRemaining);
+  return {
+    preview: `Reconnect ${platform} to keep your integrations working`,
+    heading: daysRemaining <= 1
+      ? `Your ${platform} connection expires tomorrow`
+      : `Your ${platform} connection expires in ${daysRemaining} days`,
+    body: `Your ${platform} connection expires ${when}. Reconnect to keep your integrations working — it only takes a few seconds.`,
+    cta: `Reconnect ${platform}`,
+  };
+}
+
+export function ReconnectReminderEmail(props: ReconnectReminderEmailProps) {
+  const { recipientName, appUrl, appName, platform, daysRemaining } = props;
+  const c = copy(platform, daysRemaining);
+  const connectionsUrl = `${appUrl}/connections`;
+
+  return (
+    <EmailLayout
+      previewText={c.preview}
+      appUrl={appUrl}
+      brandName={appName}
+      includePreferencesLink
+    >
+      <EmailHeading>{c.heading}</EmailHeading>
+      <EmailText>{safeGreeting(recipientName)}</EmailText>
+      <EmailText>{c.body}</EmailText>
+      <EmailButton href={connectionsUrl}>{c.cta}</EmailButton>
+    </EmailLayout>
+  );
+}
+
+ReconnectReminderEmail.PreviewProps = {
+  recipientEmail: 'preview@example.com',
+  recipientName: 'Alex',
+  appName: 'VT SaaS Template',
+  appUrl: 'https://example.com',
+  platform: 'Acme',
+  daysRemaining: 7,
+} satisfies ReconnectReminderEmailProps;
+
+export default ReconnectReminderEmail;

--- a/src/libs/email/templates/reconnect-emails.test.tsx
+++ b/src/libs/email/templates/reconnect-emails.test.tsx
@@ -1,0 +1,41 @@
+/* eslint-disable testing-library/render-result-naming-convention -- uses @react-email/render, not @testing-library */
+import { render } from '@react-email/render';
+import { describe, expect, it } from 'vitest';
+
+import { ReconnectReminderEmail } from './ReconnectReminderEmail';
+
+// Render to plain text so JSX whitespace expressions ({' '}) collapse into real
+// spaces. The plain-text renderer uppercases headings, so heading assertions are
+// case-insensitive. This template carries no hardcoded product copy — the brand
+// (appName) and connection label (platform) come from props.
+
+describe('ReconnectReminderEmail template', () => {
+  it('renders the platform label from props, not a hardcoded provider', async () => {
+    const text = await render(
+      <ReconnectReminderEmail {...ReconnectReminderEmail.PreviewProps} platform="Acme" />,
+      { plainText: true },
+    );
+
+    expect(text).toContain('Acme');
+    expect(text).toMatch(/Reconnect Acme/i);
+    expect(text).not.toMatch(/LinkedIn|ContentFlow/i);
+  });
+
+  it('renders the multi-day countdown for a T-7 reminder', async () => {
+    const text = await render(
+      <ReconnectReminderEmail {...ReconnectReminderEmail.PreviewProps} daysRemaining={7} />,
+      { plainText: true },
+    );
+
+    expect(text).toMatch(/expires in 7 days/i);
+  });
+
+  it('renders the "tomorrow" copy for a T-1 reminder', async () => {
+    const text = await render(
+      <ReconnectReminderEmail {...ReconnectReminderEmail.PreviewProps} daysRemaining={1} />,
+      { plainText: true },
+    );
+
+    expect(text).toMatch(/expires tomorrow/i);
+  });
+});

--- a/src/libs/email/types.ts
+++ b/src/libs/email/types.ts
@@ -122,3 +122,23 @@ export type PromotionGrantedEmailData = BaseTemplateData & {
   /** ISO date string for when the promotional access ends. */
   expiresAt: string;
 };
+
+/**
+ * Whole number of days until an OAuth connection expires. Common reminder
+ * cadences are T-7 (a week out) and T-1 (last nudge), but any positive value
+ * renders — the copy adapts to "in N days" / "tomorrow".
+ */
+export type ReconnectDaysRemaining = number;
+
+/**
+ * Reconnect-reminder email template data. Platform-neutral: the `platform`
+ * label (e.g. the third-party service name) comes from the caller, so the
+ * template carries no provider-specific copy.
+ */
+export type ReconnectReminderEmailData = BaseTemplateData & {
+  appUrl: string;
+  appName: string;
+  /** Human label for the expiring connection (e.g. the provider name). */
+  platform: string;
+  daysRemaining: ReconnectDaysRemaining;
+};

--- a/src/libs/hooks/use-confetti.ts
+++ b/src/libs/hooks/use-confetti.ts
@@ -1,0 +1,59 @@
+'use client';
+
+// Celebration hook exposing fireMini/fireBig. `canvas-confetti` is an OPTIONAL
+// peer dependency loaded lazily on first fire — if it's not installed the import
+// fails soft and nothing happens. A fork that wants confetti runs:
+//   npm i canvas-confetti
+import { useCallback, useRef } from 'react';
+
+// Minimal local type so we don't depend on `@types/canvas-confetti` being present.
+type ConfettiOptions = {
+  particleCount?: number;
+  spread?: number;
+  origin?: { x?: number; y?: number };
+  scalar?: number;
+  ticks?: number;
+};
+
+type ConfettiFn = (options?: ConfettiOptions) => Promise<undefined> | null;
+
+export function useConfetti() {
+  const confettiRef = useRef<ConfettiFn | null>(null);
+
+  const loadConfetti = useCallback(async (): Promise<ConfettiFn | null> => {
+    if (!confettiRef.current) {
+      try {
+        // @ts-expect-error optional peer dep -- canvas-confetti may not be installed; fails soft
+        const mod = await import('canvas-confetti');
+        confettiRef.current = mod.default as unknown as ConfettiFn;
+      } catch {
+        return null;
+      }
+    }
+    return confettiRef.current;
+  }, []);
+
+  const fireMini = useCallback(async () => {
+    const confetti = await loadConfetti();
+    confetti?.({
+      particleCount: 40,
+      spread: 55,
+      origin: { y: 0.7 },
+      scalar: 0.8,
+      ticks: 100,
+    });
+  }, [loadConfetti]);
+
+  const fireBig = useCallback(async () => {
+    const confetti = await loadConfetti();
+    if (!confetti) {
+      return;
+    }
+    confetti({ particleCount: 80, spread: 100, origin: { x: 0.3, y: 0.6 } });
+    setTimeout(() => {
+      confetti({ particleCount: 80, spread: 100, origin: { x: 0.7, y: 0.6 } });
+    }, 200);
+  }, [loadConfetti]);
+
+  return { fireMini, fireBig };
+}


### PR DESCRIPTION
## Round A · Opt-in tier — ContentFlow → template upstream contribution

4 opt-in/gated improvements (each additive; nothing forced on forks). *(multi-theme-system split to a separate PR — it's visual and needs a screenshot check.)*

| Change | Gating |
|--------|--------|
| `feat(email)` OAuth reconnect-reminder email + sender | Built on the template's EmailLayout primitives; generalized `platform: string`, `appName` from `EMAIL_FROM_NAME`, neutral copy. Inngest cron NOT ported. Opt-in infra a fork wires to its `/connections` route. |
| `feat(security)` Content-Security-Policy-**Report-Only** header | Ships **inert** (report-only, never enforcing) so no fork UI breaks; allowlist = template integrations only (self/supabase/sentry/stripe/posthog). Soak, then a fork narrows + flips to enforcing. |
| `feat(analytics)` opt-in cookieless PostHog | Behind **optional** `NEXT_PUBLIC_POSTHOG_COOKIELESS` (default off). When off: byte-identical current behavior. When on: `cookieless_mode:'always'` + no-op identify (analytics go server-side). |
| `feat(hooks)` lazy `use-confetti` | `canvas-confetti` is an **optional peer** (NOT in package.json); dynamic import fails soft. Forks that want it run `npm i canvas-confetti`. |

### Verification
- **Independent byte-gate** (produce-blind): 4/4 PASS — CSP got a security lens (Report-Only, no weakened headers, sane allowlist), cookieless env confirmed optional, confetti confirmed fail-soft.
- **`/code-review`** (correctness + security): **no defects**. Cookieless is a no-op when unset; CSP well-formed & additive; email renders correctly.
- CI locally green: check-types, lint (0 errors), 143 email/analytics tests, production build.

New env var: `NEXT_PUBLIC_POSTHOG_COOKIELESS` (optional, default off). Refs: #345 (reconnect email).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
