### PR TITLE
feat(admin): isolate admin panel from consumer theme system (#175)

### DIFF
--- a/.claude/rules/admin.md
+++ b/.claude/rules/admin.md
@@ -1,0 +1,29 @@
+---
+paths:
+  - "src/components/admin/**"
+  - "src/app/[locale]/(admin)/**"
+  - "src/app/api/admin/**"
+---
+
+# Admin panel styling
+
+Admin is a **maintainer tool** — it must NOT follow the consumer product theme.
+A downstream fork can ship warm/sage/branded consumer themes; the admin panel
+stays on the default slate/blue palette regardless.
+
+- **How it works:** `AdminLayoutClient` sets `data-admin` on its root div (SSR,
+  no flash) and mirrors it onto `document.body` via a client effect. The
+  `[data-admin]` / `.dark [data-admin]` blocks in `src/styles/global.css`
+  re-declare the full default token set, so admin always renders the default
+  light/dark theme. Light/dark is respected; theme hue is not.
+- **The body mirror is load-bearing.** Radix portals (Dialog, Sheet, Popover,
+  Select, DropdownMenu, Tooltip) mount to `document.body`, outside the layout
+  div. Without `data-admin` on `body` they escape the scope and leak the
+  consumer theme. Don't remove the body effect.
+- **Use theme tokens** (`bg-sidebar`, `bg-card`, `bg-muted`,
+  `text-muted-foreground`, `border-sidebar-border`, …). They resolve to the
+  admin-scoped values automatically. **Never** hardcode colors (`bg-slate-800`,
+  `bg-blue-600`, `dark:bg-black`) and **never** add a consumer-theme class here.
+- **To retint admin,** edit the two `[data-admin]` blocks in `global.css` —
+  nowhere else. The sidebar is intentionally always-dark (overrides the
+  near-white default `--sidebar`).

--- a/src/components/admin/AdminLayoutClient.tsx
+++ b/src/components/admin/AdminLayoutClient.tsx
@@ -3,7 +3,12 @@
 import type { ReactNode } from 'react';
 import { useEffect, useRef, useState } from 'react';
 
-import { Sheet, SheetContent, SheetDescription, SheetTitle } from '@/components/ui/sheet';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetTitle,
+} from '@/components/ui/sheet';
 
 import { AdminHeader } from './AdminHeader';
 import { AdminSidebar } from './AdminSidebar';
@@ -39,7 +44,10 @@ export function AdminLayoutClient({ children }: AdminLayoutClientProps) {
 
   useEffect(() => {
     if (isInitialized.current) {
-      localStorage.setItem('admin_sidebar_collapsed', sidebarCollapsed ? 'true' : 'false');
+      localStorage.setItem(
+        'admin_sidebar_collapsed',
+        sidebarCollapsed ? 'true' : 'false',
+      );
     }
   }, [sidebarCollapsed]);
 
@@ -54,6 +62,15 @@ export function AdminLayoutClient({ children }: AdminLayoutClientProps) {
     return () => window.removeEventListener('resize', handleResize);
   }, [mobileMenuOpen]);
 
+  // Pin admin to a theme-independent palette. The root div below carries
+  // `data-admin` for SSR'd content (no flash); mirror it onto `document.body`
+  // so Radix portals (Dialog, Sheet, Popover, …) — which mount to `body` and
+  // escape the div — also resolve the admin-scoped tokens. See global.css.
+  useEffect(() => {
+    document.body.setAttribute('data-admin', '');
+    return () => document.body.removeAttribute('data-admin');
+  }, []);
+
   // Keyboard shortcut: Escape closes mobile menu
   useEffect(() => {
     const handleKeyboard = (e: KeyboardEvent) => {
@@ -66,24 +83,20 @@ export function AdminLayoutClient({ children }: AdminLayoutClientProps) {
   }, [mobileMenuOpen]);
 
   return (
-    <div className="flex h-screen overflow-hidden bg-slate-100 dark:bg-zinc-950">
+    <div data-admin className="flex h-screen overflow-hidden bg-muted">
       {/* Desktop Sidebar */}
       <aside className="hidden md:flex" aria-label="Admin sidebar">
-        <AdminSidebar
-          collapsed={sidebarCollapsed}
-          onLinkClick={() => {}}
-        />
+        <AdminSidebar collapsed={sidebarCollapsed} onLinkClick={() => {}} />
       </aside>
 
       {/* Mobile Sidebar (Sheet) */}
       <Sheet open={mobileMenuOpen} onOpenChange={setMobileMenuOpen}>
         <SheetContent side="left" className="w-60 p-0">
           <SheetTitle className="sr-only">Admin Navigation</SheetTitle>
-          <SheetDescription className="sr-only">Main admin navigation menu</SheetDescription>
-          <AdminSidebar
-            mobile
-            onLinkClick={() => setMobileMenuOpen(false)}
-          />
+          <SheetDescription className="sr-only">
+            Main admin navigation menu
+          </SheetDescription>
+          <AdminSidebar mobile onLinkClick={() => setMobileMenuOpen(false)} />
         </SheetContent>
       </Sheet>
 
@@ -95,9 +108,7 @@ export function AdminLayoutClient({ children }: AdminLayoutClientProps) {
           sidebarCollapsed={sidebarCollapsed}
         />
 
-        <main className="flex-1 overflow-y-auto p-4 lg:p-6">
-          {children}
-        </main>
+        <main className="flex-1 overflow-y-auto p-4 lg:p-6">{children}</main>
       </div>
     </div>
   );

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -47,7 +47,11 @@ type AdminSidebarProps = {
  * - Collapsed/expanded modes
  * - Dark sidebar background
  */
-export function AdminSidebar({ collapsed = false, mobile = false, onLinkClick }: AdminSidebarProps) {
+export function AdminSidebar({
+  collapsed = false,
+  mobile = false,
+  onLinkClick,
+}: AdminSidebarProps) {
   const t = useTranslations('Admin');
   const pathname = usePathname();
 
@@ -57,14 +61,22 @@ export function AdminSidebar({ collapsed = false, mobile = false, onLinkClick }:
       group: t('nav.overview'),
       items: [
         { label: t('nav.dashboard'), href: '/admin', icon: LayoutDashboard },
-        { label: t('nav.analytics'), href: '/admin/analytics', icon: BarChart3 },
+        {
+          label: t('nav.analytics'),
+          href: '/admin/analytics',
+          icon: BarChart3,
+        },
       ],
     },
     {
       group: t('nav.management'),
       items: [
         { label: t('nav.users'), href: '/admin/users', icon: Users },
-        { label: t('nav.feedback'), href: '/admin/feedback', icon: MessageSquareText },
+        {
+          label: t('nav.feedback'),
+          href: '/admin/feedback',
+          icon: MessageSquareText,
+        },
       ],
     },
     {
@@ -98,20 +110,20 @@ export function AdminSidebar({ collapsed = false, mobile = false, onLinkClick }:
     <div
       className={cn(
         'flex h-full flex-col',
-        'bg-slate-800 dark:bg-black',
+        'bg-sidebar',
         'transition-all duration-200',
         sidebarWidth,
       )}
       data-testid="admin-sidebar"
     >
       {/* Logo/Brand area */}
-      <div className="flex h-16 items-center border-b border-slate-700 px-4">
+      <div className="flex h-16 items-center border-b border-sidebar-border px-4">
         <div className="flex items-center gap-3">
-          <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-blue-600">
-            <Shield className="size-4 text-white" />
+          <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-sidebar-primary">
+            <Shield className="size-4 text-sidebar-primary-foreground" />
           </div>
           {(!collapsed || mobile) && (
-            <span className="text-lg font-semibold text-white">
+            <span className="text-lg font-semibold text-sidebar-foreground">
               {t('brand')}
             </span>
           )}
@@ -119,16 +131,18 @@ export function AdminSidebar({ collapsed = false, mobile = false, onLinkClick }:
       </div>
 
       {/* Navigation groups */}
-      <nav className="flex-1 overflow-y-auto p-2" role="navigation" aria-label="Admin navigation">
+      <nav
+        className="flex-1 overflow-y-auto p-2"
+        role="navigation"
+        aria-label="Admin navigation"
+      >
         {navGroups.map((group, groupIndex) => (
           <div key={group.group} className="py-2">
-            {groupIndex > 0 && (
-              <Separator className="my-2 bg-slate-700" />
-            )}
+            {groupIndex > 0 && <Separator className="my-2 bg-sidebar-border" />}
 
             {/* Group label - hidden when collapsed */}
             {(!collapsed || mobile) && (
-              <div className="mb-2 px-3 text-xs font-semibold uppercase tracking-wider text-slate-400">
+              <div className="mb-2 px-3 text-xs font-semibold uppercase tracking-wider text-sidebar-foreground/70">
                 {group.group}
               </div>
             )}
@@ -148,16 +162,14 @@ export function AdminSidebar({ collapsed = false, mobile = false, onLinkClick }:
                         'flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium',
                         'transition-colors duration-150',
                         active
-                          ? 'bg-slate-700 text-white'
-                          : 'text-slate-300 hover:bg-slate-700/50 hover:text-white',
+                          ? 'bg-sidebar-accent text-sidebar-accent-foreground'
+                          : 'text-sidebar-foreground hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground',
                         collapsed && !mobile && 'justify-center px-2',
                       )}
                       aria-current={active ? 'page' : undefined}
                     >
                       <Icon className="size-5 shrink-0" />
-                      {(!collapsed || mobile) && (
-                        <span>{item.label}</span>
-                      )}
+                      {(!collapsed || mobile) && <span>{item.label}</span>}
                     </Link>
                   </li>
                 );

--- a/src/components/admin/__tests__/AdminLayoutClient.test.tsx
+++ b/src/components/admin/__tests__/AdminLayoutClient.test.tsx
@@ -87,7 +87,9 @@ describe('AdminLayoutClient', () => {
         </AdminLayoutClient>,
       );
 
-      expect(localStorageMock.getItem).toHaveBeenCalledWith('admin_sidebar_collapsed');
+      expect(localStorageMock.getItem).toHaveBeenCalledWith(
+        'admin_sidebar_collapsed',
+      );
     });
 
     it('saves collapsed state to localStorage when toggled', async () => {
@@ -104,7 +106,10 @@ describe('AdminLayoutClient', () => {
       await user.click(toggleButton);
 
       await waitFor(() => {
-        expect(localStorageMock.setItem).toHaveBeenCalledWith('admin_sidebar_collapsed', 'true');
+        expect(localStorageMock.setItem).toHaveBeenCalledWith(
+          'admin_sidebar_collapsed',
+          'true',
+        );
       });
     });
   });
@@ -120,7 +125,9 @@ describe('AdminLayoutClient', () => {
       );
 
       // Click mobile menu button
-      const menuButton = screen.getByRole('button', { name: /open navigation menu/i });
+      const menuButton = screen.getByRole('button', {
+        name: /open navigation menu/i,
+      });
       await user.click(menuButton);
 
       // Sheet should be open - look for close button which appears when sheet is open
@@ -141,12 +148,16 @@ describe('AdminLayoutClient', () => {
       );
 
       // Open menu
-      const menuButton = screen.getByRole('button', { name: /open navigation menu/i });
+      const menuButton = screen.getByRole('button', {
+        name: /open navigation menu/i,
+      });
       await user.click(menuButton);
 
       // Wait for sheet to open
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /close/i })).toBeInTheDocument();
+        expect(
+          screen.getByRole('button', { name: /close/i }),
+        ).toBeInTheDocument();
       });
 
       // Press escape
@@ -154,7 +165,9 @@ describe('AdminLayoutClient', () => {
 
       // Sheet should close
       await waitFor(() => {
-        expect(screen.queryByRole('button', { name: /close/i })).not.toBeInTheDocument();
+        expect(
+          screen.queryByRole('button', { name: /close/i }),
+        ).not.toBeInTheDocument();
       });
     });
   });
@@ -184,7 +197,7 @@ describe('AdminLayoutClient', () => {
       expect(layoutRoot).toHaveClass('overflow-hidden');
     });
 
-    it('has background color classes', () => {
+    it('uses the theme-scoped surface token and admin scope', () => {
       const { container } = render(
         <AdminLayoutClient>
           <div>Content</div>
@@ -193,7 +206,10 @@ describe('AdminLayoutClient', () => {
 
       const layoutRoot = container.firstChild as HTMLElement;
 
-      expect(layoutRoot).toHaveClass('bg-slate-100', 'dark:bg-zinc-950');
+      // Admin pins itself to a theme-independent palette (issue #175):
+      // the surface uses `bg-muted` and the root carries `data-admin`.
+      expect(layoutRoot).toHaveClass('bg-muted');
+      expect(layoutRoot).toHaveAttribute('data-admin');
     });
   });
 

--- a/src/components/admin/__tests__/AdminSidebar.test.tsx
+++ b/src/components/admin/__tests__/AdminSidebar.test.tsx
@@ -54,7 +54,10 @@ describe('AdminSidebar', () => {
 
       const usersLink = screen.getByText('nav.users').closest('a');
 
-      expect(usersLink).toHaveClass('bg-slate-700', 'text-white');
+      expect(usersLink).toHaveClass(
+        'bg-sidebar-accent',
+        'text-sidebar-accent-foreground',
+      );
     });
 
     it('sets aria-current on active item', () => {
@@ -70,7 +73,7 @@ describe('AdminSidebar', () => {
 
       const dashboardLink = screen.getByText('nav.dashboard').closest('a');
 
-      expect(dashboardLink).not.toHaveClass('bg-slate-700');
+      expect(dashboardLink).not.toHaveClass('bg-sidebar-accent');
       expect(dashboardLink).not.toHaveAttribute('aria-current');
     });
   });
@@ -191,13 +194,14 @@ describe('AdminSidebar', () => {
   });
 
   describe('styling', () => {
-    it('has dark background', () => {
+    it('uses the sidebar theme token for its background', () => {
       render(<AdminSidebar />);
 
       const sidebar = screen.getByTestId('admin-sidebar');
 
-      expect(sidebar).toHaveClass('bg-slate-800');
-      expect(sidebar).toHaveClass('dark:bg-black');
+      // The always-dark look now comes from the admin-scoped `--sidebar`
+      // token (issue #175), not a hardcoded slate/black class.
+      expect(sidebar).toHaveClass('bg-sidebar');
     });
 
     it('has transition classes', () => {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -206,6 +206,161 @@
   --sidebar-ring: hsl(217.2 91.2% 59.8%);
 }
 
+/* =============================================================================
+   Admin panel palette — theme-independent (template issue #175)
+
+   Admin is a maintainer tool; it must NOT follow the consumer product theme.
+   `[data-admin]` re-declares the full DEFAULT token set, so the admin panel
+   always looks like the default light/dark theme regardless of which consumer
+   theme (warm, sage, …) is active. It respects light/dark only, never hue.
+
+   Scope is applied on BOTH the admin layout root (SSR, no flash for the main
+   UI) AND `document.body` (via a client effect) so Radix portals — Dialog,
+   Sheet, Popover, Select, DropdownMenu, Tooltip — which mount to `body` and
+   would otherwise escape the scope, also pick up the admin palette.
+
+   The sidebar keeps its own always-dark identity (slate-800 / blue-600),
+   overriding the near-white default `--sidebar`. To retint admin, edit these
+   two blocks only — nowhere else.
+
+   NOTE ON THE `--color-*` RE-ALIAS BELOW: Tailwind's `@theme` emits
+   `--color-x: var(--x)` at `:root`, which is substituted once at `<html>` and
+   inherits down as a frozen value. Overriding a raw `--x` on a *descendant*
+   scope like `[data-admin]` therefore does NOT reach the Tailwind utilities
+   (`bg-sidebar`, `bg-card`, …) — they'd keep the html-level color. The
+   consumer multi-theme system dodges this only because next-themes sets the
+   theme class on `<html>` itself. A descendant scope must re-alias the
+   `--color-*` tokens so they recompute here against the admin raw tokens.
+   ============================================================================= */
+[data-admin] {
+  /* Re-alias Tailwind's theme colors so utilities recompute at this scope
+     (see NOTE above). Declared once here; it resolves against whichever raw
+     `--*` wins on this element, so it covers `.dark [data-admin]` too. */
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
+
+  /* Content surface — default light neutrals (mirror of `:root`) */
+  --border: hsl(214.3 31.8% 91.4%);
+  --input: hsl(214.3 31.8% 91.4%);
+  --ring: hsl(222.2 84% 4.9%);
+  --background: hsl(0 0% 100%);
+  --foreground: hsl(222.2 84% 4.9%);
+
+  --primary: hsl(222.2 47.4% 11.2%);
+  --primary-foreground: hsl(210 40% 98%);
+
+  --secondary: hsl(210 40% 96.1%);
+  --secondary-foreground: hsl(222.2 47.4% 11.2%);
+
+  --destructive: hsl(0 84.2% 60.2%);
+  --destructive-foreground: hsl(210 40% 98%);
+
+  --muted: hsl(210 40% 96.1%);
+  --muted-foreground: hsl(215.4 16.3% 42%);
+
+  --accent: hsl(210 40% 96.1%);
+  --accent-foreground: hsl(222.2 47.4% 11.2%);
+
+  --popover: hsl(0 0% 100%);
+  --popover-foreground: hsl(222.2 84% 4.9%);
+
+  --card: hsl(0 0% 100%);
+  --card-foreground: hsl(222.2 84% 4.9%);
+
+  --chart-1: hsl(12 76% 61%);
+  --chart-2: hsl(173 58% 39%);
+  --chart-3: hsl(197 37% 24%);
+  --chart-4: hsl(43 74% 66%);
+  --chart-5: hsl(27 87% 67%);
+
+  /* Always-dark sidebar (was bg-slate-800 / border-slate-700 / bg-blue-600) */
+  --sidebar: hsl(217 33% 17%); /* slate-800 */
+  --sidebar-foreground: hsl(213 27% 84%); /* slate-300 */
+  --sidebar-primary: hsl(221 83% 53%); /* blue-600 */
+  --sidebar-primary-foreground: hsl(0 0% 100%);
+  --sidebar-accent: hsl(215 25% 27%); /* slate-700 */
+  --sidebar-accent-foreground: hsl(0 0% 100%);
+  --sidebar-border: hsl(215 25% 27%); /* slate-700 */
+  --sidebar-ring: hsl(217.2 91.2% 59.8%);
+}
+
+.dark [data-admin] {
+  /* Content surface — default dark neutrals (mirror of `.dark`) */
+  --background: hsl(222.2 84% 4.9%);
+  --foreground: hsl(210 40% 98%);
+
+  --card: hsl(222.2 84% 4.9%);
+  --card-foreground: hsl(210 40% 98%);
+
+  --popover: hsl(222.2 84% 4.9%);
+  --popover-foreground: hsl(210 40% 98%);
+
+  --primary: hsl(210 40% 98%);
+  --primary-foreground: hsl(222.2 47.4% 11.2%);
+
+  --secondary: hsl(217.2 32.6% 17.5%);
+  --secondary-foreground: hsl(210 40% 98%);
+
+  --muted: hsl(217.2 32.6% 17.5%);
+  --muted-foreground: hsl(215 20.2% 65.1%);
+
+  --accent: hsl(217.2 32.6% 17.5%);
+  --accent-foreground: hsl(210 40% 98%);
+
+  --destructive: hsl(0 62.8% 30.6%);
+  --destructive-foreground: hsl(210 40% 98%);
+
+  --border: hsl(217.2 32.6% 17.5%);
+  --input: hsl(217.2 32.6% 17.5%);
+  --ring: hsl(212.7 26.8% 83.9%);
+
+  --chart-1: hsl(220 70% 50%);
+  --chart-2: hsl(160 60% 45%);
+  --chart-3: hsl(30 80% 55%);
+  --chart-4: hsl(280 65% 60%);
+  --chart-5: hsl(340 75% 55%);
+
+  /* Sidebar goes black in dark (was dark:bg-black); rest of the slate set holds */
+  --sidebar: hsl(0 0% 0%);
+  --sidebar-foreground: hsl(213 27% 84%);
+  --sidebar-primary: hsl(221 83% 53%);
+  --sidebar-primary-foreground: hsl(0 0% 100%);
+  --sidebar-accent: hsl(215 25% 27%);
+  --sidebar-accent-foreground: hsl(0 0% 100%);
+  --sidebar-border: hsl(215 25% 27%);
+  --sidebar-ring: hsl(217.2 91.2% 59.8%);
+}
+
 @layer base {
   /* ===========================================================================
      Multi-theme registry — neutral, professional defaults shipped with the


### PR DESCRIPTION
## Summary

Admin is a maintainer tool and should **not** follow the consumer product theme. Previously the admin shell used hardcoded slate/blue classes while other admin components leaked the active consumer theme via `bg-background`/`bg-card`/`text-muted-foreground` — so a fork with a warm/sage theme got a half-tinted admin. This pins admin to a theme-independent default palette, fully isolated from whichever consumer theme is active.

Closes #175.

## Approach

- **Scope, don't edit every component.** `AdminLayoutClient` sets `data-admin` on its root (SSR, no flash) and mirrors it onto `document.body` via a client effect so **Radix portals** (Dialog, Sheet, Popover, Select, DropdownMenu, Tooltip) — which mount to `body` and escape the layout div — also inherit the admin palette.
- **`[data-admin]` / `.dark [data-admin]`** blocks in `global.css` re-declare the full default token set, so admin always renders the default light/dark theme regardless of hue.
- **Sidebar shell** swapped from hardcoded `bg-slate-800`/`bg-blue-600`/`text-slate-300`/etc. to sidebar tokens (`bg-sidebar`, `bg-sidebar-primary`, …). Page background `bg-slate-100 dark:bg-zinc-950` → `bg-muted`.
- **`.claude/rules/admin.md`** documents the invariant for future forks.

### The non-obvious bit (Tailwind v4 `@theme`)

Tailwind emits `--color-x: var(--x)` at `:root`, substituted **once** at `<html>` and inherited down frozen. Overriding a raw `--x` on a *descendant* scope like `[data-admin]` therefore never reaches the utilities — they keep the html-level color. The consumer multi-theme system dodges this only because next-themes sets the theme class on `<html>` itself. Fix: re-alias the `--color-*` tokens inside `[data-admin]` so they recompute at the admin scope.

## Verification

- `npm run lint` · `check-types` · **161 tests** · `npm run build` — all green.
- Browser-verified isolation by reading **applied** `background-color` (not just the CSS variable): admin under `warm-light` is byte-identical to admin under the default theme; dark admin → black sidebar. Screenshot: admin sidebar stays slate-800 + blue-600 while a consumer sidebar in the *same* warm wrapper follows the warm theme.

> Note: only light mode is pixel-identical to before. Dark-mode page background is now `bg-muted` (subtle surface separation) vs the old near-black `zinc-950` — intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)