### PR TITLE
docs(upstream-contribute): faster local-first model + layered gate + issue-first identify

### DIFF
--- a/.claude/skills/upstream-contribute/references/fast-execution.md
+++ b/.claude/skills/upstream-contribute/references/fast-execution.md
@@ -1,0 +1,53 @@
+# Fast execution — local-first, parallel, batch-PR
+
+The stock loop (sequential waves · the engine opens a PR per group · merge one PR at a time) is **correct but slow**: it waits on remote CI per PR and serializes work the DAG doesn't force to be serial. For any non-trivial batch, prefer the **local-first, parallel, batch-PR** model below. It is the DEFAULT for medium/large contributions; keep the stock per-PR engine as the fallback for a handful of candidates where the orchestration overhead isn't worth it.
+
+The one line: **maximize safe parallelism, do all verification locally, and touch remote CI once per batch — not once per candidate.**
+
+## 1. Collapse waves → DAG-depth rounds
+
+Waves in the plan are usually packed by the batch cap, not by real ordering. Re-derive the true constraint: **only genuine dependency edges + shared-file collisions force sequencing.** Group candidates by DAG *depth*:
+
+- **Round 0** = every candidate with no unmerged dependency (the roots + all independent leaves). Usually the large majority.
+- **Round 1** = candidates whose deps are all in Round 0.
+- **Round N** = … produced only after Round N−1 is **merged to main** (so they build on real, on-main code).
+
+A 9-wave plan often collapses to 2–3 rounds this way. Within a round, everything runs in parallel; across rounds is the only sequencing.
+
+## 2. Produce in parallel, worktree-isolated, NO immediate PR
+
+Fan out one produce agent per candidate in the round, each in its own git worktree (`isolation: 'worktree'`), each branching off current `origin/main`. Every agent applies its port + strip-recipe, runs the **local CI parity** (§5), and **commits locally** — it does **not** push and does **not** open a PR. Distinct-file candidates never collide; the engine's concurrency cap (~10) handles the fan-out.
+
+Output is UNVERIFIED — same as the stock engine. The gate is still the byte-gate (`step-05`), now run locally.
+
+## 3. Verify locally (byte-gate + reviews) before any remote round-trip
+
+Run the whole gate against the **local branches** (`git diff origin/main...contrib/<id>`, re-run tests in throwaway worktrees) — see `step-05` for the risk-stratified layered gate. Fresh-context, produce-blind verifiers work identically on a local commit as on a pushed PR; the invariant is "verify real bytes, not the producer's report," which a local commit satisfies. This is where the speed comes from: **no per-PR remote-CI wait, no per-PR round-trip.**
+
+## 4. Assemble & land as batch tier-PRs
+
+Group the round's verified candidates into a few **tier-PRs** (e.g. guardrails / infra / drop-in / opt-in), not one PR per candidate. Per tier:
+
+1. Octopus-merge the candidate branches onto a fresh tier branch off `origin/main` (distinct files → conflict-free), OR cherry-pick their commits for a **linear, rebase-mergeable** history.
+2. Run the full local CI parity once on the assembled branch (catches cross-candidate interactions the per-candidate runs missed).
+3. Push → open ONE PR → remote CI runs **once** → rebase-merge.
+
+Remote CI now runs ~once per tier, not ~once per candidate. Cross-tier deps still sequence across rounds (a Round-1 tier is produced off the updated `main` after Round-0 tiers merge).
+
+## 5. Local CI parity — run EXACTLY what remote CI runs
+
+Local-first only saves time if local checks match CI; otherwise you churn on red remote CI. Before opening any PR, on the assembled tier branch run the full parity — and mind the template's gotchas that silently pass a naive local check:
+
+- **Lint by EXIT CODE, not by grepping output.** eslint colorizes with ANSI codes, so `grep '  error  '` misses real errors → false "0 errors." Use `npm run lint` and check `$?`.
+- **eslint lints workflow YAML too** — a `.yml` quote-style error fails `Lint & Types`.
+- **Run the FULL test suite**, not a subset. A change to a shared component breaks its *consumers'* tests (e.g. a `ThemeToggle` change broke `AdminHeader.test.tsx`), which a scoped `vitest run src/components/theme` never sees.
+- **commitlint**: subject ≤100 chars **and** lowercase-first-word after the type (`subject-case`). Cap produce commit subjects ≤70 to be safe.
+- **`package-lock.json` sync**: if a candidate adds a dep to `package.json`, regenerate the lock (`npm install --package-lock-only`) and commit it, or CI's `npm ci` fails.
+- **Required env vars**: set `DB_SCHEMA=vt_saas NEXT_PUBLIC_DB_SCHEMA=vt_saas` for any command that loads `Env` (both are required post-guardrails; a missing one throws at import → build/test fail).
+- **A new required env var** must be added to the CI job env blocks AND flagged as a Vercel-env action for the maintainer (Vercel env is separate from GitHub CI).
+- **Pre-existing local failures ≠ your regression**: the PGlite integration tests (`tests/integration/api/*`) fail locally with `type "…" already exists` (leftover local DB state) but pass in CI's fresh DB — confirm the same set fails on `origin/main` before worrying.
+- **Contributing a fail-on-X gate** (e.g. `npm audit --audit-level=high`) to a repo with pre-existing debt: ship it **advisory** (`continue-on-error: true`) first + a tracked remediation, so it doesn't block on debt it didn't introduce.
+
+## 6. Batch the human gates
+
+Match human intervention to the risk, not to the mechanics. Get the user to **approve a round's scope once**, then run produce → local-verify → assemble autonomously; the hard, unskippable human gate is **merge** (append-only, rebase-only, force-push routed to the user). Don't gate every candidate or every wave — that's what made the stock loop feel heavy.

--- a/.claude/skills/upstream-contribute/steps/step-01-context-prereqs.md
+++ b/.claude/skills/upstream-contribute/steps/step-01-context-prereqs.md
@@ -1,24 +1,24 @@
 ---
-name: 'step-01-context-prereqs'
-description: 'Resolve repo identity, package manager, gh/git readiness; resume-vs-new; nudge to the right repo/phase; echo + confirm SOURCE/TARGET/PLAN before anything downstream.'
-workflow_path: '${CLAUDE_SKILL_DIR}'
-thisStepFile: '{workflow_path}/steps/step-01-context-prereqs.md'
-nextStepFile: '{workflow_path}/steps/step-02-identify.md'
-workflowFile: '{workflow_path}/SKILL.md'
-detectScript: '{workflow_path}/scripts/detect-context.sh'
+name: "step-01-context-prereqs"
+description: "Resolve repo identity, package manager, gh/git readiness; resume-vs-new; nudge to the right repo/phase; echo + confirm SOURCE/TARGET/PLAN before anything downstream."
+workflow_path: "${CLAUDE_SKILL_DIR}"
+thisStepFile: "{workflow_path}/steps/step-01-context-prereqs.md"
+nextStepFile: "{workflow_path}/steps/step-02-identify.md"
+workflowFile: "{workflow_path}/SKILL.md"
+detectScript: "{workflow_path}/scripts/detect-context.sh"
 ---
 
 # Step 01 — Context & Prereqs
 
 ## STEP GOAL
 
-Pin down *where we are* and *that we can work*, then point at the right next move. By the end you've resolved repo **identity** (template or which downstream product), the package manager, `gh` auth and a clean tree; decided **resume vs. fresh**; nudged toward the canonical home for the requested phase; and **echoed + had the user confirm** the absolute `SOURCE` / `TARGET` / `PLAN` paths. Nothing produces or merges until that confirmation lands.
+Pin down _where we are_ and _that we can work_, then point at the right next move. By the end you've resolved repo **identity** (template or which downstream product), the package manager, `gh` auth and a clean tree; decided **resume vs. fresh**; nudged toward the canonical home for the requested phase; and **echoed + had the user confirm** the absolute `SOURCE` / `TARGET` / `PLAN` paths. Nothing produces or merges until that confirmation lands.
 
 ## Constraints
 
 - **Fail closed on identity.** If `detect-context.sh` can't resolve which repo is which, STOP and ask — never guess `SOURCE`/`TARGET`. Two repos addressed by absolute path is the whole safety model; a wrong guess ports product copy into the template or merges into a product.
 - **Identity = remote/marker, not folder name.** Worktrees and clones get renamed; the cwd basename lies. Trust the git remote or the template marker the script checks, never the directory name.
-- **The engine is unverified and the plan is the only resumable state.** There is no "produce checkpoint" to resume — resuming means re-pointing at an in-progress plan sidecar in the *product*, not continuing a dead engine run (see HARD RULE 2 in `{workflowFile}`).
+- **The engine is unverified and the plan is the only resumable state.** There is no "produce checkpoint" to resume — resuming means re-pointing at an in-progress plan sidecar in the _product_, not continuing a dead engine run (see HARD RULE 2 in `{workflowFile}`).
 - **Confirmation is a hard gate.** No identify/produce/merge reasoning before the user OKs the echoed paths.
 
 ## Sequence of Instructions
@@ -39,7 +39,7 @@ Report the resolved facts in one compact block (identity, package manager, `gh`,
 
 ### 3. Resume vs. fresh
 
-Look for an in-progress contribution-plan sidecar **in the product** (the plan is a product-side artifact). If one exists, summarize it (wave schedule, what's merged, what's pending) and offer:
+Look for an in-progress contribution-plan sidecar in the **template's scratch area** (where the skill runs — assume template-run; see `step-03`), falling back to the product only for a product-driven run. If one exists, summarize it (wave schedule, what's merged, what's pending) and offer:
 
 - **Continue** — adopt that plan, jump past Identify/Plan to where it left off.
 - **Fresh** — start a new pass from Identify; leave the old sidecar untouched.

--- a/.claude/skills/upstream-contribute/steps/step-02-identify.md
+++ b/.claude/skills/upstream-contribute/steps/step-02-identify.md
@@ -1,10 +1,10 @@
 ---
-name: 'step-02-identify'
-description: 'Audit the product↔template delta and tag each candidate against the contribution rubric'
-workflow_path: '${CLAUDE_SKILL_DIR}'
-thisStepFile: '{workflow_path}/steps/step-02-identify.md'
-nextStepFile: '{workflow_path}/steps/step-03-plan.md'
-workflowFile: '{workflow_path}/SKILL.md'
+name: "step-02-identify"
+description: "Audit the product↔template delta and tag each candidate against the contribution rubric"
+workflow_path: "${CLAUDE_SKILL_DIR}"
+thisStepFile: "{workflow_path}/steps/step-02-identify.md"
+nextStepFile: "{workflow_path}/steps/step-03-plan.md"
+workflowFile: "{workflow_path}/SKILL.md"
 ---
 
 # Identify — what is worth contributing up?
@@ -16,7 +16,7 @@ Compute the delta between the product and template main, screen each candidate a
 ## Constraints
 
 - **Best run from the product** (per WHERE-TO-RUN) — the delta needs product depth, and the plan it feeds is a product-side artifact. If step 01 landed you in the template, say so and offer to switch; don't fake product depth from the template side.
-- **Verify generic-vs-specific against source, never names.** A file called `email-service.ts` may be 90% template seam + 10% product copy. Read it. The one-line test for every candidate: *does this create fleet leverage?* If not, it stays in the product.
+- **Verify generic-vs-specific against source, never names.** A file called `email-service.ts` may be 90% template seam + 10% product copy. Read it. The one-line test for every candidate: _does this create fleet leverage?_ If not, it stays in the product.
 - **Dedupe ruthlessly.** A candidate already on template `main` or sitting in an open template PR is not a candidate. Check both before tagging.
 - This phase is unverified scouting, not the byte-gate. Cite evidence so phase 03 can trust the list, but the merge gate is still phase 05.
 
@@ -26,14 +26,16 @@ Compute the delta between the product and template main, screen each candidate a
 
 Spread the audit across the product's subsystems rather than reading it as one blob — auth, middleware/proxy, AI layer, jobs/publish, payments/subscriptions, email, DB workflow/migrations, UI primitives, config/env, scripts/CI. Dispatch parallel **read-only** subagents, one per subsystem cluster, each returning candidates as `file:line` + a one-line "what's generic here." Maximize the fan-out; these don't depend on each other.
 
-Each subagent's job is the *delta*, not an inventory: what does the product now have that is generic **and** not already upstream. Hand every subagent the dedupe inputs — template `main` (the canonical home) and the list of open template PRs (`gh pr list`) — so it screens before it reports.
+Each subagent's job is the _delta_, not an inventory: what does the product now have that is generic **and** not already upstream. Hand every subagent the dedupe inputs — template `main` (the canonical home), the list of open template PRs (`gh pr list`), **and the maintainer's open issues** (`gh issue list`) — so it screens before it reports.
+
+**Read the maintainer's backlog FIRST — before the delta audit, not after.** Open issues and any prior-run tracking issue (e.g. a _"follow-ups deferred during the &lt;product&gt; contribution"_ issue from an earlier run) are not just dedupe — they carry the maintainer's **already-made design decisions** (e.g. "put placeholders in a `site-config.ts`", "ship legal pages as scaffolds with an AI-drafted banner", the exact CI/branch-protection plan) and a **ready list of pre-scoped candidates** (prior deferrals). Aligning candidates to that intent up front — instead of discovering it mid-run — stops you re-deriving decisions the maintainer already documented and re-proposing work already tracked.
 
 ### 2. Screen each candidate against the rubric
 
 For every returned candidate, answer the spine's five questions against the actual source:
 
-1. **Generic?** — pattern, not product instance. (If it carries ContentFlow copy/brand/domain/schema-name, it's not generic *as-is* — see the strip-recipe below.)
-2. **Leverage?** — does it speed the *next* product, or prevent a *class* of bug? This is the one-line test; a yes here is the whole reason to contribute.
+1. **Generic?** — pattern, not product instance. (If it carries ContentFlow copy/brand/domain/schema-name, it's not generic _as-is_ — see the strip-recipe below.)
+2. **Leverage?** — does it speed the _next_ product, or prevent a _class_ of bug? This is the one-line test; a yes here is the whole reason to contribute.
 3. **Battle-tested?** — proven in product prod, not dormant/experimental code (e.g. don't harvest a phase-2 feature that's never shipped).
 4. **Most forks want it?** — broadly useful, not a one-off product shape.
 5. **Not already upstream?** — confirmed absent from template main + open PRs.
@@ -43,13 +45,13 @@ For every returned candidate, answer the spine's five questions against the actu
 Resolve every screened candidate to exactly one TAG:
 
 - **drop-in** — generic as-is; copies up unchanged. Low-effort.
-- **generalize** — useful but carries product specifics. Attach a **strip-recipe**: the exact product copy / brand / domain endpoints / schema-name / prices to strip, and the placeholder or example that replaces it. *Strip to the pattern, not the instance — template = scaffold, not library.*
+- **generalize** — useful but carries product specifics. Attach a **strip-recipe**: the exact product copy / brand / domain endpoints / schema-name / prices to strip, and the placeholder or example that replaces it. _Strip to the pattern, not the instance — template = scaffold, not library._
 - **opt-in** — opinionated or heavy subsystem. Note how it ships config-gated / flagged so forks aren't forced into a product-shaping choice.
 - **skip** — fails the rubric (product-specific, dormant, already upstream, or no fleet leverage). One-line reason each; skips are evidence the audit was honest, so keep them visible.
 
 ### 4. Phase Gate
 
-Present the tagged list grouped by tag, each row: candidate · `file:line` · tag · one-line rationale (+ strip-recipe for generalize, gating note for opt-in). Add one red-team line: the sharpest way *missing* a candidate — or harvesting one that's secretly product-shaped — bites the fleet in three months.
+Present the tagged list grouped by tag, each row: candidate · `file:line` · tag · one-line rationale (+ strip-recipe for generalize, gating note for opt-in). Add one red-team line: the sharpest way _missing_ a candidate — or harvesting one that's secretly product-shaped — bites the fleet in three months.
 
 ```
 === IDENTIFY SUMMARY ===

--- a/.claude/skills/upstream-contribute/steps/step-03-plan.md
+++ b/.claude/skills/upstream-contribute/steps/step-03-plan.md
@@ -1,11 +1,11 @@
 ---
-name: 'step-03-plan'
-description: 'Turn tagged candidates into a dependency-ordered wave schedule; write the plan sidecar in the product'
-workflow_path: '${CLAUDE_SKILL_DIR}'
-thisStepFile: '{workflow_path}/steps/step-03-plan.md'
-nextStepFile: '{workflow_path}/steps/step-04-produce.md'
-workflowFile: '{workflow_path}/SKILL.md'
-planTemplate: '{workflow_path}/templates/contribution-plan.template.md'
+name: "step-03-plan"
+description: "Turn tagged candidates into a dependency-ordered wave schedule; write the plan sidecar in the product"
+workflow_path: "${CLAUDE_SKILL_DIR}"
+thisStepFile: "{workflow_path}/steps/step-03-plan.md"
+nextStepFile: "{workflow_path}/steps/step-04-produce.md"
+workflowFile: "{workflow_path}/SKILL.md"
+planTemplate: "{workflow_path}/templates/contribution-plan.template.md"
 ---
 
 # Phase 03 — Plan: candidates → wave schedule
@@ -18,9 +18,9 @@ A wave is the unit the engine runs (step 04). Get the waves right here and produ
 
 ## Constraints
 
-- **The plan sidecar lives in the PRODUCT** (e.g. `_bmad-output/`), built from `{planTemplate}`. Never write it into the template engine — the template stays a scaffold, and this artifact is product state.
+- **The plan sidecar lives where you RUN the skill — assume the template** (the common case: this is the template's own tooling, run from the template against a downstream `SOURCE`). Put it in a **gitignored scratch area** (e.g. `_bmad-output/` or `.claude/tmp/` — whichever the template already gitignores) so it never pollutes the fork-synced tree. Only when a run is genuinely driven _from_ the downstream product does the sidecar live there instead. Built from `{planTemplate}`; it is transient run-state, never committed as template code.
 - **The migration journal is a serial spine, not a parallel field.** `migrations/meta/_journal.json` is an ordered, linear chain — two PRs that each append a migration cannot coexist in one wave. Cap **≤1 migration-bearer per wave**; chain the rest across waves. Most non-migration PRs hang off this spine as parallel leaves.
-- **Across waves is sequential by construction:** the next wave is produced *off the updated `main`* (deps + prior migrations already merged), so produce sees zero reconciliation. Within a wave is parallel. Don't serialize leaves that don't collide.
+- **Across waves is sequential by construction:** the next wave is produced _off the updated `main`_ (deps + prior migrations already merged), so produce sees zero reconciliation. Within a wave is parallel. Don't serialize leaves that don't collide.
 - **Engine batch cap ~3–4 per wave.** Bigger batches dilute the byte-gate and risk a half-run you can't resume (HARD RULE 2). Prefer more, smaller waves.
 - Planning only — no branches, no PRs, no engine. Skip anything tagged `skip`; it never enters a wave (but record the deferral so step 07 files a tracking issue).
 
@@ -28,14 +28,14 @@ A wave is the unit the engine runs (step 04). Get the waves right here and produ
 
 ### 1. Build the dependency DAG (what needs what ON MAIN first)
 
-For each candidate, ask: does this build on a seam another candidate introduces? An opt-in feature that imports a config helper, a route that needs a middleware wrapper, a second migration that assumes the first table — these are edges. The dependent can't be produced until its dependency is *merged to main*. Resolve cycles by splitting or merging candidates; a real cycle is a planning bug.
+For each candidate, ask: does this build on a seam another candidate introduces? An opt-in feature that imports a config helper, a route that needs a middleware wrapper, a second migration that assumes the first table — these are edges. The dependent can't be produced until its dependency is _merged to main_. Resolve cycles by splitting or merging candidates; a real cycle is a planning bug.
 
 ### 2. Build the collision graph over shared hot files
 
 Two PRs collide when they both touch a file `main` will see at merge time. Classify each shared file — the treatment differs:
 
 - **SERIALIZING — migration journal** (`migrations/meta/_journal.json` + snapshots): the linear chain. ≤1 migration-bearer per wave; the rest become a dependency chain across waves.
-- **SERIALIZING — overlapping infra:** two candidates building the *same* table / the *same* subsystem seam. Dependency-order them; never parallel, even if files look additive — the second must be produced against the first.
+- **SERIALIZING — overlapping infra:** two candidates building the _same_ table / the _same_ subsystem seam. Dependency-order them; never parallel, even if files look additive — the second must be produced against the first.
 - **ADDITIVE — cheap union** (schema barrel/`index.ts`, prod-setup, locale JSON, `package.json`): append-only edits that union trivially. Parallel within a wave is fine; reconcile the union at merge.
 
 When unsure whether two PRs are additive or overlapping, treat as overlapping (serialize) — fail-closed, matching the engine's selector posture.
@@ -53,7 +53,7 @@ Pack waves greedily against four gates. A candidate is eligible for wave N when:
 3. wave N holds **≤1 migration-bearer**, and
 4. wave N is **within the batch cap (~3–4)**.
 
-Within a wave: parallel. Across waves: sequential, each produced off the updated main. The result is a serial migration chain with parallel leaves fanning off each wave. State for each candidate: tier, deps, the hot files it touches, and which collision class triggered its placement — so the user can see *why* it landed where it did.
+Within a wave: parallel. Across waves: sequential, each produced off the updated main. The result is a serial migration chain with parallel leaves fanning off each wave. State for each candidate: tier, deps, the hot files it touches, and which collision class triggered its placement — so the user can see _why_ it landed where it did.
 
 ### 5. Write the sidecar, present, gate
 

--- a/.claude/skills/upstream-contribute/steps/step-04-produce.md
+++ b/.claude/skills/upstream-contribute/steps/step-04-produce.md
@@ -1,11 +1,11 @@
 ---
-name: 'step-04-produce'
-description: 'Run the engine for ONE wave, produce-only — open PRs, verify nothing'
-workflow_path: '${CLAUDE_SKILL_DIR}'
-thisStepFile: '{workflow_path}/steps/step-04-produce.md'
-nextStepFile: '{workflow_path}/steps/step-05-verify.md'
-workflowFile: '{workflow_path}/SKILL.md'
-engine: '{workflow_path}/workflows/port-to-template.js'
+name: "step-04-produce"
+description: "Run the engine for ONE wave, produce-only — open PRs, verify nothing"
+workflow_path: "${CLAUDE_SKILL_DIR}"
+thisStepFile: "{workflow_path}/steps/step-04-produce.md"
+nextStepFile: "{workflow_path}/steps/step-05-verify.md"
+workflowFile: "{workflow_path}/SKILL.md"
+engine: "{workflow_path}/workflows/port-to-template.js"
 ---
 
 # Phase 04 — Produce (one wave, produce-only)
@@ -14,9 +14,11 @@ engine: '{workflow_path}/workflows/port-to-template.js'
 
 Fan out the engine across exactly **one wave** of the plan's schedule — produce-agents prep, implement, and push each group's branch and open its PR — and hand the resulting PR list to verify. You walk away with N draft PRs and **zero confidence in them**. The engine's output (including any self-review it ran) is a hypothesis; it carries **zero weight**. The gate is step-05, not here.
 
+> **DEFAULT to the faster local-first model for non-trivial batches — see [`references/fast-execution.md`](../references/fast-execution.md).** Instead of the stock "sequential waves · engine opens a PR per group · merge one-at-a-time", collapse waves → **DAG-depth rounds**, produce all independent candidates **in parallel** (worktree-isolated, NO immediate PR), **verify locally**, then assemble & land as **batch tier-PRs** so remote CI runs once per tier, not once per candidate. The step below (stock per-PR engine) remains the fallback for a handful of candidates where orchestration overhead isn't worth it. Either way, produce output is UNVERIFIED and step-05 is the gate.
+
 ## Constraints
 
-- **Best run from the template** (canonical skill home, where the risk lives). The engine addresses both repos by absolute path, so it functions from any cwd — but confirm repo *identity* before invoking, not cwd name.
+- **Best run from the template** (canonical skill home, where the risk lives). The engine addresses both repos by absolute path, so it functions from any cwd — but confirm repo _identity_ before invoking, not cwd name.
 - **One wave only.** Never widen the group set to drain the backlog faster. Small batches are what let a single engine run finish without resuming, and what keep the verify gate tractable. Later waves come back through this step.
 - **Fail-closed, never default to "all".** If the wave's group set doesn't resolve cleanly from the plan sidecar, STOP and surface it. A silent fallback to every group is the failure this guard exists to prevent — the engine itself errors on an unresolved selector, and so do you.
 - **Never resume a half-finished produce run.** If the engine dies mid-group, re-run that group **fresh** — the idempotent precheck skips already-merged work, so a clean re-run is safe and a resume is not (resuming desyncs reports from bytes). Do not hand the engine a "continue from group K" instruction.
@@ -26,7 +28,7 @@ Fan out the engine across exactly **one wave** of the plan's schedule — produc
 
 ### 1. Resolve this wave's group set
 
-Read the plan sidecar (the wave schedule emitted by step-03). Identify the **next wave that isn't fully merged** and pull its group set — the groups that are parallel-safe *within* this wave. If resolution is ambiguous or empty, treat it as the fail-closed case below — do not guess.
+Read the plan sidecar (the wave schedule emitted by step-03). Identify the **next wave that isn't fully merged** and pull its group set — the groups that are parallel-safe _within_ this wave. If resolution is ambiguous or empty, treat it as the fail-closed case below — do not guess.
 
 ### 2. Echo resolved inputs + confirm (fail-closed)
 
@@ -43,7 +45,7 @@ Proceed? [C] produce  ·  [R] revise the wave
 
 On confirm, run the engine via the **Workflow** tool — not Bash, not Task:
 
-- `scriptPath`: `{engine}`  (i.e. `${CLAUDE_SKILL_DIR}/workflows/port-to-template.js`)
+- `scriptPath`: `{engine}` (i.e. `${CLAUDE_SKILL_DIR}/workflows/port-to-template.js`)
 - `args`: `{ source, target, plan, groups }` — `groups` = exactly the resolved set from step 1, never broader.
 
 Let it run to completion for this wave. It fans out produce-agents in isolated branches with per-group failure isolation; a single group failing does not poison its siblings.

--- a/.claude/skills/upstream-contribute/steps/step-05-verify.md
+++ b/.claude/skills/upstream-contribute/steps/step-05-verify.md
@@ -1,12 +1,12 @@
 ---
-name: 'step-05-verify'
-description: 'Independent fresh-context byte-gate per PR — the only merge gate'
-workflow_path: '${CLAUDE_SKILL_DIR}'
-thisStepFile: '{workflow_path}/steps/step-05-verify.md'
-nextStepFile: '{workflow_path}/steps/step-06-merge.md'
-workflowFile: '{workflow_path}/SKILL.md'
-merge_gate: '{workflow_path}/checklists/merge-gate.md'
-verify_helpers: '{workflow_path}/scripts/verify-pushed-pr.sh'
+name: "step-05-verify"
+description: "Independent fresh-context byte-gate per PR — the only merge gate"
+workflow_path: "${CLAUDE_SKILL_DIR}"
+thisStepFile: "{workflow_path}/steps/step-05-verify.md"
+nextStepFile: "{workflow_path}/steps/step-06-merge.md"
+workflowFile: "{workflow_path}/SKILL.md"
+merge_gate: "{workflow_path}/checklists/merge-gate.md"
+verify_helpers: "{workflow_path}/scripts/verify-pushed-pr.sh"
 ---
 
 # Step 5: Verify — independent byte-gate per PR
@@ -19,7 +19,7 @@ The spine. For every PR the produce wave opened, an independent fresh-context su
 
 - **This is the ONLY merge gate.** The produce run's own review/fix carries zero weight here (`merge-gate.md` is unskippable). Nothing merges that didn't independently PASS.
 - **The verifier is fresh-context and produce-blind.** Its entire context is: PR number/branch, the original finding/claim, and `{merge_gate}`. Do **not** hand it (and instruct it never to read) the produce reports, engine logs, or implementation brief. By construction it sees only the pushed branch — that's the point. A verifier that read the report would just be grading the report.
-- **Trust bytes, not reports.** "Green CI", "tests pass", an engine summary — all hypotheses until `git show` / a re-run confirms them. Treat a check that *skipped* as not-run, not as pass.
+- **Trust bytes, not reports.** "Green CI", "tests pass", an engine summary — all hypotheses until `git show` / a re-run confirms them. Treat a check that _skipped_ as not-run, not as pass.
 - **FAIL means re-produce fresh, not patch-in-place.** Never resume or hand-tweak a failed branch from the main session — that desyncs reports from bytes. Loop the failed group back through produce clean (step 04); the idempotent precheck skips what already merged.
 - Read-only here. This step opens no PRs and merges nothing.
 
@@ -27,7 +27,7 @@ The spine. For every PR the produce wave opened, an independent fresh-context su
 
 ### 1. Enumerate what the wave actually pushed
 
-Collect the PRs this wave opened — number, branch, the finding/claim each one answers, and its risk tier (carried from the plan). Confirm each is real and open (`gh pr view`); a PR the engine *reported* but didn't push is itself a FAIL — flag it, no verifier needed.
+Collect the PRs this wave opened — number, branch, the finding/claim each one answers, and its risk tier (carried from the plan). Confirm each is real and open (`gh pr view`); a PR the engine _reported_ but didn't push is itself a FAIL — flag it, no verifier needed.
 
 ### 2. Tier verification depth by risk
 
@@ -36,6 +36,16 @@ Match scrutiny to blast radius — over-verifying drop-ins wastes the budget tha
 - **Drop-in / low-risk** (config, copy-stripped scaffold, mechanical): light pass — confirm the bytes exist and nothing product-specific leaked.
 - **Generalize / medium**: standard gate — bytes + the relevant test re-run + strip-to-pattern check.
 - **Security / payment / auth / HIGH**: adversarial — spawn **multiple skeptics**, and **replay the exploit or failing test against the pushed branch** (the helpers in `{verify_helpers}` exist for exactly this). One PASS isn't enough until the original attack provably no longer works.
+
+### 2b. Layer independent reviews on the byte-gate (the byte-gate alone is claim-blind)
+
+The byte-gate verifies **claim-fidelity** — that the pushed code _matches what the produce agent said it would do_. Necessary, but **structurally blind to whether the claim itself is correct**: if the design has a hole the claim never covered, the byte-gate PASSes a real defect. Close that blind spot by layering fresh-context, **produce-blind** reviews on top, scaled by risk:
+
+- **`/code-review` on every tier** (correctness + reuse/simplification). Catches design/logic defects the claim omits and re-implementations of things the template already has. _Proven:_ it caught a webhook concurrency regression the claim-check passed, and a PostHog `$set`-nesting no-op whose mocked test passed.
+- **`/security-review` on the payment / auth / entitlement / security tiers** (authz, injection, secret handling, data exposure).
+- **Adversarial skeptics** (per the HIGH tier above) — prompt them to _refute_ and re-run the exploit/test; they catch entitlement/logic holes a single verifier misses. _Proven:_ skeptics caught a never-expiring-promotion defect the primary verifier passed.
+
+Run these on the same bytes (local branch or pushed PR — see `references/fast-execution.md`), produce-blind, and treat any confirmed finding as a FAIL routed back through produce/fix → re-verify. Cheap on drop-ins; worth every token on payment/auth.
 
 ### 3. Spawn one fresh verifier per PR
 


### PR DESCRIPTION
## Institutionalize learnings from the ContentFlow contribution run

Four process improvements to the `upstream-contribute` skill, distilled from a full run (PRs #355–#363). All docs-only.

1. **Faster execution model** — new `references/fast-execution.md`: default to **local-first + parallel-by-DAG-depth + batch-tier-PR** over the stock sequential-wave/per-PR-engine loop (produce in parallel worktrees → verify locally → land as batch tier-PRs so remote CI runs once per tier). Includes the **local-CI-parity checklist + template gotchas** (lint by exit-code, full vitest, commitlint ≤100/lowercase, package-lock sync, `NEXT_PUBLIC_DB_SCHEMA` env, eslint-lints-YAML, PGlite-integration-tests-fail-locally, advisory-first for fail-on-debt gates) that cost ~6 red-CI round-trips this run. `step-04` now points to it as the default; stock engine kept as fallback.
2. **Risk-stratified layered gate** (`step-05`) — the byte-gate verifies *claim-fidelity* but is **blind to whether the claim itself is correct**; layer produce-blind `/code-review` (all tiers) + `/security-review` (payment/auth/security) + adversarial skeptics. Cites the 3 real defects each layer caught this run (webhook race, PostHog `$set` nesting, never-expiring promo).
3. **Issue-first identify** (`step-02`) — read the maintainer's open issues + prior-run tracking issues **before** the delta audit (design decisions + prior deferrals + dedupe context), not mid-run.
4. **State co-located in the template** (`step-01` + `step-03`) — assume template-run; the plan sidecar + scratch live in the template's gitignored scratch, not the downstream product repo.

_Filed via `/compound`._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
