### PR TITLE
fix(jobs): log silently-swallowed stale-reset errors in claimDueTasks

### DIFF
--- a/src/libs/jobs/claim.test.ts
+++ b/src/libs/jobs/claim.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { logger } from '@/libs/Logger';
 import { createAdminClient } from '@/libs/supabase/admin';
 
 import { claimDueTasks, STALE_TASK_THRESHOLD_MS } from './claim';
@@ -18,9 +19,14 @@ vi.mock('@/libs/supabase/admin', () => ({
   createAdminClient: vi.fn(),
 }));
 
+vi.mock('@/libs/Logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
+}));
+
 type SupabaseMockOptions = {
   tasksData?: unknown;
   tasksError?: unknown;
+  staleError?: unknown;
 };
 
 /**
@@ -33,10 +39,14 @@ function buildSupabaseMock(options: SupabaseMockOptions = {}) {
     data: options.tasksData ?? [],
     error: options.tasksError ?? null,
   });
-  const lteOnClaimMock = vi.fn().mockReturnValue({ select: selectAfterUpdateMock });
+  const lteOnClaimMock = vi
+    .fn()
+    .mockReturnValue({ select: selectAfterUpdateMock });
   const eqOnClaimMock = vi.fn().mockReturnValue({ lte: lteOnClaimMock });
 
-  const lteOnStaleMock = vi.fn().mockResolvedValue({ data: null, error: null });
+  const lteOnStaleMock = vi
+    .fn()
+    .mockResolvedValue({ data: null, error: options.staleError ?? null });
   const inOnStaleMock = vi.fn().mockReturnValue({ lte: lteOnStaleMock });
 
   let updateCallCount = 0;
@@ -81,7 +91,10 @@ describe('claimDueTasks', () => {
     const after = new Date().toISOString();
 
     expect(mockSupabase.from).toHaveBeenCalledWith('scheduled_tasks');
-    expect(mockSupabase._eqOnClaimMock).toHaveBeenCalledWith('status', 'scheduled');
+    expect(mockSupabase._eqOnClaimMock).toHaveBeenCalledWith(
+      'status',
+      'scheduled',
+    );
     expect(mockSupabase._selectAfterUpdateMock).toHaveBeenCalledWith('id');
     expect(mockSupabase._lteOnClaimMock).toHaveBeenCalledOnce();
 
@@ -132,7 +145,8 @@ describe('claimDueTasks', () => {
     ]);
     expect(mockSupabase._lteOnStaleMock).toHaveBeenCalledOnce();
 
-    const [staleField, staleValue] = mockSupabase._lteOnStaleMock.mock.calls[0]!;
+    const [staleField, staleValue]
+      = mockSupabase._lteOnStaleMock.mock.calls[0]!;
 
     expect(staleField).toBe('updated_at');
     expect(STALE_TASK_THRESHOLD_MS).toBe(30 * 60 * 1000);
@@ -150,5 +164,25 @@ describe('claimDueTasks', () => {
     );
 
     await expect(claimDueTasks()).rejects.toThrow(/connection lost/);
+  });
+
+  it('logs but does not throw when the stale-reset UPDATE errors', async () => {
+    const mockSupabase = buildSupabaseMock({
+      tasksData: [{ id: 't-1' }],
+      staleError: { message: 'stale-reset write failed' },
+    });
+    vi.mocked(createAdminClient).mockReturnValue(
+      mockSupabase as unknown as ReturnType<typeof createAdminClient>,
+    );
+
+    // The atomic claim already succeeded, so a failed best-effort stale-reset
+    // must not fail the tick — it returns the claimed IDs and logs the error.
+    const result = await claimDueTasks();
+
+    expect(result).toEqual(['t-1']);
+    expect(logger.error).toHaveBeenCalledWith(
+      { error: 'stale-reset write failed' },
+      expect.stringContaining('stale-reset failed'),
+    );
   });
 });

--- a/src/libs/jobs/claim.ts
+++ b/src/libs/jobs/claim.ts
@@ -1,4 +1,5 @@
 import type { ScheduledTaskWrite } from '@/libs/jobs/types';
+import { logger } from '@/libs/Logger';
 import { createAdminClient } from '@/libs/supabase/admin';
 
 /**
@@ -56,11 +57,21 @@ export async function claimDueTasks(): Promise<string[]> {
     status: 'scheduled',
     updated_at: new Date().toISOString(),
   };
-  await supabase
+  const { error: staleError } = await supabase
     .from('scheduled_tasks')
     .update(resetPayload as never)
     .in('status', ['claimed', 'running'])
     .lte('updated_at', staleThreshold);
+
+  // Best-effort: a failed stale-reset must not fail the tick — the claim above
+  // already succeeded and its IDs must be returned. Log it (the next tick retries
+  // the reset anyway) so a persistently stuck reset is observable rather than silent.
+  if (staleError) {
+    logger.error(
+      { error: staleError.message },
+      '[scheduled-tasks-cron] stale-reset failed; in-flight tasks remain until the next tick',
+    );
+  }
 
   return (tasks ?? []).map((t: { id: string }) => t.id);
 }


### PR DESCRIPTION
## Closes #345 (item 2) — surface silently-swallowed stale-reset errors

The canonical `src/libs/jobs/claim.ts` discarded the result of its best-effort **stale-reset** UPDATE — if that write failed, nothing was logged and stuck-in-flight tasks would silently wait for a later tick with no signal. This is the observability/robustness polish tracked in #345 item 2 (the refinement dropped during the #335↔#336 job-infra reconcile).

**Change:** capture the stale-reset `error` and `logger.error` it (pino, matching the sibling `blocking.ts` convention). Deliberately **non-throwing** — the atomic claim above has already succeeded and its IDs must be returned; a failed best-effort reset must not fail the whole tick (the next tick retries the reset anyway). The `'running'`-status allowance from #345's description is already present (`['claimed','running']`), and the claim path already throws on failure.

**Test:** new case asserting the stale-reset error is logged, `claimDueTasks()` does **not** throw, and it still returns the claimed IDs.

### Verification (local)
- `lint:fix` clean · `check-types` clean · `vitest src/libs/jobs src/libs/inngest` → 19/19 (incl. the new case)
- `next build` not run locally (Turbopack workspace-root inference fails from the nested `.claude/worktrees/` path — no isolated `node_modules`); the change is a lib-file log line with no route/config/dep impact, and remote CI runs the real build.

Scope: one file + its test. `fix` (patch) — closes a silent-error gap.
