### PR TITLE
feat(theme): multi-theme system with OKLCH support

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -96,6 +96,14 @@ export default async function RootLayout(props: {
   // which dynamically adds a `style` attribute to the body tag.
   return (
     <html lang={locale} suppressHydrationWarning>
+      <head>
+        {/* Prevent FOUC: sync the .dark class + selected theme before first paint. */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `try{var t=localStorage.getItem('theme');if(!t||t==='system'){t=window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light';}var d=t==='dark'||t.indexOf('-dark')!==-1;var e=document.documentElement;if(d)e.classList.add('dark');else e.classList.remove('dark');if(t!=='light'&&t!=='dark')e.classList.add(t);}catch(e){}`,
+          }}
+        />
+      </head>
       <body className="bg-background text-foreground antialiased" suppressHydrationWarning>
         <a
           href="#main-content"

--- a/src/components/admin/__tests__/AdminHeader.test.tsx
+++ b/src/components/admin/__tests__/AdminHeader.test.tsx
@@ -147,8 +147,8 @@ describe('AdminHeader', () => {
     it('renders theme toggle', () => {
       render(<AdminHeader {...defaultProps} />);
 
-      // ThemeToggle with compact mode
-      const themeButton = screen.getByRole('button', { name: /switch to/i });
+      // ThemeToggle (grouped picker) with compact mode
+      const themeButton = screen.getByRole('button', { name: /select theme/i });
 
       expect(themeButton).toBeInTheDocument();
     });

--- a/src/components/theme/ThemeProvider.tsx
+++ b/src/components/theme/ThemeProvider.tsx
@@ -1,13 +1,42 @@
 'use client';
 
-import { ThemeProvider as NextThemesProvider } from 'next-themes';
+import { ThemeProvider as NextThemesProvider, useTheme } from 'next-themes';
 import type { ComponentProps } from 'react';
+import { useEffect } from 'react';
+
+import { ALL_THEME_IDS, isDarkTheme } from './theme-config';
+
+/**
+ * Keeps the `.dark` class on <html> in sync with the resolved theme so
+ * Tailwind's `dark:` variant works for EVERY dark theme in the registry, not
+ * just the built-in `dark`. next-themes only toggles `.dark` for its own
+ * `dark`/`system` handling, so custom `*-dark` themes need this bridge.
+ */
+function DarkClassSync() {
+  const { resolvedTheme } = useTheme();
+
+  useEffect(() => {
+    if (!resolvedTheme) {
+      return;
+    }
+    const html = document.documentElement;
+    if (isDarkTheme(resolvedTheme)) {
+      html.classList.add('dark');
+    } else {
+      html.classList.remove('dark');
+    }
+  }, [resolvedTheme]);
+
+  return null;
+}
 
 type ThemeProviderProps = ComponentProps<typeof NextThemesProvider>;
 
 /**
  * Theme Provider Component
- * Wraps next-themes provider for app-wide dark mode support
+ * Wraps next-themes for app-wide theming. Extends the base light/dark setup
+ * with the named themes from the registry (`ALL_THEME_IDS`) while preserving
+ * `system` support and the default light/dark behavior.
  */
 export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
   return (
@@ -15,9 +44,11 @@ export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
       attribute="class"
       defaultTheme="system"
       enableSystem
+      themes={[...ALL_THEME_IDS, 'system']}
       disableTransitionOnChange
       {...props}
     >
+      <DarkClassSync />
       {children}
     </NextThemesProvider>
   );

--- a/src/components/theme/ThemeToggle.tsx
+++ b/src/components/theme/ThemeToggle.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Moon, Sun } from 'lucide-react';
+import { Check, Monitor, Moon, Sun } from 'lucide-react';
 import { useTheme } from 'next-themes';
 import { useEffect, useState } from 'react';
 
@@ -9,14 +9,18 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { cn } from '@/utils/Helpers';
 
+import { isDarkTheme, THEME_GROUPS } from './theme-config';
+
 type ThemeToggleProps = {
   /** Show label text next to icon */
   showLabel?: boolean;
-  /** Compact mode - icon only button without dropdown */
+  /** Compact mode - icon-only trigger button */
   compact?: boolean;
   /** Extra classes for the trigger button (e.g. to override the ghost hover) */
   className?: string;
@@ -24,7 +28,9 @@ type ThemeToggleProps = {
 
 /**
  * Theme Toggle Component
- * Provides UI for switching between light, dark, and system themes
+ * Grouped dropdown theme picker: color swatches per theme family, sun/moon
+ * icons per light/dark variant, a check mark on the active theme, plus a
+ * System option. Light/dark selection behaves exactly as before.
  */
 export function ThemeToggle({ showLabel = false, compact = false, className }: ThemeToggleProps) {
   const { setTheme, theme, resolvedTheme } = useTheme();
@@ -45,68 +51,58 @@ export function ThemeToggle({ showLabel = false, compact = false, className }: T
     );
   }
 
-  // Compact mode: simple toggle between light/dark
-  if (compact) {
-    return (
-      <Button
-        variant="ghost"
-        size="icon"
-        onClick={() => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')}
-        aria-label={`Switch to ${resolvedTheme === 'dark' ? 'light' : 'dark'} mode`}
-        className={className}
-      >
-        {resolvedTheme === 'dark'
-          ? (
-              <Sun className="size-4" />
-            )
-          : (
-              <Moon className="size-4" />
-            )}
-      </Button>
-    );
-  }
+  const currentIsDark = resolvedTheme ? isDarkTheme(resolvedTheme) : false;
+  const TriggerIcon = currentIsDark ? Moon : Sun;
 
-  // Full mode: dropdown with all theme options
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <Button
           variant="ghost"
-          size="sm"
-          className={cn('w-full justify-start', className)}
-          aria-label="Toggle theme"
+          size={compact ? 'icon' : 'sm'}
+          className={cn(!compact && 'w-full justify-start', className)}
+          aria-label="Select theme"
         >
-          {resolvedTheme === 'dark'
-            ? (
-                <Moon className="size-4" />
-              )
-            : (
-                <Sun className="size-4" />
-              )}
-          {showLabel && <span className="ml-2">Theme</span>}
+          <TriggerIcon className="size-4" />
+          {showLabel && !compact && <span className="ml-2">Theme</span>}
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
-        <DropdownMenuItem
-          onClick={() => setTheme('light')}
-          className={theme === 'light' ? 'bg-accent' : ''}
-        >
-          <Sun className="mr-2 size-4" />
-          Light
-        </DropdownMenuItem>
-        <DropdownMenuItem
-          onClick={() => setTheme('dark')}
-          className={theme === 'dark' ? 'bg-accent' : ''}
-        >
-          <Moon className="mr-2 size-4" />
-          Dark
-        </DropdownMenuItem>
+      <DropdownMenuContent align="end" className="w-48">
+        {THEME_GROUPS.map((group, i) => (
+          <div key={group.group}>
+            {i > 0 && <DropdownMenuSeparator />}
+            <DropdownMenuLabel className="flex items-center gap-2">
+              <span
+                className="size-3 rounded-full border border-border/50"
+                style={{ backgroundColor: group.swatch }}
+              />
+              {group.group}
+            </DropdownMenuLabel>
+            {group.themes.map(t => (
+              <DropdownMenuItem
+                key={t.id}
+                onClick={() => setTheme(t.id)}
+                className="flex items-center justify-between"
+              >
+                <span className="flex items-center gap-2">
+                  {t.isDark ? <Moon className="size-3.5" /> : <Sun className="size-3.5" />}
+                  {t.label}
+                </span>
+                {theme === t.id && <Check className="size-3.5 text-primary" />}
+              </DropdownMenuItem>
+            ))}
+          </div>
+        ))}
+        <DropdownMenuSeparator />
         <DropdownMenuItem
           onClick={() => setTheme('system')}
-          className={theme === 'system' ? 'bg-accent' : ''}
+          className="flex items-center justify-between"
         >
-          <span className="mr-2 size-4 text-center">💻</span>
-          System
+          <span className="flex items-center gap-2">
+            <Monitor className="size-3.5" />
+            System
+          </span>
+          {theme === 'system' && <Check className="size-3.5 text-primary" />}
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/src/components/theme/index.ts
+++ b/src/components/theme/index.ts
@@ -1,2 +1,4 @@
+export type { Theme, ThemeGroup, ThemeId } from './theme-config';
+export { ALL_THEME_IDS, isDarkTheme, THEME_GROUPS } from './theme-config';
 export { ThemeProvider } from './ThemeProvider';
 export { ThemeToggle } from './ThemeToggle';

--- a/src/components/theme/theme-config.test.ts
+++ b/src/components/theme/theme-config.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment node
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { ALL_THEME_IDS, isDarkTheme, THEME_GROUPS } from './theme-config';
+
+describe('theme-config', () => {
+  it('exposes every theme id from the groups in ALL_THEME_IDS', () => {
+    const fromGroups = THEME_GROUPS.flatMap(g => g.themes.map(t => t.id));
+
+    expect(ALL_THEME_IDS).toEqual(fromGroups);
+  });
+
+  it('keeps the next-themes-compatible default ids (light / dark)', () => {
+    expect(ALL_THEME_IDS).toContain('light');
+    expect(ALL_THEME_IDS).toContain('dark');
+  });
+
+  it('has no duplicate theme ids', () => {
+    expect(new Set(ALL_THEME_IDS).size).toBe(ALL_THEME_IDS.length);
+  });
+
+  it('ships neutral default groups only (no product-specific names)', () => {
+    const names = THEME_GROUPS.map(g => g.group);
+
+    expect(names).toEqual(['Default', 'Modern SaaS', 'Warm Sand', 'Sage Green']);
+  });
+
+  describe('isDarkTheme', () => {
+    it('flags the built-in dark theme', () => {
+      expect(isDarkTheme('dark')).toBe(true);
+      expect(isDarkTheme('light')).toBe(false);
+    });
+
+    it('flags every registry theme by its `isDark` metadata', () => {
+      for (const group of THEME_GROUPS) {
+        for (const theme of group.themes) {
+          expect(isDarkTheme(theme.id)).toBe(theme.isDark);
+        }
+      }
+    });
+  });
+
+  it('defines a CSS block in global.css for every non-default theme id', () => {
+    const css = readFileSync(
+      join(process.cwd(), 'src/styles/global.css'),
+      'utf8',
+    );
+
+    for (const id of ALL_THEME_IDS) {
+      // `light` / `dark` live in :root / .dark, not a `.<id>` class.
+      if (id === 'light' || id === 'dark') {
+        continue;
+      }
+
+      expect(css).toContain(`.${id} {`);
+    }
+  });
+});

--- a/src/components/theme/theme-config.ts
+++ b/src/components/theme/theme-config.ts
@@ -1,0 +1,78 @@
+/**
+ * Multi-theme registry (template issue #250).
+ *
+ * Type-safe source of truth for the themes the app ships. Each theme id maps to
+ * a CSS class in `src/styles/global.css` (except the default `light` / `dark`,
+ * which live in `:root` / `.dark`). Keep the two files in sync.
+ *
+ * The `light`/`dark` ids are the defaults `next-themes` already uses, so the
+ * existing light/dark toggle keeps working unchanged.
+ */
+
+export type ThemeId
+  = | 'light'
+    | 'dark'
+    | 'modern-light'
+    | 'modern-dark'
+    | 'warm-light'
+    | 'warm-dark'
+    | 'sage-light'
+    | 'sage-dark';
+
+export type Theme = {
+  id: ThemeId;
+  label: string;
+  isDark: boolean;
+};
+
+export type ThemeGroup = {
+  /** Display name for the group (e.g. shown as a dropdown section label). */
+  group: string;
+  /** Representative color for the group swatch (any CSS color: HSL or OKLCH). */
+  swatch: string;
+  /** The light/dark variants that belong to this group. */
+  themes: Theme[];
+};
+
+export const THEME_GROUPS: ThemeGroup[] = [
+  {
+    group: 'Default',
+    swatch: 'hsl(222.2 47.4% 11.2%)',
+    themes: [
+      { id: 'light', label: 'Light', isDark: false },
+      { id: 'dark', label: 'Dark', isDark: true },
+    ],
+  },
+  {
+    group: 'Modern SaaS',
+    swatch: 'hsl(217.2 91.2% 59.8%)',
+    themes: [
+      { id: 'modern-light', label: 'Light', isDark: false },
+      { id: 'modern-dark', label: 'Dark', isDark: true },
+    ],
+  },
+  {
+    group: 'Warm Sand',
+    swatch: 'oklch(0.55 0.155 39.0427)',
+    themes: [
+      { id: 'warm-light', label: 'Light', isDark: false },
+      { id: 'warm-dark', label: 'Dark', isDark: true },
+    ],
+  },
+  {
+    group: 'Sage Green',
+    swatch: 'oklch(0.5486 0.0866 132.737)',
+    themes: [
+      { id: 'sage-light', label: 'Light', isDark: false },
+      { id: 'sage-dark', label: 'Dark', isDark: true },
+    ],
+  },
+];
+
+/** Every registered theme id, in the shape next-themes' `themes` prop expects. */
+export const ALL_THEME_IDS = THEME_GROUPS.flatMap(g => g.themes.map(t => t.id));
+
+/** True when a theme id is a dark variant (drives the `.dark` class sync). */
+export function isDarkTheme(themeId: string): boolean {
+  return themeId === 'dark' || themeId.endsWith('-dark');
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -5,57 +5,70 @@
 
 @plugin '@tailwindcss/typography';
 
+/*
+  Multi-theme token architecture (template issue #250).
+
+  @theme passes each Tailwind color through as `var(--<token>)` instead of a
+  baked `hsl(...)` value, so a theme block can supply the token in ANY color
+  space — HSL or OKLCH — and `var()` resolves to a complete color at runtime.
+  Raw tokens (`--primary`, `--background`, …) are defined per theme below.
+
+  Default theme = light (`:root`) / dark (`.dark`). Their values are the exact
+  same triples the template shipped before this refactor, just wrapped in
+  `hsl(...)` so `var(--primary)` resolves to a full color. Appearance of the
+  default theme is unchanged.
+*/
 @theme {
-  --color-border: hsl(214.3 31.8% 91.4%);
-  --color-input: hsl(214.3 31.8% 91.4%);
-  --color-ring: hsl(222.2 84% 4.9%);
-  --color-background: hsl(0 0% 100%);
-  --color-foreground: hsl(222.2 84% 4.9%);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
 
-  --color-primary: hsl(222.2 47.4% 11.2%);
-  --color-primary-foreground: hsl(210 40% 98%);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
 
-  --color-secondary: hsl(210 40% 96.1%);
-  --color-secondary-foreground: hsl(222.2 47.4% 11.2%);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
 
-  --color-destructive: hsl(0 84.2% 60.2%);
-  --color-destructive-foreground: hsl(210 40% 98%);
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
 
-  --color-muted: hsl(210 40% 96.1%);
-  --color-muted-foreground: hsl(215.4 16.3% 42%);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
 
-  --color-accent: hsl(210 40% 96.1%);
-  --color-accent-foreground: hsl(222.2 47.4% 11.2%);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
 
-  --color-popover: hsl(0 0% 100%);
-  --color-popover-foreground: hsl(222.2 84% 4.9%);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
 
-  --color-card: hsl(0 0% 100%);
-  --color-card-foreground: hsl(222.2 84% 4.9%);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
 
-  --color-chart-1: hsl(12 76% 61%);
-  --color-chart-2: hsl(173 58% 39%);
-  --color-chart-3: hsl(197 37% 24%);
-  --color-chart-4: hsl(43 74% 66%);
-  --color-chart-5: hsl(27 87% 67%);
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
 
-  --color-sidebar: hsl(0 0% 98%);
-  --color-sidebar-foreground: hsl(240 5.3% 26.1%);
-  --color-sidebar-primary: hsl(240 5.9% 10%);
-  --color-sidebar-primary-foreground: hsl(0 0% 98%);
-  --color-sidebar-accent: hsl(240 4.8% 95.9%);
-  --color-sidebar-accent-foreground: hsl(240 5.9% 10%);
-  --color-sidebar-border: hsl(220 13% 91%);
-  --color-sidebar-ring: hsl(217.2 91.2% 59.8%);
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
 
   /* Marketing shell (opt-in): self-contained footer brand tokens with safe
      defaults — no dependency on a multi-theme system. */
-  --color-footer-bg: hsl(222.2 47.4% 11.2%);
-  --color-footer-foreground: hsl(210 40% 98%);
+  --color-footer-bg: var(--footer-bg);
+  --color-footer-foreground: var(--footer-foreground);
 
-  --radius-lg: 0.5rem;
-  --radius-md: calc(0.5rem - 2px);
-  --radius-sm: calc(0.5rem - 4px);
+  --radius-lg: var(--radius);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-sm: calc(var(--radius) - 4px);
 
   --animate-accordion-down: accordion-down 0.2s ease-out;
   --animate-accordion-up: accordion-up 0.2s ease-out;
@@ -89,49 +102,353 @@
   }
 }
 
+/* =============================================================================
+   Default theme — light (`:root`)
+   Same values the template shipped before #250, wrapped in hsl() so
+   `var(--*)` resolves to a full color. DO NOT alter these numbers — they
+   define the template's out-of-the-box appearance.
+   ============================================================================= */
+:root {
+  --border: hsl(214.3 31.8% 91.4%);
+  --input: hsl(214.3 31.8% 91.4%);
+  --ring: hsl(222.2 84% 4.9%);
+  --background: hsl(0 0% 100%);
+  --foreground: hsl(222.2 84% 4.9%);
+
+  --primary: hsl(222.2 47.4% 11.2%);
+  --primary-foreground: hsl(210 40% 98%);
+
+  --secondary: hsl(210 40% 96.1%);
+  --secondary-foreground: hsl(222.2 47.4% 11.2%);
+
+  --destructive: hsl(0 84.2% 60.2%);
+  --destructive-foreground: hsl(210 40% 98%);
+
+  --muted: hsl(210 40% 96.1%);
+  --muted-foreground: hsl(215.4 16.3% 42%);
+
+  --accent: hsl(210 40% 96.1%);
+  --accent-foreground: hsl(222.2 47.4% 11.2%);
+
+  --popover: hsl(0 0% 100%);
+  --popover-foreground: hsl(222.2 84% 4.9%);
+
+  --card: hsl(0 0% 100%);
+  --card-foreground: hsl(222.2 84% 4.9%);
+
+  --chart-1: hsl(12 76% 61%);
+  --chart-2: hsl(173 58% 39%);
+  --chart-3: hsl(197 37% 24%);
+  --chart-4: hsl(43 74% 66%);
+  --chart-5: hsl(27 87% 67%);
+
+  --sidebar: hsl(0 0% 98%);
+  --sidebar-foreground: hsl(240 5.3% 26.1%);
+  --sidebar-primary: hsl(240 5.9% 10%);
+  --sidebar-primary-foreground: hsl(0 0% 98%);
+  --sidebar-accent: hsl(240 4.8% 95.9%);
+  --sidebar-accent-foreground: hsl(240 5.9% 10%);
+  --sidebar-border: hsl(220 13% 91%);
+  --sidebar-ring: hsl(217.2 91.2% 59.8%);
+
+  --footer-bg: hsl(222.2 47.4% 11.2%);
+  --footer-foreground: hsl(210 40% 98%);
+
+  --radius: 0.5rem;
+}
+
+/* =============================================================================
+   Default theme — dark (`.dark`)
+   Same values the template shipped before #250, raw-token form.
+   ============================================================================= */
 .dark {
-  --color-background: hsl(222.2 84% 4.9%);
-  --color-foreground: hsl(210 40% 98%);
+  --background: hsl(222.2 84% 4.9%);
+  --foreground: hsl(210 40% 98%);
 
-  --color-card: hsl(222.2 84% 4.9%);
-  --color-card-foreground: hsl(210 40% 98%);
+  --card: hsl(222.2 84% 4.9%);
+  --card-foreground: hsl(210 40% 98%);
 
-  --color-popover: hsl(222.2 84% 4.9%);
-  --color-popover-foreground: hsl(210 40% 98%);
+  --popover: hsl(222.2 84% 4.9%);
+  --popover-foreground: hsl(210 40% 98%);
 
-  --color-primary: hsl(210 40% 98%);
-  --color-primary-foreground: hsl(222.2 47.4% 11.2%);
+  --primary: hsl(210 40% 98%);
+  --primary-foreground: hsl(222.2 47.4% 11.2%);
 
-  --color-secondary: hsl(217.2 32.6% 17.5%);
-  --color-secondary-foreground: hsl(210 40% 98%);
+  --secondary: hsl(217.2 32.6% 17.5%);
+  --secondary-foreground: hsl(210 40% 98%);
 
-  --color-muted: hsl(217.2 32.6% 17.5%);
-  --color-muted-foreground: hsl(215 20.2% 65.1%);
+  --muted: hsl(217.2 32.6% 17.5%);
+  --muted-foreground: hsl(215 20.2% 65.1%);
 
-  --color-accent: hsl(217.2 32.6% 17.5%);
-  --color-accent-foreground: hsl(210 40% 98%);
+  --accent: hsl(217.2 32.6% 17.5%);
+  --accent-foreground: hsl(210 40% 98%);
 
-  --color-destructive: hsl(0 62.8% 30.6%);
-  --color-destructive-foreground: hsl(210 40% 98%);
+  --destructive: hsl(0 62.8% 30.6%);
+  --destructive-foreground: hsl(210 40% 98%);
 
-  --color-border: hsl(217.2 32.6% 17.5%);
-  --color-input: hsl(217.2 32.6% 17.5%);
-  --color-ring: hsl(212.7 26.8% 83.9%);
+  --border: hsl(217.2 32.6% 17.5%);
+  --input: hsl(217.2 32.6% 17.5%);
+  --ring: hsl(212.7 26.8% 83.9%);
 
-  --color-chart-1: hsl(220 70% 50%);
-  --color-chart-2: hsl(160 60% 45%);
-  --color-chart-3: hsl(30 80% 55%);
-  --color-chart-4: hsl(280 65% 60%);
-  --color-chart-5: hsl(340 75% 55%);
+  --chart-1: hsl(220 70% 50%);
+  --chart-2: hsl(160 60% 45%);
+  --chart-3: hsl(30 80% 55%);
+  --chart-4: hsl(280 65% 60%);
+  --chart-5: hsl(340 75% 55%);
 
-  --color-sidebar: hsl(240 5.9% 10%);
-  --color-sidebar-foreground: hsl(240 4.8% 95.9%);
-  --color-sidebar-primary: hsl(224.3 76.3% 48%);
-  --color-sidebar-primary-foreground: hsl(0 0% 100%);
-  --color-sidebar-accent: hsl(240 3.7% 15.9%);
-  --color-sidebar-accent-foreground: hsl(240 4.8% 95.9%);
-  --color-sidebar-border: hsl(240 3.7% 15.9%);
-  --color-sidebar-ring: hsl(217.2 91.2% 59.8%);
+  --sidebar: hsl(240 5.9% 10%);
+  --sidebar-foreground: hsl(240 4.8% 95.9%);
+  --sidebar-primary: hsl(224.3 76.3% 48%);
+  --sidebar-primary-foreground: hsl(0 0% 100%);
+  --sidebar-accent: hsl(240 3.7% 15.9%);
+  --sidebar-accent-foreground: hsl(240 4.8% 95.9%);
+  --sidebar-border: hsl(240 3.7% 15.9%);
+  --sidebar-ring: hsl(217.2 91.2% 59.8%);
+}
+
+@layer base {
+  /* ===========================================================================
+     Multi-theme registry — neutral, professional defaults shipped with the
+     template. Each theme provides raw `--*` tokens (HSL or OKLCH). Keep in sync
+     with `src/components/theme/theme-config.ts` (THEME_GROUPS).
+     =========================================================================== */
+
+  /* -------------------------------------------------------------------------
+     Modern SaaS — professional blue, B2B default (HSL)
+     ------------------------------------------------------------------------- */
+  .modern-light {
+    --background: hsl(0 0% 100%);
+    --foreground: hsl(222.2 84% 4.9%);
+    --card: hsl(0 0% 100%);
+    --card-foreground: hsl(222.2 84% 4.9%);
+    --popover: hsl(0 0% 100%);
+    --popover-foreground: hsl(222.2 84% 4.9%);
+    --primary: hsl(217.2 91.2% 59.8%);
+    --primary-foreground: hsl(210 40% 98%);
+    --secondary: hsl(210 40% 96.1%);
+    --secondary-foreground: hsl(222.2 47.4% 11.2%);
+    --muted: hsl(210 40% 96.1%);
+    --muted-foreground: hsl(215.4 16.3% 46.9%);
+    --accent: hsl(210 40% 96.1%);
+    --accent-foreground: hsl(222.2 47.4% 11.2%);
+    --destructive: hsl(0 84.2% 60.2%);
+    --destructive-foreground: hsl(210 40% 98%);
+    --border: hsl(214.3 31.8% 91.4%);
+    --input: hsl(214.3 31.8% 91.4%);
+    --ring: hsl(217.2 91.2% 59.8%);
+    --chart-1: hsl(217.2 91.2% 59.8%);
+    --chart-2: hsl(160 60% 45%);
+    --chart-3: hsl(30 80% 55%);
+    --chart-4: hsl(280 65% 60%);
+    --chart-5: hsl(340 75% 55%);
+    --radius: 0.5rem;
+    --sidebar: hsl(0 0% 98%);
+    --sidebar-foreground: hsl(222.2 84% 4.9%);
+    --sidebar-primary: hsl(217.2 91.2% 59.8%);
+    --sidebar-primary-foreground: hsl(210 40% 98%);
+    --sidebar-accent: hsl(210 40% 96.1%);
+    --sidebar-accent-foreground: hsl(222.2 47.4% 11.2%);
+    --sidebar-border: hsl(214.3 31.8% 91.4%);
+    --sidebar-ring: hsl(217.2 91.2% 59.8%);
+    --footer-bg: hsl(222.2 47.4% 11.2%);
+    --footer-foreground: hsl(210 40% 98%);
+  }
+
+  .modern-dark {
+    --background: hsl(222.2 84% 4.9%);
+    --foreground: hsl(210 40% 98%);
+    --card: hsl(222.2 84% 4.9%);
+    --card-foreground: hsl(210 40% 98%);
+    --popover: hsl(222.2 84% 4.9%);
+    --popover-foreground: hsl(210 40% 98%);
+    --primary: hsl(217.2 91.2% 59.8%);
+    --primary-foreground: hsl(222.2 47.4% 11.2%);
+    --secondary: hsl(217.2 32.6% 17.5%);
+    --secondary-foreground: hsl(210 40% 98%);
+    --muted: hsl(217.2 32.6% 17.5%);
+    --muted-foreground: hsl(215 20.2% 65.1%);
+    --accent: hsl(217.2 32.6% 17.5%);
+    --accent-foreground: hsl(210 40% 98%);
+    --destructive: hsl(0 62.8% 30.6%);
+    --destructive-foreground: hsl(210 40% 98%);
+    --border: hsl(217.2 32.6% 17.5%);
+    --input: hsl(217.2 32.6% 17.5%);
+    --ring: hsl(224.3 76.3% 48%);
+    --chart-1: hsl(220 70% 50%);
+    --chart-2: hsl(160 60% 45%);
+    --chart-3: hsl(30 80% 55%);
+    --chart-4: hsl(280 65% 60%);
+    --chart-5: hsl(340 75% 55%);
+    --radius: 0.5rem;
+    --sidebar: hsl(222.2 84% 4.9%);
+    --sidebar-foreground: hsl(210 40% 98%);
+    --sidebar-primary: hsl(217.2 91.2% 59.8%);
+    --sidebar-primary-foreground: hsl(222.2 47.4% 11.2%);
+    --sidebar-accent: hsl(217.2 32.6% 17.5%);
+    --sidebar-accent-foreground: hsl(210 40% 98%);
+    --sidebar-border: hsl(217.2 32.6% 17.5%);
+    --sidebar-ring: hsl(224.3 76.3% 48%);
+    --footer-bg: hsl(222.2 84% 4.9%);
+    --footer-foreground: hsl(210 40% 98%);
+  }
+
+  /* -------------------------------------------------------------------------
+     Warm Sand — warm neutral, terracotta accent (OKLCH)
+     ------------------------------------------------------------------------- */
+  .warm-light {
+    --background: oklch(0.9818 0.0054 95.0986);
+    --foreground: oklch(0.3438 0.0269 95.7226);
+    --card: oklch(0.9665 0.0067 97.3521);
+    --card-foreground: oklch(0.1908 0.002 106.5859);
+    --popover: oklch(1 0 0);
+    --popover-foreground: oklch(0.2671 0.0196 98.939);
+    --primary: oklch(0.55 0.155 39.0427);
+    --primary-foreground: oklch(1 0 0);
+    --secondary: oklch(0.9245 0.0138 92.9892);
+    --secondary-foreground: oklch(0.4334 0.0177 98.6048);
+    --muted: oklch(0.9341 0.0153 90.239);
+    --muted-foreground: oklch(0.5341 0.0078 97.4503);
+    --accent: oklch(0.9245 0.0138 92.9892);
+    --accent-foreground: oklch(0.2671 0.0196 98.939);
+    --destructive: oklch(0.6368 0.2078 25.3313);
+    --destructive-foreground: oklch(1 0 0);
+    --border: oklch(0.8847 0.0069 97.3627);
+    --input: oklch(0.7621 0.0156 98.3528);
+    --ring: oklch(0.55 0.155 39.0427);
+    --chart-1: oklch(0.5583 0.1276 42.9956);
+    --chart-2: oklch(0.6898 0.1581 290.4107);
+    --chart-3: oklch(0.8816 0.0276 93.128);
+    --chart-4: oklch(0.8822 0.0403 298.1792);
+    --chart-5: oklch(0.5608 0.1348 42.0584);
+    --radius: 0.75rem;
+    --sidebar: oklch(0.9663 0.008 98.8792);
+    --sidebar-foreground: oklch(0.359 0.0051 106.6524);
+    --sidebar-primary: oklch(0.55 0.155 39.0427);
+    --sidebar-primary-foreground: oklch(0.9881 0 0);
+    --sidebar-accent: oklch(0.9245 0.0138 92.9892);
+    --sidebar-accent-foreground: oklch(0.325 0 0);
+    --sidebar-border: oklch(0.8847 0.0069 97.3627);
+    --sidebar-ring: oklch(0.55 0.155 39.0427);
+    --footer-bg: oklch(0.2679 0.0036 106.6427);
+    --footer-foreground: oklch(0.9576 0.0027 106.4494);
+  }
+
+  .warm-dark {
+    --background: oklch(0.2679 0.0036 106.6427);
+    --foreground: oklch(0.9576 0.0027 106.4494);
+    --card: oklch(0.2928 0.0018 106.5092);
+    --card-foreground: oklch(0.9818 0.0054 95.0986);
+    --popover: oklch(0.3085 0.0035 106.6039);
+    --popover-foreground: oklch(0.9211 0.004 106.4781);
+    --primary: oklch(0.6 0.155 38.7559);
+    --primary-foreground: oklch(0.1908 0.002 106.5859);
+    --secondary: oklch(0.9818 0.0054 95.0986);
+    --secondary-foreground: oklch(0.3085 0.0035 106.6039);
+    --muted: oklch(0.2213 0.0038 106.707);
+    --muted-foreground: oklch(0.7713 0.0169 99.0657);
+    --accent: oklch(0.213 0.0078 95.4245);
+    --accent-foreground: oklch(0.9663 0.008 98.8792);
+    --destructive: oklch(0.6368 0.2078 25.3313);
+    --destructive-foreground: oklch(1 0 0);
+    --border: oklch(0.3618 0.0101 106.8928);
+    --input: oklch(0.4336 0.0113 100.2195);
+    --ring: oklch(0.6 0.155 38.7559);
+    --chart-1: oklch(0.5583 0.1276 42.9956);
+    --chart-2: oklch(0.6898 0.1581 290.4107);
+    --chart-3: oklch(0.213 0.0078 95.4245);
+    --chart-4: oklch(0.3074 0.0516 289.323);
+    --chart-5: oklch(0.5608 0.1348 42.0584);
+    --radius: 0.75rem;
+    --sidebar: oklch(0.2357 0.0024 67.7077);
+    --sidebar-foreground: oklch(0.8074 0.0142 93.0137);
+    --sidebar-primary: oklch(0.325 0 0);
+    --sidebar-primary-foreground: oklch(0.9881 0 0);
+    --sidebar-accent: oklch(0.168 0.002 106.6177);
+    --sidebar-accent-foreground: oklch(0.8074 0.0142 93.0137);
+    --sidebar-border: oklch(0.3618 0.0101 106.8928);
+    --sidebar-ring: oklch(0.6 0.155 38.7559);
+    --footer-bg: oklch(0.2101 0.0032 106.6427);
+    --footer-foreground: oklch(0.9576 0.0027 106.4494);
+  }
+
+  /* -------------------------------------------------------------------------
+     Sage Green — calm, earthy green (OKLCH)
+     ------------------------------------------------------------------------- */
+  .sage-light {
+    --background: oklch(0.994 0 0);
+    --foreground: oklch(0.2 0 0);
+    --card: oklch(0.994 0 0);
+    --card-foreground: oklch(0.2 0 0);
+    --popover: oklch(0.9911 0 0);
+    --popover-foreground: oklch(0.2 0 0);
+    --primary: oklch(0.5486 0.0866 132.737);
+    --primary-foreground: oklch(1 0 0);
+    --secondary: oklch(0.954 0.0063 255.4755);
+    --secondary-foreground: oklch(0.1344 0 0);
+    --muted: oklch(0.9702 0 0);
+    --muted-foreground: oklch(0.5 0 0);
+    --accent: oklch(0.4429 0.0444 134.5073);
+    --accent-foreground: oklch(1 0 0);
+    --destructive: oklch(0.4926 0.1864 26.2192);
+    --destructive-foreground: oklch(1 0 0);
+    --border: oklch(0.93 0.0094 286.2156);
+    --input: oklch(0.9401 0 0);
+    --ring: oklch(0.5486 0.0866 132.737);
+    --chart-1: oklch(0.7459 0.1483 156.4499);
+    --chart-2: oklch(0.5393 0.2713 286.7462);
+    --chart-3: oklch(0.7336 0.1758 50.5517);
+    --chart-4: oklch(0.5828 0.1809 259.7276);
+    --chart-5: oklch(0.559 0 0);
+    --radius: 0.75rem;
+    --sidebar: oklch(0.9777 0.0051 247.8763);
+    --sidebar-foreground: oklch(0.2 0 0);
+    --sidebar-primary: oklch(0.5486 0.0866 132.737);
+    --sidebar-primary-foreground: oklch(1 0 0);
+    --sidebar-accent: oklch(0.93 0.0136 134.8996);
+    --sidebar-accent-foreground: oklch(0.2 0 0);
+    --sidebar-border: oklch(0.9401 0 0);
+    --sidebar-ring: oklch(0.5486 0.0866 132.737);
+    --footer-bg: oklch(0.1173 0.009 73.4751);
+    --footer-foreground: oklch(0.9796 0.0017 67.8026);
+  }
+
+  .sage-dark {
+    --background: oklch(0.1173 0.009 73.4751);
+    --foreground: oklch(0.9796 0.0017 67.8026);
+    --card: oklch(0.1609 0.0115 80.9823);
+    --card-foreground: oklch(0.9796 0.0017 67.8026);
+    --popover: oklch(0.1405 0.0109 88.4982);
+    --popover-foreground: oklch(0.9796 0.0017 67.8026);
+    --primary: oklch(0.783 0.0384 132.737);
+    --primary-foreground: oklch(0.0986 0.0063 72.5271);
+    --secondary: oklch(0.251 0.0148 76.2105);
+    --secondary-foreground: oklch(0.9198 0.0075 80.7204);
+    --muted: oklch(0.2203 0.0129 77.9565);
+    --muted-foreground: oklch(0.6511 0.0081 80.7132);
+    --accent: oklch(0.4429 0.0444 134.5073);
+    --accent-foreground: oklch(1 0 0);
+    --destructive: oklch(0.4926 0.1864 26.2192);
+    --destructive-foreground: oklch(0.9796 0.0017 67.8026);
+    --border: oklch(0.2806 0.0246 82.6847);
+    --input: oklch(0.1994 0.0155 75.9533);
+    --ring: oklch(0.783 0.0384 132.737);
+    --chart-1: oklch(0.5636 0.1645 136.9338);
+    --chart-2: oklch(0.6509 0.1756 135.9702);
+    --chart-3: oklch(0.7246 0.1732 135.119);
+    --chart-4: oklch(0.8539 0.1402 133.7838);
+    --chart-5: oklch(0.783 0.0384 132.737);
+    --radius: 0.75rem;
+    --sidebar: oklch(0.0986 0.0063 72.5271);
+    --sidebar-foreground: oklch(0.9498 0.0046 78.2977);
+    --sidebar-primary: oklch(0.783 0.0384 132.737);
+    --sidebar-primary-foreground: oklch(0.0986 0.0063 72.5271);
+    --sidebar-accent: oklch(0.4429 0.0444 134.5073);
+    --sidebar-accent-foreground: oklch(1 0 0);
+    --sidebar-border: oklch(0.2513 0.02 80.2775);
+    --sidebar-ring: oklch(0.783 0.0384 132.737);
+    --footer-bg: oklch(0.0986 0.0063 72.5271);
+    --footer-foreground: oklch(0.9498 0.0046 78.2977);
+  }
 }
 
 @layer base {


### PR DESCRIPTION
## Multi-theme system (#250) — ContentFlow → template

Upstreams ContentFlow's multi-theme color system, **extending** the template's existing next-themes setup (not replacing it).

- **`@theme` OKLCH support** (`global.css`): migrated the token passthrough from `hsl(var(--*))` to `var(--*)` so themes can supply HSL **or** OKLCH. Default light/dark tokens moved into `:root`/`.dark` wrapped in `hsl(...)` — **appearance byte-identical** (verified 66/66 tokens).
- **`theme-config.ts`** — typed theme registry (ids, groups, swatches, dark detection) + 3 neutral default themes (Modern SaaS blue, Warm Sand OKLCH, Sage Green OKLCH).
- **`ThemeProvider`** extended with the registry + a `.dark` class sync (Tailwind `dark:` still works); system/light/dark preserved.
- **`ThemeToggle`** — grouped dropdown picker with color swatches, sun/moon icons, check marks.
- **FOUC script** in `layout.tsx` — syncs `.dark` + theme class before first paint.

### Verification
- **Independent byte-gate** (produce-blind): PASS — **default-theme preservation confirmed 66/66 tokens byte-identical** (light 34/34, dark 32/32); `@theme` fully migrated (no half-migration); picker/provider/FOUC correct; `next.config.mjs` unchanged; no product theme names.
- **Visual check**: default light theme renders correctly (sign-in page screenshot) — the `@theme` migration did not break colors. (Authed shell screenshot was blocked by a pre-existing local PGlite dev-DB state, unrelated to this change.)
- CI locally green: check-types, lint (0 errors), 7 theme tests, production build (real build, no worktree workaround).

Refs: #250. (PageHeader `iconClassName` from #250 already landed in the drop-in tier.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
