### PR TITLE
feat(admin): tier-grant dialog wired into user detail

### DIFF
--- a/src/components/admin/AssignTierDialog.tsx
+++ b/src/components/admin/AssignTierDialog.tsx
@@ -1,0 +1,336 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useQuery } from '@tanstack/react-query';
+import { Loader2 } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { useEffect, useTransition } from 'react';
+import { useForm } from 'react-hook-form';
+import { toast } from 'sonner';
+import { z } from 'zod';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+import type { ActiveTier } from '@/libs/actions/subscriptions';
+import { assignTier, getActiveTiers } from '@/libs/actions/subscriptions';
+import { useUserSubscriptionDetail } from '@/libs/hooks/use-user-subscription-detail';
+
+// Tier slugs the promotion-eligibility guard keys off — must match the server
+// action's PROMO_TIER_NAME / PAID_TIER_NAMES (see libs/actions/subscriptions.ts).
+// The template ships generic 'free' / 'pro' / 'promotion' slugs; a fork keeps
+// the slugs and only re-skins the display copy.
+const PROMO_TIER_NAME = 'promotion';
+const PAID_TIER_NAMES = ['pro'];
+
+// Client-side form schema (trialExpiresAt is a date string, not ISO datetime).
+const assignTierFormSchema = z.object({
+  tierId: z.string().uuid('Tier is required'),
+  status: z.enum(['active', 'trial', 'expired', 'cancelled']),
+  trialExpiresAt: z.string().optional(),
+  expiresAt: z.string().optional(),
+  reason: z.string().max(500).optional(),
+}).refine(
+  data => !(data.status === 'trial' && !data.trialExpiresAt),
+  { message: 'Trial expiry date is required when status is trial', path: ['trialExpiresAt'] },
+);
+
+type AssignTierFormValues = z.infer<typeof assignTierFormSchema>;
+
+type AssignTierDialogProps = {
+  userId: string;
+  userEmail: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSaved: () => void;
+};
+
+export function AssignTierDialog({
+  userId,
+  userEmail,
+  open,
+  onOpenChange,
+  onSaved,
+}: AssignTierDialogProps) {
+  const t = useTranslations('Admin.AssignTier');
+  const [isPending, startTransition] = useTransition();
+
+  // Fetch tiers for the dropdown.
+  const { data: tiers } = useQuery<ActiveTier[]>({
+    queryKey: ['active-tiers'],
+    queryFn: async () => {
+      const result = await getActiveTiers();
+      if (result.error) {
+        throw new Error(result.error.message);
+      }
+      return result.data;
+    },
+    staleTime: 60_000,
+  });
+
+  // Fetch the current subscription to pre-fill the form.
+  const { data: subscriptionDetail } = useUserSubscriptionDetail(open ? userId : null);
+
+  const form = useForm<AssignTierFormValues>({
+    resolver: zodResolver(assignTierFormSchema),
+    defaultValues: {
+      tierId: '',
+      status: 'active',
+      trialExpiresAt: '',
+      expiresAt: '',
+      reason: '',
+    },
+  });
+
+  const watchedStatus = form.watch('status');
+  const watchedTierId = form.watch('tierId');
+  const selectedTier = tiers?.find(tier => tier.id === watchedTierId);
+  const isPromotionTier = selectedTier?.name === PROMO_TIER_NAME;
+  const currentTierName = subscriptionDetail?.tierName;
+  // Promotion can only be granted to free or trial users — not active paid users.
+  const cannotGrantPromotion
+    = isPromotionTier
+      && !!currentTierName
+      && PAID_TIER_NAMES.includes(currentTierName)
+      && subscriptionDetail?.status === 'active';
+
+  // Pre-fill the form when subscription data loads.
+  useEffect(() => {
+    if (open && subscriptionDetail) {
+      // Default promotion expiry: 1 month from today.
+      const defaultExpiresAt = new Date();
+      defaultExpiresAt.setMonth(defaultExpiresAt.getMonth() + 1);
+
+      form.reset({
+        tierId: subscriptionDetail.tierId,
+        status: subscriptionDetail.status,
+        trialExpiresAt: subscriptionDetail.trialExpiresAt
+          ? new Date(subscriptionDetail.trialExpiresAt).toISOString().slice(0, 10)
+          : '',
+        expiresAt: subscriptionDetail.expiresAt
+          ? new Date(subscriptionDetail.expiresAt).toISOString().slice(0, 10)
+          : defaultExpiresAt.toISOString().slice(0, 10),
+        reason: '',
+      });
+    }
+  }, [open, subscriptionDetail, form]);
+
+  const onSubmit = (data: AssignTierFormValues) => {
+    startTransition(async () => {
+      // Convert date strings to ISO datetimes for the server action.
+      const trialExpiresAt = data.status === 'trial' && data.trialExpiresAt
+        ? new Date(`${data.trialExpiresAt}T23:59:59.999Z`).toISOString()
+        : null;
+
+      const expiresAt = isPromotionTier && data.expiresAt
+        ? new Date(`${data.expiresAt}T23:59:59.999Z`).toISOString()
+        : null;
+
+      const result = await assignTier({
+        userId,
+        tierId: data.tierId,
+        status: data.status,
+        trialExpiresAt,
+        expiresAt,
+        reason: data.reason || undefined,
+      });
+
+      if (result.error) {
+        toast.error(result.error.message);
+        return;
+      }
+
+      toast.success(t('success'));
+      onSaved();
+      onOpenChange(false);
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[450px]" data-testid="assign-tier-dialog">
+        <DialogHeader>
+          <DialogTitle>{t('title', { email: userEmail })}</DialogTitle>
+          <DialogDescription className="sr-only">
+            {t('description')}
+          </DialogDescription>
+        </DialogHeader>
+
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            {/* Tier Select */}
+            <FormField
+              control={form.control}
+              name="tierId"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t('fields.tier')}</FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormControl>
+                      <SelectTrigger data-testid="tier-select">
+                        <SelectValue placeholder={t('placeholders.tier')} />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {tiers?.map(tier => (
+                        <SelectItem key={tier.id} value={tier.id}>
+                          {tier.displayName}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Status Select */}
+            <FormField
+              control={form.control}
+              name="status"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t('fields.status')}</FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormControl>
+                      <SelectTrigger data-testid="status-select">
+                        <SelectValue placeholder={t('placeholders.status')} />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="active">{t('statuses.active')}</SelectItem>
+                      <SelectItem value="trial">{t('statuses.trial')}</SelectItem>
+                      <SelectItem value="expired">{t('statuses.expired')}</SelectItem>
+                      <SelectItem value="cancelled">{t('statuses.cancelled')}</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Trial Expiry Date — shown only when status is trial. */}
+            {watchedStatus === 'trial' && (
+              <FormField
+                control={form.control}
+                name="trialExpiresAt"
+                render={({ field: { ref: _ref, ...field } }) => (
+                  <FormItem>
+                    <FormLabel>{t('fields.trialExpiry')}</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="date"
+                        min={new Date().toISOString().slice(0, 10)}
+                        {...field}
+                        data-testid="trial-expiry-input"
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            )}
+
+            {/* Promotion End Date — shown only when a promotion tier is active. */}
+            {isPromotionTier && watchedStatus === 'active' && (
+              <FormField
+                control={form.control}
+                name="expiresAt"
+                render={({ field: { ref: _ref, ...field } }) => (
+                  <FormItem>
+                    <FormLabel>{t('fields.promotionEnd')}</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="date"
+                        min={new Date().toISOString().slice(0, 10)}
+                        {...field}
+                        data-testid="expires-at-input"
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            )}
+
+            {cannotGrantPromotion && (
+              <p className="text-sm text-destructive" role="alert" data-testid="promotion-eligibility-warning">
+                {t('promotionEligibilityWarning')}
+              </p>
+            )}
+
+            {/* Reason */}
+            <FormField
+              control={form.control}
+              name="reason"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    {t('fields.reason')}
+                    <span className="ml-1 text-xs text-muted-foreground">{t('fields.reasonHint')}</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder={t('placeholders.reason')}
+                      maxLength={500}
+                      rows={2}
+                      name={field.name}
+                      value={field.value ?? ''}
+                      onChange={field.onChange}
+                      onBlur={field.onBlur}
+                      disabled={field.disabled}
+                      data-testid="reason-textarea"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={isPending}
+              >
+                {t('cancel')}
+              </Button>
+              <Button
+                type="submit"
+                disabled={isPending || cannotGrantPromotion}
+                data-testid="assign-tier-submit"
+              >
+                {isPending && <Loader2 className="mr-2 size-4 animate-spin" />}
+                {t('assign')}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/admin/BulkPromotionInviteDialog.tsx
+++ b/src/components/admin/BulkPromotionInviteDialog.tsx
@@ -1,0 +1,335 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useQuery } from '@tanstack/react-query';
+import { Loader2 } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { useCallback, useEffect, useState, useTransition } from 'react';
+import { useForm } from 'react-hook-form';
+import { toast } from 'sonner';
+import { z } from 'zod';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+import type { ActiveTier } from '@/libs/actions/subscriptions';
+import { bulkAssignTier, getActiveTiers } from '@/libs/actions/subscriptions';
+
+// Must match the server action's PROMO_TIER_NAME (libs/actions/subscriptions.ts).
+const PROMO_TIER_NAME = 'promotion';
+
+// Client-side form schema. A single `expiryDate` field maps to either
+// `trialExpiresAt` or `expiresAt` at submit time based on tier + status.
+const bulkAssignFormSchema = z.object({
+  emailsRaw: z.string().min(1, 'At least one email is required').max(10_000),
+  tierId: z.string().uuid('Tier is required'),
+  status: z.enum(['active', 'trial']),
+  expiryDate: z.string().optional(),
+});
+
+type BulkAssignFormValues = z.infer<typeof bulkAssignFormSchema>;
+
+type BulkPromotionInviteDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+export function BulkPromotionInviteDialog({
+  open,
+  onOpenChange,
+}: BulkPromotionInviteDialogProps) {
+  const t = useTranslations('Admin.BulkAssign');
+  const [isPending, startTransition] = useTransition();
+  const [phase, setPhase] = useState<'form' | 'results'>('form');
+  const [results, setResults] = useState<{ updated: string[]; not_found: string[] } | null>(null);
+
+  // Fetch tiers for the dropdown.
+  const { data: tiers } = useQuery<ActiveTier[]>({
+    queryKey: ['active-tiers'],
+    queryFn: async () => {
+      const result = await getActiveTiers();
+      if (result.error) {
+        throw new Error(result.error.message);
+      }
+      return result.data;
+    },
+    staleTime: 60_000,
+  });
+
+  // Find the promotion tier id for the default selection.
+  const promotionTierId = tiers?.find(tier => tier.name === PROMO_TIER_NAME)?.id ?? '';
+
+  const form = useForm<BulkAssignFormValues>({
+    resolver: zodResolver(bulkAssignFormSchema),
+    defaultValues: {
+      emailsRaw: '',
+      tierId: '',
+      status: 'trial',
+      expiryDate: '',
+    },
+  });
+
+  const watchedStatus = form.watch('status');
+  const watchedTierId = form.watch('tierId');
+  const selectedTier = tiers?.find(tier => tier.id === watchedTierId);
+  const isPromotionTier = selectedTier?.name === PROMO_TIER_NAME;
+  // The expiry field is required when:
+  //   - status='trial' (any tier)            → maps to trial_expires_at
+  //   - tier='promotion' AND status='active' → maps to expires_at
+  const showExpiryField = watchedStatus === 'trial' || (isPromotionTier && watchedStatus === 'active');
+  const expiryFieldLabel = watchedStatus === 'trial' ? t('fields.trialExpiry') : t('fields.promotionEnd');
+
+  // Default to the promotion tier once tiers load.
+  useEffect(() => {
+    if (promotionTierId && !form.getValues('tierId')) {
+      form.setValue('tierId', promotionTierId);
+    }
+  }, [promotionTierId, form]);
+
+  // Reset on dialog close.
+  const handleOpenChange = useCallback((newOpen: boolean) => {
+    if (!newOpen) {
+      setPhase('form');
+      setResults(null);
+      form.reset({
+        emailsRaw: '',
+        tierId: promotionTierId || '',
+        status: 'trial',
+        expiryDate: '',
+      });
+    }
+    onOpenChange(newOpen);
+  }, [onOpenChange, form, promotionTierId]);
+
+  const onSubmit = (data: BulkAssignFormValues) => {
+    // Client-side guard for the conditional expiry field. Server re-validates.
+    const tierName = tiers?.find(tier => tier.id === data.tierId)?.name;
+    const expiryRequired = data.status === 'trial' || (tierName === PROMO_TIER_NAME && data.status === 'active');
+    if (expiryRequired && !data.expiryDate) {
+      form.setError('expiryDate', {
+        message: data.status === 'trial'
+          ? 'Trial expiry date is required when status is trial'
+          : 'Promotion end date is required',
+      });
+      return;
+    }
+
+    startTransition(async () => {
+      const isoDateTime = data.expiryDate
+        ? new Date(`${data.expiryDate}T23:59:59.999Z`).toISOString()
+        : null;
+
+      const result = await bulkAssignTier({
+        emailsRaw: data.emailsRaw,
+        tierId: data.tierId,
+        status: data.status,
+        // Trial expiry vs promotion expiry route to different DB columns.
+        trialExpiresAt: data.status === 'trial' ? isoDateTime : null,
+        expiresAt: tierName === PROMO_TIER_NAME && data.status === 'active' ? isoDateTime : null,
+      });
+
+      if (result.error) {
+        toast.error(result.error.message);
+        return;
+      }
+
+      setResults(result.data);
+      setPhase('results');
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-[500px]" data-testid="bulk-assign-dialog">
+        <DialogHeader>
+          <DialogTitle>{t('title')}</DialogTitle>
+          <DialogDescription className="sr-only">
+            {t('description')}
+          </DialogDescription>
+        </DialogHeader>
+
+        {phase === 'form'
+          ? (
+              <Form {...form}>
+                <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+                  {/* Emails Textarea */}
+                  <FormField
+                    control={form.control}
+                    name="emailsRaw"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t('fields.emails')}</FormLabel>
+                        <FormControl>
+                          <Textarea
+                            placeholder={t('placeholders.emails')}
+                            rows={6}
+                            maxLength={10_000}
+                            name={field.name}
+                            value={field.value}
+                            onChange={field.onChange}
+                            onBlur={field.onBlur}
+                            disabled={field.disabled}
+                            data-testid="emails-textarea"
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  {/* Tier Select */}
+                  <FormField
+                    control={form.control}
+                    name="tierId"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t('fields.tier')}</FormLabel>
+                        <Select onValueChange={field.onChange} value={field.value}>
+                          <FormControl>
+                            <SelectTrigger data-testid="bulk-tier-select">
+                              <SelectValue placeholder={t('placeholders.tier')} />
+                            </SelectTrigger>
+                          </FormControl>
+                          <SelectContent>
+                            {tiers?.map(tier => (
+                              <SelectItem key={tier.id} value={tier.id}>
+                                {tier.displayName}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  {/* Status Select */}
+                  <FormField
+                    control={form.control}
+                    name="status"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t('fields.status')}</FormLabel>
+                        <Select onValueChange={field.onChange} value={field.value}>
+                          <FormControl>
+                            <SelectTrigger data-testid="bulk-status-select">
+                              <SelectValue placeholder={t('placeholders.status')} />
+                            </SelectTrigger>
+                          </FormControl>
+                          <SelectContent>
+                            <SelectItem value="active">{t('statuses.active')}</SelectItem>
+                            <SelectItem value="trial">{t('statuses.trial')}</SelectItem>
+                          </SelectContent>
+                        </Select>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  {/* Expiry date — for trial (any tier) or active + promotion. */}
+                  {showExpiryField && (
+                    <FormField
+                      control={form.control}
+                      name="expiryDate"
+                      render={({ field: { ref: _ref, ...field } }) => (
+                        <FormItem>
+                          <FormLabel>{expiryFieldLabel}</FormLabel>
+                          <FormControl>
+                            <Input
+                              type="date"
+                              min={new Date().toISOString().slice(0, 10)}
+                              {...field}
+                              data-testid="bulk-trial-expiry-input"
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                  )}
+
+                  <p className="text-xs text-muted-foreground">
+                    {t('notFoundHint')}
+                  </p>
+
+                  <DialogFooter>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={() => handleOpenChange(false)}
+                      disabled={isPending}
+                    >
+                      {t('cancel')}
+                    </Button>
+                    <Button type="submit" disabled={isPending} data-testid="bulk-assign-submit">
+                      {isPending && <Loader2 className="mr-2 size-4 animate-spin" />}
+                      {t('assign')}
+                    </Button>
+                  </DialogFooter>
+                </form>
+              </Form>
+            )
+          : (
+              <div className="space-y-4">
+                {/* Results */}
+                {results && results.updated.length > 0 && (
+                  <section className="space-y-2">
+                    <Badge variant="active">
+                      {t('results.updated', { count: results.updated.length })}
+                    </Badge>
+                    <ul className="max-h-40 space-y-1 overflow-y-auto text-sm" data-testid="updated-emails-list">
+                      {results.updated.map(email => (
+                        <li key={email}>{email}</li>
+                      ))}
+                    </ul>
+                  </section>
+                )}
+
+                {results && results.not_found.length > 0 && (
+                  <section className="space-y-2">
+                    <Badge variant="secondary">
+                      {t('results.notFound', { count: results.not_found.length })}
+                    </Badge>
+                    <ul className="max-h-40 space-y-1 overflow-y-auto text-sm text-muted-foreground" data-testid="not-found-emails-list">
+                      {results.not_found.map(email => (
+                        <li key={email}>{email}</li>
+                      ))}
+                    </ul>
+                  </section>
+                )}
+
+                <DialogFooter>
+                  <Button onClick={() => handleOpenChange(false)} data-testid="bulk-assign-done">
+                    {t('done')}
+                  </Button>
+                </DialogFooter>
+              </div>
+            )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/admin/UserDetailDialog.tsx
+++ b/src/components/admin/UserDetailDialog.tsx
@@ -1,15 +1,19 @@
 'use client';
 
 import type { User } from '@supabase/supabase-js';
+import { useQueryClient } from '@tanstack/react-query';
 import { format, formatDistanceToNow } from 'date-fns';
 import {
   AlertTriangle,
   Ban,
   CheckCircle,
+  CreditCard,
   Key,
+  RefreshCw,
   Settings,
   Trash2,
   User as UserIcon,
+  UserCog,
 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useState } from 'react';
@@ -26,11 +30,21 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Separator } from '@/components/ui/separator';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useUserSubscriptionDetail } from '@/libs/hooks/use-user-subscription-detail';
 import { getUserInitials, getUserStatus } from '@/libs/queries/userUtils';
 
+import { AssignTierDialog } from './AssignTierDialog';
 import { DeleteUserDialog } from './DeleteUserDialog';
 import { ResetPasswordDialog } from './ResetPasswordDialog';
 import { SuspendUserDialog } from './SuspendUserDialog';
+
+// Promotion tier slug — matches the server action's PROMO_TIER_NAME so the tier
+// badge highlights promo grants without hardcoding product-specific copy.
+const PROMO_TIER_NAME = 'promotion';
+
+// Moved to module scope to satisfy e18e/prefer-static-regex.
+const WHITESPACE_REGEX = /\s+/g;
 
 type UserDetailDialogProps = {
   user: User | null;
@@ -48,14 +62,16 @@ export function UserDetailDialog({
   onUserUpdated,
 }: UserDetailDialogProps) {
   const t = useTranslations('Admin.UserDetail');
+  const queryClient = useQueryClient();
   const [showSuspendDialog, setShowSuspendDialog] = useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [showResetDialog, setShowResetDialog] = useState(false);
+  const [showAssignTierDialog, setShowAssignTierDialog] = useState(false);
 
-  // Internal state to track user data after actions
+  // Internal state to track user data after actions.
   const [localUser, setLocalUser] = useState<User | null>(null);
 
-  // Use localUser if available (after an action), otherwise use prop
+  // Use localUser if available (after an action), otherwise use prop.
   const displayUser = localUser ?? user;
 
   if (!displayUser) {
@@ -66,7 +82,7 @@ export function UserDetailDialog({
   const userStatus = getUserStatus(displayUser);
   const isSuspended = userStatus === 'suspended';
 
-  // Reset local state when dialog closes
+  // Reset local state when dialog closes.
   const handleOpenChange = (newOpen: boolean) => {
     if (!newOpen) {
       setLocalUser(null);
@@ -74,7 +90,7 @@ export function UserDetailDialog({
     onOpenChange(newOpen);
   };
 
-  // Handle user updated from child dialogs
+  // Handle user updated from child dialogs.
   const handleUserUpdated = (updatedUser?: User) => {
     if (updatedUser) {
       setLocalUser(updatedUser);
@@ -82,7 +98,7 @@ export function UserDetailDialog({
     onUserUpdated();
   };
 
-  // Handle user deleted - close dialog and notify parent
+  // Handle user deleted - close dialog and notify parent.
   const handleUserDeleted = () => {
     handleOpenChange(false);
     onUserUpdated();
@@ -91,7 +107,7 @@ export function UserDetailDialog({
   return (
     <>
       <Dialog open={open} onOpenChange={handleOpenChange}>
-        <DialogContent className="sm:max-w-[500px]" data-testid="user-detail-dialog">
+        <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[500px]" data-testid="user-detail-dialog">
           <DialogHeader>
             <DialogTitle>{t('title')}</DialogTitle>
             <DialogDescription className="sr-only">
@@ -186,6 +202,30 @@ export function UserDetailDialog({
 
             <Separator />
 
+            {/* Subscription Section */}
+            <div className="space-y-4">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2 text-sm font-semibold">
+                  <CreditCard className="size-4" />
+                  {t('sections.subscription')}
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setShowAssignTierDialog(true)}
+                  className="gap-1"
+                  data-testid="open-assign-tier"
+                >
+                  <UserCog className="size-3.5" />
+                  {t('actions.assignTier')}
+                </Button>
+              </div>
+
+              <SubscriptionDetailGrid userId={displayUser.id} />
+            </div>
+
+            <Separator />
+
             {/* Actions Section */}
             <div className="space-y-3">
               <div className="flex items-center gap-2 text-sm font-semibold">
@@ -266,11 +306,122 @@ export function UserDetailDialog({
         open={showResetDialog}
         onOpenChange={setShowResetDialog}
       />
+
+      <AssignTierDialog
+        userId={displayUser.id}
+        userEmail={displayUser.email ?? ''}
+        open={showAssignTierDialog}
+        onOpenChange={setShowAssignTierDialog}
+        onSaved={() => {
+          queryClient.invalidateQueries({ queryKey: ['user-subscription-detail', displayUser.id] });
+          handleUserUpdated();
+        }}
+      />
     </>
   );
 }
 
-// Info row component for displaying key-value pairs
+// --- Subscription Detail Grid Sub-Component ---
+
+function SubscriptionDetailGrid({ userId }: { userId: string }) {
+  const t = useTranslations('Admin.UserDetail');
+  const { data, isLoading, error, refetch } = useUserSubscriptionDetail(userId);
+
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-2 gap-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="flex flex-col gap-1">
+            <Skeleton className="h-3 w-16" />
+            <Skeleton className="h-5 w-24" />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-destructive">
+        <span>{t('subscription.loadError')}</span>
+        <Button variant="ghost" size="sm" onClick={() => refetch()} className="gap-1">
+          <RefreshCw className="size-3" />
+          {t('subscription.retry')}
+        </Button>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <p className="text-sm text-muted-foreground">{t('subscription.noRecord')}</p>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      {/* Current Tier */}
+      <InfoRow
+        label={t('fields.currentTier')}
+        value={<TierBadge tierName={data.tierName} displayName={data.displayName} />}
+      />
+
+      {/* Status */}
+      <InfoRow
+        label={t('fields.subscriptionStatus')}
+        value={<StatusBadge status={data.status} />}
+      />
+
+      {/* Trial Expires */}
+      <InfoRow
+        label={t('fields.trialExpires')}
+        value={
+          data.trialExpiresAt
+            ? format(new Date(data.trialExpiresAt), 'MMM d, yyyy')
+            : '–'
+        }
+      />
+
+      {/* Plan Expires (promotion / paid window) */}
+      <InfoRow
+        label={t('fields.expiresAt')}
+        value={
+          data.expiresAt
+            ? format(new Date(data.expiresAt), 'MMM d, yyyy')
+            : '–'
+        }
+      />
+    </div>
+  );
+}
+
+// --- Badge Helper Components ---
+
+function TierBadge({ tierName, displayName }: { tierName: string; displayName: string }) {
+  if (tierName === PROMO_TIER_NAME) {
+    return <Badge variant="pending">{displayName}</Badge>;
+  }
+  if (tierName === 'free') {
+    return <Badge variant="secondary">{displayName}</Badge>;
+  }
+  // Any paid tier ('pro', etc.).
+  return <Badge variant="default">{displayName}</Badge>;
+}
+
+function StatusBadge({ status }: { status: string }) {
+  switch (status) {
+    case 'active':
+      return <Badge variant="active">{status}</Badge>;
+    case 'trial':
+      return <Badge variant="pending">{status}</Badge>;
+    case 'expired':
+      return <Badge variant="destructive">{status}</Badge>;
+    default:
+      return <Badge variant="secondary">{status}</Badge>;
+  }
+}
+
+// Info row component for displaying key-value pairs.
 function InfoRow({ label, value }: { label: string; value: React.ReactNode }) {
   return (
     <div className="flex flex-col gap-1">
@@ -286,7 +437,7 @@ function InfoRow({ label, value }: { label: string; value: React.ReactNode }) {
   );
 }
 
-// Action button component for user actions
+// Action button component for user actions.
 type ActionButtonProps = {
   icon: React.ReactNode;
   iconBgClassName: string;
@@ -316,7 +467,7 @@ function ActionButton({
         ${variant === 'danger' ? 'border-destructive hover:bg-destructive/10' : 'hover:bg-muted'}
         ${disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'}
       `}
-      data-testid={`action-${title.toLowerCase().replace(/\s+/g, '-')}`}
+      data-testid={`action-${title.toLowerCase().replace(WHITESPACE_REGEX, '-')}`}
     >
       <div className={`flex size-9 items-center justify-center rounded-md ${iconBgClassName}`}>
         {icon}

--- a/src/components/admin/__tests__/AssignTierDialog.test.tsx
+++ b/src/components/admin/__tests__/AssignTierDialog.test.tsx
@@ -1,0 +1,157 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Suppress the radix-ui Dialog warning about a missing aria description.
+let originalWarn: typeof console.warn;
+
+beforeAll(() => {
+  originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    if (typeof args[0] === 'string' && args[0].includes('Missing `Description`')) {
+      return;
+    }
+    originalWarn(...args);
+  };
+});
+
+afterAll(() => {
+  console.warn = originalWarn;
+});
+
+// Mock next-intl — echo the key back (params interpolated) so assertions can key
+// off the translation path.
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string, params?: Record<string, unknown>) => {
+    if (params) {
+      let result = key;
+      Object.entries(params).forEach(([k, v]) => {
+        result = result.replace(`{${k}}`, String(v));
+      });
+      return result;
+    }
+    return key;
+  },
+}));
+
+// sonner toasts.
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+vi.mock('sonner', () => ({
+  toast: { success: (...a: unknown[]) => toastSuccess(...a), error: (...a: unknown[]) => toastError(...a) },
+}));
+
+// Server actions seam.
+const assignTier = vi.fn();
+const getActiveTiers = vi.fn();
+vi.mock('@/libs/actions/subscriptions', () => ({
+  assignTier: (...a: unknown[]) => assignTier(...a),
+  getActiveTiers: (...a: unknown[]) => getActiveTiers(...a),
+}));
+
+// Subscription-detail hook seam — controls the pre-fill + eligibility state.
+const useUserSubscriptionDetail = vi.fn();
+vi.mock('@/libs/hooks/use-user-subscription-detail', () => ({
+  useUserSubscriptionDetail: (...a: unknown[]) => useUserSubscriptionDetail(...a),
+}));
+
+const { AssignTierDialog } = await import('../AssignTierDialog');
+
+const FREE_TIER = { id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', name: 'free', displayName: 'Free' };
+const PRO_TIER = { id: 'bbbbbbbb-bbbb-4bbb-9bbb-bbbbbbbbbbbb', name: 'pro', displayName: 'Pro' };
+const PROMO_TIER = { id: 'cccccccc-cccc-4ccc-accc-cccccccccccc', name: 'promotion', displayName: 'Promotion' };
+const TIERS = [FREE_TIER, PRO_TIER, PROMO_TIER];
+
+function makeSubscription(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'sub-1',
+    tierId: FREE_TIER.id,
+    tierName: 'free',
+    displayName: 'Free',
+    status: 'active',
+    trialExpiresAt: null,
+    expiresAt: null,
+    startedAt: new Date('2024-01-01').toISOString(),
+    ...overrides,
+  };
+}
+
+function renderDialog(props: Partial<Parameters<typeof AssignTierDialog>[0]> = {}) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const onSaved = vi.fn();
+  const onOpenChange = vi.fn();
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+  render(
+    <AssignTierDialog
+      userId="user-1"
+      userEmail="target@example.com"
+      open
+      onOpenChange={onOpenChange}
+      onSaved={onSaved}
+      {...props}
+    />,
+    { wrapper },
+  );
+  return { onSaved, onOpenChange };
+}
+
+describe('AssignTierDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getActiveTiers.mockResolvedValue({ data: TIERS, error: null });
+    useUserSubscriptionDetail.mockReturnValue({ data: makeSubscription() });
+  });
+
+  it('renders the dialog with the target email in the title', () => {
+    renderDialog();
+
+    expect(screen.getByTestId('assign-tier-dialog')).toBeInTheDocument();
+    // The next-intl mock echoes the key path; the email param is passed through
+    // t('title', { email }) — assert the tier + status selects are present.
+    expect(screen.getByTestId('tier-select')).toBeInTheDocument();
+    expect(screen.getByTestId('status-select')).toBeInTheDocument();
+  });
+
+  it('submits the selected tier via the assignTier action', async () => {
+    assignTier.mockResolvedValue({ data: { userId: 'user-1' }, error: null });
+    const { onSaved } = renderDialog();
+
+    // The dialog pre-fills to the current (free) tier — submitting exercises the
+    // assignTier action without a fragile Radix Select interaction.
+    await screen.findByTestId('tier-select');
+    await userEvent.click(screen.getByTestId('assign-tier-submit'));
+
+    await waitFor(() => {
+      expect(assignTier).toHaveBeenCalledTimes(1);
+    });
+
+    expect(assignTier).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'user-1', tierId: FREE_TIER.id, status: 'active' }),
+    );
+
+    await waitFor(() => {
+      expect(onSaved).toHaveBeenCalled();
+    });
+
+    expect(toastSuccess).toHaveBeenCalled();
+  });
+
+  it('shows the eligibility warning and blocks submit when promoting an active paid user', async () => {
+    // Current: active PRO user → promotion is ineligible.
+    useUserSubscriptionDetail.mockReturnValue({
+      data: makeSubscription({ tierId: PRO_TIER.id, tierName: 'pro', displayName: 'Pro', status: 'active' }),
+    });
+    renderDialog();
+
+    // Select the promotion tier.
+    await userEvent.click(await screen.findByTestId('tier-select'));
+    await userEvent.click(await screen.findByRole('option', { name: 'Promotion' }));
+
+    expect(await screen.findByTestId('promotion-eligibility-warning')).toBeInTheDocument();
+    expect(screen.getByTestId('assign-tier-submit')).toBeDisabled();
+  });
+});

--- a/src/components/admin/__tests__/UserDetailDialog.test.tsx
+++ b/src/components/admin/__tests__/UserDetailDialog.test.tsx
@@ -1,6 +1,8 @@
 import type { User } from '@supabase/supabase-js';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
+import type { ReactNode } from 'react';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { UserDetailDialog } from '../UserDetailDialog';
@@ -49,6 +51,16 @@ vi.mock('../ResetPasswordDialog', () => ({
   ResetPasswordDialog: vi.fn(() => null),
 }));
 
+vi.mock('../AssignTierDialog', () => ({
+  AssignTierDialog: vi.fn(() => null),
+}));
+
+// Subscription-detail hook seam — the Subscription section reads from it.
+const useUserSubscriptionDetail = vi.fn();
+vi.mock('@/libs/hooks/use-user-subscription-detail', () => ({
+  useUserSubscriptionDetail: (...a: unknown[]) => useUserSubscriptionDetail(...a),
+}));
+
 // Create mock user
 const createMockUser = (overrides: Partial<User> = {}): User => ({
   id: 'user-1',
@@ -80,33 +92,56 @@ const defaultProps = {
   onUserUpdated: mockOnUserUpdated,
 };
 
+function renderDialog(props: Partial<Omit<typeof defaultProps, 'user'>> & { user?: User | null } = {}) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+  return render(<UserDetailDialog {...defaultProps} {...props} />, { wrapper });
+}
+
 describe('UserDetailDialog', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    useUserSubscriptionDetail.mockReturnValue({
+      data: {
+        id: 'sub-1',
+        tierId: 'tier-1',
+        tierName: 'free',
+        displayName: 'Free',
+        status: 'active',
+        trialExpiresAt: null,
+        expiresAt: null,
+        startedAt: '2024-01-15T00:00:00Z',
+      },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
   });
 
   describe('rendering', () => {
     it('does not render when user is null', () => {
-      render(<UserDetailDialog {...defaultProps} user={null} />);
+      renderDialog({ user: null });
 
       expect(screen.queryByTestId('user-detail-dialog')).not.toBeInTheDocument();
     });
 
     it('renders dialog when open with user', () => {
-      render(<UserDetailDialog {...defaultProps} />);
+      renderDialog();
 
       // Dialog content should be rendered
       expect(screen.getByTestId('user-detail-dialog')).toBeInTheDocument();
     });
 
     it('displays user email', () => {
-      render(<UserDetailDialog {...defaultProps} />);
+      renderDialog();
 
       expect(screen.getByText('test@example.com')).toBeInTheDocument();
     });
 
     it('displays user display name if available', () => {
-      render(<UserDetailDialog {...defaultProps} />);
+      renderDialog();
 
       // Display name appears in header (h3) and in info section
       const displayNameElements = screen.getAllByText('Test User');
@@ -115,15 +150,25 @@ describe('UserDetailDialog', () => {
     });
 
     it('displays username with @ prefix', () => {
-      render(<UserDetailDialog {...defaultProps} />);
+      renderDialog();
 
       expect(screen.getByText('@testuser')).toBeInTheDocument();
     });
   });
 
+  describe('subscription section', () => {
+    it('renders the Assign Tier trigger and the current tier', () => {
+      renderDialog();
+
+      expect(screen.getByTestId('open-assign-tier')).toBeInTheDocument();
+      expect(screen.getByText('fields.currentTier')).toBeInTheDocument();
+      expect(screen.getByText('Free')).toBeInTheDocument();
+    });
+  });
+
   describe('action buttons', () => {
     it('renders all action buttons', () => {
-      render(<UserDetailDialog {...defaultProps} />);
+      renderDialog();
 
       expect(screen.getByText('actions.resetPassword')).toBeInTheDocument();
       expect(screen.getByText('actions.suspend')).toBeInTheDocument();
@@ -135,7 +180,7 @@ describe('UserDetailDialog', () => {
         banned_until: '2099-12-31T00:00:00Z',
       });
 
-      render(<UserDetailDialog {...defaultProps} user={suspendedUser} />);
+      renderDialog({ user: suspendedUser });
 
       expect(screen.getByText('actions.unsuspend')).toBeInTheDocument();
     });
@@ -145,13 +190,7 @@ describe('UserDetailDialog', () => {
     it('disables action buttons for own account', () => {
       const ownUser = createMockUser({ id: 'current-admin-user-id' });
 
-      render(
-        <UserDetailDialog
-          {...defaultProps}
-          user={ownUser}
-          currentUserId="current-admin-user-id"
-        />,
-      );
+      renderDialog({ user: ownUser, currentUserId: 'current-admin-user-id' });
 
       // Find action buttons - they should be disabled
       const resetButton = screen.getByTestId('action-actions.resetpassword');
@@ -166,19 +205,13 @@ describe('UserDetailDialog', () => {
     it('shows warning message for own account', () => {
       const ownUser = createMockUser({ id: 'current-admin-user-id' });
 
-      render(
-        <UserDetailDialog
-          {...defaultProps}
-          user={ownUser}
-          currentUserId="current-admin-user-id"
-        />,
-      );
+      renderDialog({ user: ownUser, currentUserId: 'current-admin-user-id' });
 
       expect(screen.getByText('ownAccountWarning')).toBeInTheDocument();
     });
 
     it('does not show warning for other users', () => {
-      render(<UserDetailDialog {...defaultProps} />);
+      renderDialog();
 
       expect(screen.queryByText('ownAccountWarning')).not.toBeInTheDocument();
     });
@@ -188,7 +221,7 @@ describe('UserDetailDialog', () => {
     it('calls onOpenChange when close button is clicked', async () => {
       const user = userEvent.setup();
 
-      render(<UserDetailDialog {...defaultProps} />);
+      renderDialog();
 
       const closeButton = screen.getByRole('button', { name: 'close' });
       await user.click(closeButton);
@@ -199,7 +232,7 @@ describe('UserDetailDialog', () => {
 
   describe('user info display', () => {
     it('displays signup date', () => {
-      render(<UserDetailDialog {...defaultProps} />);
+      renderDialog();
 
       expect(screen.getByText('fields.signupDate')).toBeInTheDocument();
       // Date formatted as "January 15, 2024"
@@ -211,7 +244,7 @@ describe('UserDetailDialog', () => {
         last_sign_in_at: undefined,
       });
 
-      render(<UserDetailDialog {...defaultProps} user={neverLoggedInUser} />);
+      renderDialog({ user: neverLoggedInUser });
 
       expect(screen.getByText('never')).toBeInTheDocument();
     });

--- a/src/components/admin/index.ts
+++ b/src/components/admin/index.ts
@@ -1,8 +1,10 @@
 export { AdminHeader } from './AdminHeader';
 export { AdminLayoutClient } from './AdminLayoutClient';
 export { AdminSidebar } from './AdminSidebar';
+export { AssignTierDialog } from './AssignTierDialog';
 export { AuditLogFilters } from './AuditLogFilters';
 export { AuditLogTable } from './AuditLogTable';
+export { BulkPromotionInviteDialog } from './BulkPromotionInviteDialog';
 export { EmailTestForm } from './EmailTestForm';
 export { ExportCsvButton } from './ExportCsvButton';
 export { FeedbackCard } from './FeedbackCard';

--- a/src/libs/hooks/use-user-subscription-detail.ts
+++ b/src/libs/hooks/use-user-subscription-detail.ts
@@ -1,0 +1,36 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { getUserSubscriptionDetail } from '@/libs/actions/subscriptions';
+
+/**
+ * Reads a single user's subscription summary for the admin detail panel. Powers
+ * the "Subscription" section and pre-fills the Assign Tier dialog. Shares its
+ * query key with the invalidation call in `UserDetailDialog` so a grant refreshes
+ * the panel immediately.
+ *
+ * A NOT_FOUND result means the user simply has no subscription row — surfaced as
+ * `null` data, not an error.
+ */
+export function useUserSubscriptionDetail(userId: string | null) {
+  return useQuery({
+    queryKey: ['user-subscription-detail', userId],
+    queryFn: async () => {
+      if (!userId) {
+        throw new Error('No userId');
+      }
+      const result = await getUserSubscriptionDetail(userId);
+      if (result.error) {
+        // NOT_FOUND means the user simply has no subscription row — not an error.
+        if (result.error.code === 'NOT_FOUND') {
+          return null;
+        }
+        throw new Error(result.error.message);
+      }
+      return result.data;
+    },
+    enabled: !!userId,
+    staleTime: 30_000, // 30s — subscription data changes infrequently.
+  });
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -178,7 +178,8 @@
       "sections": {
         "accountInfo": "Account Information",
         "actions": "Actions",
-        "dangerZone": "Danger Zone"
+        "dangerZone": "Danger Zone",
+        "subscription": "Subscription"
       },
       "fields": {
         "username": "Username",
@@ -186,7 +187,11 @@
         "signupDate": "Signed Up",
         "lastLogin": "Last Login",
         "emailVerified": "Email Verified",
-        "userId": "User ID"
+        "userId": "User ID",
+        "currentTier": "Current Tier",
+        "subscriptionStatus": "Status",
+        "trialExpires": "Trial Expires",
+        "expiresAt": "Plan Expires"
       },
       "status": {
         "active": "Active",
@@ -201,7 +206,8 @@
         "unsuspend": "Unsuspend User",
         "unsuspendDesc": "Restore account access",
         "delete": "Delete User",
-        "deleteDesc": "Permanently remove user and all their data"
+        "deleteDesc": "Permanently remove user and all their data",
+        "assignTier": "Assign Tier"
       },
       "suspend": {
         "title": "Suspend {email}?",
@@ -246,7 +252,12 @@
         "successNote": "The user should receive the email shortly. Ask them to check spam if not received.",
         "error": "Failed to Send Reset Email"
       },
-      "cancel": "Cancel"
+      "cancel": "Cancel",
+      "subscription": {
+        "noRecord": "No subscription record found",
+        "loadError": "Failed to load subscription data",
+        "retry": "Retry"
+      }
     },
     "Feedback": {
       "title": "Feedback Management",
@@ -327,6 +338,61 @@
         "next": "Next",
         "page": "Page {current} of {total}"
       }
+    },
+    "AssignTier": {
+      "title": "Assign Tier — {email}",
+      "description": "Assign a subscription tier to this user",
+      "fields": {
+        "tier": "Tier",
+        "status": "Status",
+        "trialExpiry": "Trial Expiry Date",
+        "promotionEnd": "Promotion End Date",
+        "reason": "Reason",
+        "reasonHint": "(optional)"
+      },
+      "placeholders": {
+        "tier": "Select a tier",
+        "status": "Select status",
+        "reason": "Reason for tier change (audit log)"
+      },
+      "statuses": {
+        "active": "Active",
+        "trial": "Trial",
+        "expired": "Expired",
+        "cancelled": "Cancelled"
+      },
+      "promotionEligibilityWarning": "Promotion can only be granted to free or trial users — not active paid users.",
+      "success": "Tier assigned",
+      "cancel": "Cancel",
+      "assign": "Assign"
+    },
+    "BulkAssign": {
+      "title": "Bulk Assign Tier",
+      "description": "Assign a subscription tier to multiple users by email",
+      "fields": {
+        "emails": "Emails",
+        "tier": "Tier",
+        "status": "Status",
+        "trialExpiry": "Trial Expiry Date",
+        "promotionEnd": "Promotion End Date"
+      },
+      "placeholders": {
+        "emails": "Paste one email per line",
+        "tier": "Select a tier",
+        "status": "Select status"
+      },
+      "statuses": {
+        "active": "Active",
+        "trial": "Trial"
+      },
+      "notFoundHint": "Users not found in the system will be listed in the results and skipped.",
+      "results": {
+        "updated": "{count} Updated",
+        "notFound": "{count} Not Found"
+      },
+      "cancel": "Cancel",
+      "assign": "Assign",
+      "done": "Done"
     }
   },
   "Index": {


### PR DESCRIPTION
## Round C · Admin tier-grant UI — ContentFlow → template

The operator UI that drives the merged `assignTier`/`bulkAssignTier` server actions (Round B).

- **`AssignTierDialog`** — per-user grant dialog (shadcn Dialog/Form/Select/Input/Textarea + rhf + zod + sonner): tier + status select, conditional trial/promo expiry pickers, reason-for-audit textarea, and a client-side promotion-eligibility warning that mirrors the server guard. Submits via `assignTier`.
- **`use-user-subscription-detail`** — react-query hook over `getUserSubscriptionDetail`.
- **`UserDetailDialog`** — wired: a new Subscription section surfacing the user's current plan + an "Assign Tier" button. Existing reset/suspend/delete untouched.
- **`BulkPromotionInviteDialog`** — a **reusable primitive** (exported, drives `bulkAssignTier`) a fork mounts on its admin users page for batch grants. Not wired to a default trigger by design.

Theme variables throughout (no hardcoded colors, #175); user-facing copy via `Admin.*` next-intl keys in `en.json` (hi/bn are Crowdin-generated per the template's documented i18n workflow — see `src/libs/i18n.ts`).

### Verification
- **Independent byte-gate** (produce-blind): PASS — 159 tests, all elements confirmed, theme vars used, no product leaks.
- **`/code-review`**: core wiring correct (form↔server shape matches, eligibility warning mirrors the server guard, hook + QueryClientProvider sound, no reset/suspend/delete regression). No HIGH defects.
- CI locally green: check-types, lint (0 errors), 159 admin/hooks tests.

Depends on: Round B `assignTier`/`bulkAssignTier`/`getUserSubscriptionDetail` (merged). Refs: #175 (theme vars).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
