### PR TITLE
docs: CI Gate smoke test (throwaway — will close)

### DIFF
--- a/docs/_ci-gate-smoke.md
+++ b/docs/_ci-gate-smoke.md
@@ -1,0 +1,3 @@
+# CI Gate smoke test
+
+Throwaway docs-only change to verify the CI Gate aggregator lets docs-only PRs merge (heavy jobs skip → CI Gate green). Safe to close+delete.


### PR DESCRIPTION
Verifies the CI Gate aggregator (#363) unblocks docs-only PRs: the heavy jobs should SKIP and `CI Gate` should be the only required check → mergeable. Will close + delete after verification.