### PR TITLE
fix(theme)+feat(marketing): app-wide custom-palette cascade fix + scoped marketing theme

### DIFF
--- a/src/app/[locale]/(unauth)/(marketing)/layout.tsx
+++ b/src/app/[locale]/(unauth)/(marketing)/layout.tsx
@@ -1,5 +1,6 @@
 import { AuthDialogProvider } from '@/components/marketing/auth-dialog';
 import { MarketingFooter } from '@/components/marketing/footer';
+import { MarketingThemeScope } from '@/components/marketing/marketing-theme-scope';
 import { MarketingNavbar } from '@/components/marketing/navbar';
 import { isDarkTheme } from '@/components/theme/theme-config';
 import { SITE_CONFIG } from '@/config/site-config';
@@ -25,18 +26,21 @@ import { cn } from '@/utils/Helpers';
  * marketing look from the signed-in user's theme (there is no visitor toggle),
  * so a fork can give the landing site its own brand palette. The class is
  * rendered server-side from static config, so there is NO FOUC. `isDarkTheme`
- * adds `.dark` for dark marketing themes so the few Tailwind `dark:` variant
- * utilities (currently only on /terms + /privacy) resolve to the marketing
- * theme's darkness rather than the app's.
+ * adds `.dark` for dark marketing themes so Tailwind `dark:` variant utilities
+ * resolve to the marketing theme's darkness.
  *
- * Known edges (narrow, documented rather than blocking):
- * - A returning visitor whose in-app theme is dark keeps a `.dark` class on
- *   `<html>`; under a LIGHT marketing theme those /terms + /privacy `dark:`
- *   utilities still fire off that ancestor. A fork expecting dark-preference
- *   traffic on a light marketing site should tokenize those two pages.
- * - The auth dialog is portaled to `document.body` (outside this wrapper), so
- *   it follows the app theme, not the marketing theme. Fine for the default
- *   (both light); revisit only if a fork's marketing theme diverges sharply.
+ * Two subtleties this handles:
+ * - `dark:` utilities are ANCESTOR-scoped (`.dark *`), so a subtree `.light`
+ *   can't cancel an OS-dark visitor's `<html class="dark">` (ThemeProvider uses
+ *   `defaultTheme="system"`). The only `dark:` utilities in the marketing tree
+ *   are on /terms + /privacy; those pages instead branch on
+ *   `isDarkTheme(SITE_CONFIG.marketingTheme)` so they follow the marketing
+ *   theme, not the visitor's OS. New marketing UI should do the same, not use
+ *   `dark:`.
+ * - Radix portals (the auth Dialog) mount to `document.body`, outside this
+ *   wrapper. `MarketingThemeScope` mirrors the theme class onto `body` (client
+ *   effect, like the admin panel) so portalled overlays inherit the marketing
+ *   palette too.
  */
 export default function MarketingLayout({
   children,
@@ -44,16 +48,12 @@ export default function MarketingLayout({
   children: React.ReactNode;
 }) {
   const theme = SITE_CONFIG.marketingTheme;
+  const themeClass = cn(theme, isDarkTheme(theme) && 'dark');
 
   return (
     <AuthDialogProvider>
-      <div
-        className={cn(
-          'flex min-h-screen flex-col bg-background text-foreground',
-          theme,
-          isDarkTheme(theme) && 'dark',
-        )}
-      >
+      <MarketingThemeScope themeClass={themeClass} />
+      <div className={cn('flex min-h-screen flex-col bg-background text-foreground', themeClass)}>
         <MarketingNavbar />
         {/* pt-16 clears the fixed navbar (h-16); flex-1 makes content fill the
             viewport so the footer stays at the bottom on short/empty pages. */}

--- a/src/app/[locale]/(unauth)/(marketing)/layout.tsx
+++ b/src/app/[locale]/(unauth)/(marketing)/layout.tsx
@@ -1,6 +1,9 @@
 import { AuthDialogProvider } from '@/components/marketing/auth-dialog';
 import { MarketingFooter } from '@/components/marketing/footer';
 import { MarketingNavbar } from '@/components/marketing/navbar';
+import { isDarkTheme } from '@/components/theme/theme-config';
+import { SITE_CONFIG } from '@/config/site-config';
+import { cn } from '@/utils/Helpers';
 
 /**
  * Shared chrome for every marketing page (`/`, `/about`, `/blog`, `/changelog`,
@@ -16,15 +19,41 @@ import { MarketingNavbar } from '@/components/marketing/navbar';
  * `MarketingNavbar` (whose CTAs call `openSignIn`/`openSignUp`) AND the page
  * `children` (which mount `AuthDialogAutoOpener`) so both stay descendants of
  * the provider — otherwise the dialog never opens.
+ *
+ * Theme scoping: the shell carries `SITE_CONFIG.marketingTheme` as a CSS class,
+ * which redefines the color tokens for this subtree ONLY. This decouples the
+ * marketing look from the signed-in user's theme (there is no visitor toggle),
+ * so a fork can give the landing site its own brand palette. The class is
+ * rendered server-side from static config, so there is NO FOUC. `isDarkTheme`
+ * adds `.dark` for dark marketing themes so the few Tailwind `dark:` variant
+ * utilities (currently only on /terms + /privacy) resolve to the marketing
+ * theme's darkness rather than the app's.
+ *
+ * Known edges (narrow, documented rather than blocking):
+ * - A returning visitor whose in-app theme is dark keeps a `.dark` class on
+ *   `<html>`; under a LIGHT marketing theme those /terms + /privacy `dark:`
+ *   utilities still fire off that ancestor. A fork expecting dark-preference
+ *   traffic on a light marketing site should tokenize those two pages.
+ * - The auth dialog is portaled to `document.body` (outside this wrapper), so
+ *   it follows the app theme, not the marketing theme. Fine for the default
+ *   (both light); revisit only if a fork's marketing theme diverges sharply.
  */
 export default function MarketingLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const theme = SITE_CONFIG.marketingTheme;
+
   return (
     <AuthDialogProvider>
-      <div className="flex min-h-screen flex-col">
+      <div
+        className={cn(
+          'flex min-h-screen flex-col bg-background text-foreground',
+          theme,
+          isDarkTheme(theme) && 'dark',
+        )}
+      >
         <MarketingNavbar />
         {/* pt-16 clears the fixed navbar (h-16); flex-1 makes content fill the
             viewport so the footer stays at the bottom on short/empty pages. */}

--- a/src/app/[locale]/(unauth)/(marketing)/privacy/page.tsx
+++ b/src/app/[locale]/(unauth)/(marketing)/privacy/page.tsx
@@ -2,10 +2,12 @@ import { AlertTriangle } from 'lucide-react';
 import type { Metadata } from 'next';
 
 import { LegalTableOfContents } from '@/components/legal/legal-toc';
+import { isDarkTheme } from '@/components/theme/theme-config';
 import { SITE_CONFIG } from '@/config/site-config';
 import { getSiteUrl } from '@/libs/seo/config';
 import { generateHreflangLinks } from '@/libs/seo/hreflang';
 import { generateSocialMetadata } from '@/libs/seo/opengraph';
+import { cn } from '@/utils/Helpers';
 
 const PATH = '/privacy';
 const TITLE = 'Privacy Policy';
@@ -64,15 +66,21 @@ export default async function PrivacyPage(props: {
     day: 'numeric',
   });
 
+  // Marketing pages are theme-scoped by the (marketing) layout, INDEPENDENT of
+  // the app's `<html>` theme. Drive dark styling off the marketing theme config
+  // (not Tailwind's ancestor-based `dark:`), which would otherwise fire off an
+  // OS-dark visitor's `<html class="dark">` and invert this light page.
+  const marketingDark = isDarkTheme(SITE_CONFIG.marketingTheme);
+
   return (
     <section className="relative overflow-hidden pb-20 pt-12">
       <div className="pointer-events-none absolute -top-32 left-1/2 h-[420px] w-[420px] -translate-x-1/2 rounded-full bg-primary/10 blur-[120px]" />
 
       <div className="relative mx-auto max-w-3xl px-4 sm:px-6">
         {/* AI-drafted disclaimer banner */}
-        <div className="not-prose mb-10 flex items-start gap-3 rounded-xl border border-amber-500/30 bg-amber-500/10 p-4 text-sm text-amber-900 dark:text-amber-200">
+        <div className={cn('not-prose mb-10 flex items-start gap-3 rounded-xl border border-amber-500/30 bg-amber-500/10 p-4 text-sm text-amber-900', marketingDark && 'text-amber-200')}>
           <AlertTriangle
-            className="mt-0.5 size-5 shrink-0 text-amber-600 dark:text-amber-400"
+            className={cn('mt-0.5 size-5 shrink-0 text-amber-600', marketingDark && 'text-amber-400')}
             aria-hidden
           />
           <p>
@@ -100,7 +108,7 @@ export default async function PrivacyPage(props: {
 
         <LegalTableOfContents sections={[...SECTIONS]} className="mb-12" />
 
-        <article className="prose prose-neutral max-w-none dark:prose-invert">
+        <article className={cn('prose prose-neutral max-w-none', marketingDark && 'prose-invert')}>
           <p>
             This Privacy Policy explains how
             {' '}

--- a/src/app/[locale]/(unauth)/(marketing)/terms/page.tsx
+++ b/src/app/[locale]/(unauth)/(marketing)/terms/page.tsx
@@ -2,10 +2,12 @@ import { AlertTriangle } from 'lucide-react';
 import type { Metadata } from 'next';
 
 import { LegalTableOfContents } from '@/components/legal/legal-toc';
+import { isDarkTheme } from '@/components/theme/theme-config';
 import { SITE_CONFIG } from '@/config/site-config';
 import { getSiteUrl } from '@/libs/seo/config';
 import { generateHreflangLinks } from '@/libs/seo/hreflang';
 import { generateSocialMetadata } from '@/libs/seo/opengraph';
+import { cn } from '@/utils/Helpers';
 
 const PATH = '/terms';
 const TITLE = 'Terms of Service';
@@ -64,15 +66,21 @@ export default async function TermsPage(props: {
     day: 'numeric',
   });
 
+  // Marketing pages are theme-scoped by the (marketing) layout, INDEPENDENT of
+  // the app's `<html>` theme. Drive dark styling off the marketing theme config
+  // (not Tailwind's ancestor-based `dark:`), which would otherwise fire off an
+  // OS-dark visitor's `<html class="dark">` and invert this light page.
+  const marketingDark = isDarkTheme(SITE_CONFIG.marketingTheme);
+
   return (
     <section className="relative overflow-hidden pb-20 pt-12">
       <div className="pointer-events-none absolute -top-32 left-1/2 h-[420px] w-[420px] -translate-x-1/2 rounded-full bg-primary/10 blur-[120px]" />
 
       <div className="relative mx-auto max-w-3xl px-4 sm:px-6">
         {/* AI-drafted disclaimer banner */}
-        <div className="not-prose mb-10 flex items-start gap-3 rounded-xl border border-amber-500/30 bg-amber-500/10 p-4 text-sm text-amber-900 dark:text-amber-200">
+        <div className={cn('not-prose mb-10 flex items-start gap-3 rounded-xl border border-amber-500/30 bg-amber-500/10 p-4 text-sm text-amber-900', marketingDark && 'text-amber-200')}>
           <AlertTriangle
-            className="mt-0.5 size-5 shrink-0 text-amber-600 dark:text-amber-400"
+            className={cn('mt-0.5 size-5 shrink-0 text-amber-600', marketingDark && 'text-amber-400')}
             aria-hidden
           />
           <p>
@@ -100,7 +108,7 @@ export default async function TermsPage(props: {
 
         <LegalTableOfContents sections={[...SECTIONS]} className="mb-12" />
 
-        <article className="prose prose-neutral max-w-none dark:prose-invert">
+        <article className={cn('prose prose-neutral max-w-none', marketingDark && 'prose-invert')}>
           <p>
             These Terms of Service (the &ldquo;Terms&rdquo;) govern your access
             to and use of the services, websites, and applications provided by

--- a/src/components/admin/analytics/SignupsChart.tsx
+++ b/src/components/admin/analytics/SignupsChart.tsx
@@ -29,7 +29,7 @@ type SignupsChartProps = {
 const chartConfig = {
   signups: {
     label: 'Signups',
-    color: 'var(--color-primary)',
+    color: 'var(--primary)',
   },
 };
 
@@ -59,12 +59,12 @@ export function SignupsChart({
               <linearGradient id="fillSignups" x1="0" y1="0" x2="0" y2="1">
                 <stop
                   offset="5%"
-                  stopColor="var(--color-primary)"
+                  stopColor="var(--primary)"
                   stopOpacity={0.8}
                 />
                 <stop
                   offset="95%"
-                  stopColor="var(--color-primary)"
+                  stopColor="var(--primary)"
                   stopOpacity={0.1}
                 />
               </linearGradient>
@@ -87,7 +87,7 @@ export function SignupsChart({
             <Area
               type="monotone"
               dataKey="signups"
-              stroke="var(--color-primary)"
+              stroke="var(--primary)"
               strokeWidth={2}
               fill="url(#fillSignups)"
             />

--- a/src/components/marketing/marketing-theme-scope.tsx
+++ b/src/components/marketing/marketing-theme-scope.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useEffect } from 'react';
+
+/**
+ * Mirrors the marketing theme class(es) onto `document.body` so Radix portals —
+ * the auth Dialog, dropdown/select menus — which mount to `body` OUTSIDE the
+ * marketing shell wrapper, inherit the marketing palette instead of the app's
+ * `<html>` theme. Without this, a fork with a dark `marketingTheme` would open a
+ * light auth modal over its dark landing page.
+ *
+ * This mirrors the admin panel's body-scope pattern (see `AdminLayoutClient` +
+ * the `[data-admin]` blocks in `global.css`). The main marketing UI is themed by
+ * the SSR'd wrapper class (no FOUC); portalled overlays are user-triggered after
+ * hydration, so a client-only effect is sufficient. The effect removes the
+ * classes on unmount so the scope never leaks onto non-marketing routes.
+ */
+export function MarketingThemeScope({ themeClass }: { themeClass: string }) {
+  useEffect(() => {
+    const classes = themeClass.split(' ').filter(Boolean);
+    if (classes.length === 0) {
+      return;
+    }
+    const { body } = document;
+    // Only remove classes this effect actually added, so we don't strip a class
+    // the body already carried (defensive against overlap with other scopes).
+    const added = classes.filter(c => !body.classList.contains(c));
+    body.classList.add(...added);
+    return () => body.classList.remove(...added);
+  }, [themeClass]);
+
+  return null;
+}

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -233,7 +233,7 @@ const ChartTooltipContent = ({
                             !hideIndicator && (
                               <div
                                 className={cn(
-                                  'shrink-0 rounded-[2px] border-border bg-(--color-bg)',
+                                  'shrink-0 rounded-[2px] border-(--color-border) bg-(--color-bg)',
                                   {
                                     'h-2.5 w-2.5': indicator === 'dot',
                                     'w-1': indicator === 'line',

--- a/src/config/site-config.ts
+++ b/src/config/site-config.ts
@@ -9,6 +9,8 @@
  * branding — replace them with your product's real details after forking.
  */
 
+import type { ThemeId } from '@/components/theme/theme-config';
+
 export type SiteConfig = {
   brand: {
     name: string;
@@ -21,6 +23,15 @@ export type SiteConfig = {
     social: Record<string, string>;
     supportEmail: string;
   };
+  /**
+   * Theme applied to the public marketing surface (`/`, `/about`, `/blog`,
+   * `/changelog`, `/terms`, `/privacy`). Scoped to the marketing shell only —
+   * it is INDEPENDENT of the in-app user theme (no visitor toggle), so the
+   * landing site can carry its own brand look while the signed-in app keeps
+   * the user's chosen theme. Any `ThemeId` from the theme registry works.
+   * Default `light` preserves the template's out-of-the-box marketing look.
+   */
+  marketingTheme: ThemeId;
   /** Placeholders for the future /terms + /privacy scaffold. */
   legal: {
     companyLegalName: string;
@@ -43,6 +54,7 @@ const brand = {
 
 export const SITE_CONFIG = {
   brand,
+  marketingTheme: 'light',
   legal: {
     companyLegalName: 'Your Company, Inc.',
     governingLaw: 'State of Delaware, USA',

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -235,52 +235,15 @@
    overriding the near-white default `--sidebar`. To retint admin, edit these
    two blocks only — nowhere else.
 
-   NOTE ON THE `--color-*` RE-ALIAS BELOW: Tailwind's `@theme` emits
-   `--color-x: var(--x)` at `:root`, which is substituted once at `<html>` and
-   inherits down as a frozen value. Overriding a raw `--x` on a *descendant*
-   scope like `[data-admin]` therefore does NOT reach the Tailwind utilities
-   (`bg-sidebar`, `bg-card`, …) — they'd keep the html-level color. The
-   consumer multi-theme system dodges this only because next-themes sets the
-   theme class on `<html>` itself. A descendant scope must re-alias the
-   `--color-*` tokens so they recompute here against the admin raw tokens.
+   How the scope reaches Tailwind utilities: `@theme inline` (top of this file)
+   compiles color utilities to `var(--<raw-token>)` at the use-site, so
+   re-declaring the raw `--*` tokens on `[data-admin]` below is enough — the
+   utilities recompute against them here (this also covers `.dark [data-admin]`).
+   No `--color-*` re-alias is needed; that was only required before `@theme
+   inline`, when `--color-x` was resolved once at `:root` and frozen for
+   descendants.
    ============================================================================= */
 [data-admin] {
-  /* Re-alias Tailwind's theme colors so utilities recompute at this scope
-     (see NOTE above). Declared once here; it resolves against whichever raw
-     `--*` wins on this element, so it covers `.dark [data-admin]` too. */
-  --color-border: var(--border);
-  --color-input: var(--input);
-  --color-ring: var(--ring);
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --color-primary: var(--primary);
-  --color-primary-foreground: var(--primary-foreground);
-  --color-secondary: var(--secondary);
-  --color-secondary-foreground: var(--secondary-foreground);
-  --color-destructive: var(--destructive);
-  --color-destructive-foreground: var(--destructive-foreground);
-  --color-muted: var(--muted);
-  --color-muted-foreground: var(--muted-foreground);
-  --color-accent: var(--accent);
-  --color-accent-foreground: var(--accent-foreground);
-  --color-popover: var(--popover);
-  --color-popover-foreground: var(--popover-foreground);
-  --color-card: var(--card);
-  --color-card-foreground: var(--card-foreground);
-  --color-chart-1: var(--chart-1);
-  --color-chart-2: var(--chart-2);
-  --color-chart-3: var(--chart-3);
-  --color-chart-4: var(--chart-4);
-  --color-chart-5: var(--chart-5);
-  --color-sidebar: var(--sidebar);
-  --color-sidebar-foreground: var(--sidebar-foreground);
-  --color-sidebar-primary: var(--sidebar-primary);
-  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-  --color-sidebar-accent: var(--sidebar-accent);
-  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-  --color-sidebar-border: var(--sidebar-border);
-  --color-sidebar-ring: var(--sidebar-ring);
-
   /* Content surface — default light neutrals (mirror of `:root`) */
   --border: hsl(214.3 31.8% 91.4%);
   --input: hsl(214.3 31.8% 91.4%);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -8,17 +8,24 @@
 /*
   Multi-theme token architecture (template issue #250).
 
-  @theme passes each Tailwind color through as `var(--<token>)` instead of a
-  baked `hsl(...)` value, so a theme block can supply the token in ANY color
-  space — HSL or OKLCH — and `var()` resolves to a complete color at runtime.
-  Raw tokens (`--primary`, `--background`, …) are defined per theme below.
+  `@theme inline` makes every Tailwind color utility emit `var(--<raw-token>)`
+  DIRECTLY (e.g. `bg-background` → `background-color: var(--background)`) instead
+  of routing through a `--color-*` variable resolved once at `:root`. The
+  `inline` keyword is load-bearing: it is what lets a theme class re-scope the
+  palette on a SUBTREE (the marketing shell, an `[data-admin]` panel) — a plain
+  `@theme` resolves `var(--background)` at `:root` and inheritance can't undo
+  that further down the tree. Each theme block supplies the raw `--*` tokens in
+  ANY color space (HSL or OKLCH); `var()` resolves to a full color at runtime.
 
-  Default theme = light (`:root`) / dark (`.dark`). Their values are the exact
-  same triples the template shipped before this refactor, just wrapped in
-  `hsl(...)` so `var(--primary)` resolves to a full color. Appearance of the
-  default theme is unchanged.
+  Default theme = light (`:root` / `.light`) / dark (`.dark`). Their values are
+  the exact triples the template shipped before this refactor, wrapped in
+  `hsl(...)`. Appearance of the default theme is unchanged.
+
+  NOTE: with `inline`, `--color-*` variables are NOT emitted — consume raw
+  tokens (`var(--primary)`), never `var(--color-primary)`, in hand-written CSS
+  or inline styles.
 */
-@theme {
+@theme inline {
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
@@ -103,12 +110,17 @@
 }
 
 /* =============================================================================
-   Default theme — light (`:root`)
+   Default theme — light (`:root`, also `.light`)
    Same values the template shipped before #250, wrapped in hsl() so
    `var(--*)` resolves to a full color. DO NOT alter these numbers — they
    define the template's out-of-the-box appearance.
+   The `.light` selector mirrors `:root` so the default light theme can be
+   pinned to a subtree (e.g. the marketing shell) the same way `.dark` /
+   `.warm-light` / etc. are — a class-scoped theme needs a class, and light
+   otherwise lives only on `:root`.
    ============================================================================= */
-:root {
+:root,
+.light {
   --border: hsl(214.3 31.8% 91.4%);
   --input: hsl(214.3 31.8% 91.4%);
   --ring: hsl(222.2 84% 4.9%);
@@ -361,249 +373,247 @@
   --sidebar-ring: hsl(217.2 91.2% 59.8%);
 }
 
-@layer base {
-  /* ===========================================================================
-     Multi-theme registry — neutral, professional defaults shipped with the
-     template. Each theme provides raw `--*` tokens (HSL or OKLCH). Keep in sync
-     with `src/components/theme/theme-config.ts` (THEME_GROUPS).
-     =========================================================================== */
+/* ===========================================================================
+   Multi-theme registry — neutral, professional defaults shipped with the
+   template. Each theme provides raw `--*` tokens (HSL or OKLCH). Keep in sync
+   with `src/components/theme/theme-config.ts` (THEME_GROUPS).
+   =========================================================================== */
 
-  /* -------------------------------------------------------------------------
-     Modern SaaS — professional blue, B2B default (HSL)
-     ------------------------------------------------------------------------- */
-  .modern-light {
-    --background: hsl(0 0% 100%);
-    --foreground: hsl(222.2 84% 4.9%);
-    --card: hsl(0 0% 100%);
-    --card-foreground: hsl(222.2 84% 4.9%);
-    --popover: hsl(0 0% 100%);
-    --popover-foreground: hsl(222.2 84% 4.9%);
-    --primary: hsl(217.2 91.2% 59.8%);
-    --primary-foreground: hsl(210 40% 98%);
-    --secondary: hsl(210 40% 96.1%);
-    --secondary-foreground: hsl(222.2 47.4% 11.2%);
-    --muted: hsl(210 40% 96.1%);
-    --muted-foreground: hsl(215.4 16.3% 46.9%);
-    --accent: hsl(210 40% 96.1%);
-    --accent-foreground: hsl(222.2 47.4% 11.2%);
-    --destructive: hsl(0 84.2% 60.2%);
-    --destructive-foreground: hsl(210 40% 98%);
-    --border: hsl(214.3 31.8% 91.4%);
-    --input: hsl(214.3 31.8% 91.4%);
-    --ring: hsl(217.2 91.2% 59.8%);
-    --chart-1: hsl(217.2 91.2% 59.8%);
-    --chart-2: hsl(160 60% 45%);
-    --chart-3: hsl(30 80% 55%);
-    --chart-4: hsl(280 65% 60%);
-    --chart-5: hsl(340 75% 55%);
-    --radius: 0.5rem;
-    --sidebar: hsl(0 0% 98%);
-    --sidebar-foreground: hsl(222.2 84% 4.9%);
-    --sidebar-primary: hsl(217.2 91.2% 59.8%);
-    --sidebar-primary-foreground: hsl(210 40% 98%);
-    --sidebar-accent: hsl(210 40% 96.1%);
-    --sidebar-accent-foreground: hsl(222.2 47.4% 11.2%);
-    --sidebar-border: hsl(214.3 31.8% 91.4%);
-    --sidebar-ring: hsl(217.2 91.2% 59.8%);
-    --footer-bg: hsl(222.2 47.4% 11.2%);
-    --footer-foreground: hsl(210 40% 98%);
-  }
+/* -------------------------------------------------------------------------
+   Modern SaaS — professional blue, B2B default (HSL)
+   ------------------------------------------------------------------------- */
+.modern-light {
+  --background: hsl(0 0% 100%);
+  --foreground: hsl(222.2 84% 4.9%);
+  --card: hsl(0 0% 100%);
+  --card-foreground: hsl(222.2 84% 4.9%);
+  --popover: hsl(0 0% 100%);
+  --popover-foreground: hsl(222.2 84% 4.9%);
+  --primary: hsl(217.2 91.2% 59.8%);
+  --primary-foreground: hsl(210 40% 98%);
+  --secondary: hsl(210 40% 96.1%);
+  --secondary-foreground: hsl(222.2 47.4% 11.2%);
+  --muted: hsl(210 40% 96.1%);
+  --muted-foreground: hsl(215.4 16.3% 46.9%);
+  --accent: hsl(210 40% 96.1%);
+  --accent-foreground: hsl(222.2 47.4% 11.2%);
+  --destructive: hsl(0 84.2% 60.2%);
+  --destructive-foreground: hsl(210 40% 98%);
+  --border: hsl(214.3 31.8% 91.4%);
+  --input: hsl(214.3 31.8% 91.4%);
+  --ring: hsl(217.2 91.2% 59.8%);
+  --chart-1: hsl(217.2 91.2% 59.8%);
+  --chart-2: hsl(160 60% 45%);
+  --chart-3: hsl(30 80% 55%);
+  --chart-4: hsl(280 65% 60%);
+  --chart-5: hsl(340 75% 55%);
+  --radius: 0.5rem;
+  --sidebar: hsl(0 0% 98%);
+  --sidebar-foreground: hsl(222.2 84% 4.9%);
+  --sidebar-primary: hsl(217.2 91.2% 59.8%);
+  --sidebar-primary-foreground: hsl(210 40% 98%);
+  --sidebar-accent: hsl(210 40% 96.1%);
+  --sidebar-accent-foreground: hsl(222.2 47.4% 11.2%);
+  --sidebar-border: hsl(214.3 31.8% 91.4%);
+  --sidebar-ring: hsl(217.2 91.2% 59.8%);
+  --footer-bg: hsl(222.2 47.4% 11.2%);
+  --footer-foreground: hsl(210 40% 98%);
+}
 
-  .modern-dark {
-    --background: hsl(222.2 84% 4.9%);
-    --foreground: hsl(210 40% 98%);
-    --card: hsl(222.2 84% 4.9%);
-    --card-foreground: hsl(210 40% 98%);
-    --popover: hsl(222.2 84% 4.9%);
-    --popover-foreground: hsl(210 40% 98%);
-    --primary: hsl(217.2 91.2% 59.8%);
-    --primary-foreground: hsl(222.2 47.4% 11.2%);
-    --secondary: hsl(217.2 32.6% 17.5%);
-    --secondary-foreground: hsl(210 40% 98%);
-    --muted: hsl(217.2 32.6% 17.5%);
-    --muted-foreground: hsl(215 20.2% 65.1%);
-    --accent: hsl(217.2 32.6% 17.5%);
-    --accent-foreground: hsl(210 40% 98%);
-    --destructive: hsl(0 62.8% 30.6%);
-    --destructive-foreground: hsl(210 40% 98%);
-    --border: hsl(217.2 32.6% 17.5%);
-    --input: hsl(217.2 32.6% 17.5%);
-    --ring: hsl(224.3 76.3% 48%);
-    --chart-1: hsl(220 70% 50%);
-    --chart-2: hsl(160 60% 45%);
-    --chart-3: hsl(30 80% 55%);
-    --chart-4: hsl(280 65% 60%);
-    --chart-5: hsl(340 75% 55%);
-    --radius: 0.5rem;
-    --sidebar: hsl(222.2 84% 4.9%);
-    --sidebar-foreground: hsl(210 40% 98%);
-    --sidebar-primary: hsl(217.2 91.2% 59.8%);
-    --sidebar-primary-foreground: hsl(222.2 47.4% 11.2%);
-    --sidebar-accent: hsl(217.2 32.6% 17.5%);
-    --sidebar-accent-foreground: hsl(210 40% 98%);
-    --sidebar-border: hsl(217.2 32.6% 17.5%);
-    --sidebar-ring: hsl(224.3 76.3% 48%);
-    --footer-bg: hsl(222.2 84% 4.9%);
-    --footer-foreground: hsl(210 40% 98%);
-  }
+.modern-dark {
+  --background: hsl(222.2 84% 4.9%);
+  --foreground: hsl(210 40% 98%);
+  --card: hsl(222.2 84% 4.9%);
+  --card-foreground: hsl(210 40% 98%);
+  --popover: hsl(222.2 84% 4.9%);
+  --popover-foreground: hsl(210 40% 98%);
+  --primary: hsl(217.2 91.2% 59.8%);
+  --primary-foreground: hsl(222.2 47.4% 11.2%);
+  --secondary: hsl(217.2 32.6% 17.5%);
+  --secondary-foreground: hsl(210 40% 98%);
+  --muted: hsl(217.2 32.6% 17.5%);
+  --muted-foreground: hsl(215 20.2% 65.1%);
+  --accent: hsl(217.2 32.6% 17.5%);
+  --accent-foreground: hsl(210 40% 98%);
+  --destructive: hsl(0 62.8% 30.6%);
+  --destructive-foreground: hsl(210 40% 98%);
+  --border: hsl(217.2 32.6% 17.5%);
+  --input: hsl(217.2 32.6% 17.5%);
+  --ring: hsl(224.3 76.3% 48%);
+  --chart-1: hsl(220 70% 50%);
+  --chart-2: hsl(160 60% 45%);
+  --chart-3: hsl(30 80% 55%);
+  --chart-4: hsl(280 65% 60%);
+  --chart-5: hsl(340 75% 55%);
+  --radius: 0.5rem;
+  --sidebar: hsl(222.2 84% 4.9%);
+  --sidebar-foreground: hsl(210 40% 98%);
+  --sidebar-primary: hsl(217.2 91.2% 59.8%);
+  --sidebar-primary-foreground: hsl(222.2 47.4% 11.2%);
+  --sidebar-accent: hsl(217.2 32.6% 17.5%);
+  --sidebar-accent-foreground: hsl(210 40% 98%);
+  --sidebar-border: hsl(217.2 32.6% 17.5%);
+  --sidebar-ring: hsl(224.3 76.3% 48%);
+  --footer-bg: hsl(222.2 84% 4.9%);
+  --footer-foreground: hsl(210 40% 98%);
+}
 
-  /* -------------------------------------------------------------------------
-     Warm Sand — warm neutral, terracotta accent (OKLCH)
-     ------------------------------------------------------------------------- */
-  .warm-light {
-    --background: oklch(0.9818 0.0054 95.0986);
-    --foreground: oklch(0.3438 0.0269 95.7226);
-    --card: oklch(0.9665 0.0067 97.3521);
-    --card-foreground: oklch(0.1908 0.002 106.5859);
-    --popover: oklch(1 0 0);
-    --popover-foreground: oklch(0.2671 0.0196 98.939);
-    --primary: oklch(0.55 0.155 39.0427);
-    --primary-foreground: oklch(1 0 0);
-    --secondary: oklch(0.9245 0.0138 92.9892);
-    --secondary-foreground: oklch(0.4334 0.0177 98.6048);
-    --muted: oklch(0.9341 0.0153 90.239);
-    --muted-foreground: oklch(0.5341 0.0078 97.4503);
-    --accent: oklch(0.9245 0.0138 92.9892);
-    --accent-foreground: oklch(0.2671 0.0196 98.939);
-    --destructive: oklch(0.6368 0.2078 25.3313);
-    --destructive-foreground: oklch(1 0 0);
-    --border: oklch(0.8847 0.0069 97.3627);
-    --input: oklch(0.7621 0.0156 98.3528);
-    --ring: oklch(0.55 0.155 39.0427);
-    --chart-1: oklch(0.5583 0.1276 42.9956);
-    --chart-2: oklch(0.6898 0.1581 290.4107);
-    --chart-3: oklch(0.8816 0.0276 93.128);
-    --chart-4: oklch(0.8822 0.0403 298.1792);
-    --chart-5: oklch(0.5608 0.1348 42.0584);
-    --radius: 0.75rem;
-    --sidebar: oklch(0.9663 0.008 98.8792);
-    --sidebar-foreground: oklch(0.359 0.0051 106.6524);
-    --sidebar-primary: oklch(0.55 0.155 39.0427);
-    --sidebar-primary-foreground: oklch(0.9881 0 0);
-    --sidebar-accent: oklch(0.9245 0.0138 92.9892);
-    --sidebar-accent-foreground: oklch(0.325 0 0);
-    --sidebar-border: oklch(0.8847 0.0069 97.3627);
-    --sidebar-ring: oklch(0.55 0.155 39.0427);
-    --footer-bg: oklch(0.2679 0.0036 106.6427);
-    --footer-foreground: oklch(0.9576 0.0027 106.4494);
-  }
+/* -------------------------------------------------------------------------
+   Warm Sand — warm neutral, terracotta accent (OKLCH)
+   ------------------------------------------------------------------------- */
+.warm-light {
+  --background: oklch(0.9818 0.0054 95.0986);
+  --foreground: oklch(0.3438 0.0269 95.7226);
+  --card: oklch(0.9665 0.0067 97.3521);
+  --card-foreground: oklch(0.1908 0.002 106.5859);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.2671 0.0196 98.939);
+  --primary: oklch(0.55 0.155 39.0427);
+  --primary-foreground: oklch(1 0 0);
+  --secondary: oklch(0.9245 0.0138 92.9892);
+  --secondary-foreground: oklch(0.4334 0.0177 98.6048);
+  --muted: oklch(0.9341 0.0153 90.239);
+  --muted-foreground: oklch(0.5341 0.0078 97.4503);
+  --accent: oklch(0.9245 0.0138 92.9892);
+  --accent-foreground: oklch(0.2671 0.0196 98.939);
+  --destructive: oklch(0.6368 0.2078 25.3313);
+  --destructive-foreground: oklch(1 0 0);
+  --border: oklch(0.8847 0.0069 97.3627);
+  --input: oklch(0.7621 0.0156 98.3528);
+  --ring: oklch(0.55 0.155 39.0427);
+  --chart-1: oklch(0.5583 0.1276 42.9956);
+  --chart-2: oklch(0.6898 0.1581 290.4107);
+  --chart-3: oklch(0.8816 0.0276 93.128);
+  --chart-4: oklch(0.8822 0.0403 298.1792);
+  --chart-5: oklch(0.5608 0.1348 42.0584);
+  --radius: 0.75rem;
+  --sidebar: oklch(0.9663 0.008 98.8792);
+  --sidebar-foreground: oklch(0.359 0.0051 106.6524);
+  --sidebar-primary: oklch(0.55 0.155 39.0427);
+  --sidebar-primary-foreground: oklch(0.9881 0 0);
+  --sidebar-accent: oklch(0.9245 0.0138 92.9892);
+  --sidebar-accent-foreground: oklch(0.325 0 0);
+  --sidebar-border: oklch(0.8847 0.0069 97.3627);
+  --sidebar-ring: oklch(0.55 0.155 39.0427);
+  --footer-bg: oklch(0.2679 0.0036 106.6427);
+  --footer-foreground: oklch(0.9576 0.0027 106.4494);
+}
 
-  .warm-dark {
-    --background: oklch(0.2679 0.0036 106.6427);
-    --foreground: oklch(0.9576 0.0027 106.4494);
-    --card: oklch(0.2928 0.0018 106.5092);
-    --card-foreground: oklch(0.9818 0.0054 95.0986);
-    --popover: oklch(0.3085 0.0035 106.6039);
-    --popover-foreground: oklch(0.9211 0.004 106.4781);
-    --primary: oklch(0.6 0.155 38.7559);
-    --primary-foreground: oklch(0.1908 0.002 106.5859);
-    --secondary: oklch(0.9818 0.0054 95.0986);
-    --secondary-foreground: oklch(0.3085 0.0035 106.6039);
-    --muted: oklch(0.2213 0.0038 106.707);
-    --muted-foreground: oklch(0.7713 0.0169 99.0657);
-    --accent: oklch(0.213 0.0078 95.4245);
-    --accent-foreground: oklch(0.9663 0.008 98.8792);
-    --destructive: oklch(0.6368 0.2078 25.3313);
-    --destructive-foreground: oklch(1 0 0);
-    --border: oklch(0.3618 0.0101 106.8928);
-    --input: oklch(0.4336 0.0113 100.2195);
-    --ring: oklch(0.6 0.155 38.7559);
-    --chart-1: oklch(0.5583 0.1276 42.9956);
-    --chart-2: oklch(0.6898 0.1581 290.4107);
-    --chart-3: oklch(0.213 0.0078 95.4245);
-    --chart-4: oklch(0.3074 0.0516 289.323);
-    --chart-5: oklch(0.5608 0.1348 42.0584);
-    --radius: 0.75rem;
-    --sidebar: oklch(0.2357 0.0024 67.7077);
-    --sidebar-foreground: oklch(0.8074 0.0142 93.0137);
-    --sidebar-primary: oklch(0.325 0 0);
-    --sidebar-primary-foreground: oklch(0.9881 0 0);
-    --sidebar-accent: oklch(0.168 0.002 106.6177);
-    --sidebar-accent-foreground: oklch(0.8074 0.0142 93.0137);
-    --sidebar-border: oklch(0.3618 0.0101 106.8928);
-    --sidebar-ring: oklch(0.6 0.155 38.7559);
-    --footer-bg: oklch(0.2101 0.0032 106.6427);
-    --footer-foreground: oklch(0.9576 0.0027 106.4494);
-  }
+.warm-dark {
+  --background: oklch(0.2679 0.0036 106.6427);
+  --foreground: oklch(0.9576 0.0027 106.4494);
+  --card: oklch(0.2928 0.0018 106.5092);
+  --card-foreground: oklch(0.9818 0.0054 95.0986);
+  --popover: oklch(0.3085 0.0035 106.6039);
+  --popover-foreground: oklch(0.9211 0.004 106.4781);
+  --primary: oklch(0.6 0.155 38.7559);
+  --primary-foreground: oklch(0.1908 0.002 106.5859);
+  --secondary: oklch(0.9818 0.0054 95.0986);
+  --secondary-foreground: oklch(0.3085 0.0035 106.6039);
+  --muted: oklch(0.2213 0.0038 106.707);
+  --muted-foreground: oklch(0.7713 0.0169 99.0657);
+  --accent: oklch(0.213 0.0078 95.4245);
+  --accent-foreground: oklch(0.9663 0.008 98.8792);
+  --destructive: oklch(0.6368 0.2078 25.3313);
+  --destructive-foreground: oklch(1 0 0);
+  --border: oklch(0.3618 0.0101 106.8928);
+  --input: oklch(0.4336 0.0113 100.2195);
+  --ring: oklch(0.6 0.155 38.7559);
+  --chart-1: oklch(0.5583 0.1276 42.9956);
+  --chart-2: oklch(0.6898 0.1581 290.4107);
+  --chart-3: oklch(0.213 0.0078 95.4245);
+  --chart-4: oklch(0.3074 0.0516 289.323);
+  --chart-5: oklch(0.5608 0.1348 42.0584);
+  --radius: 0.75rem;
+  --sidebar: oklch(0.2357 0.0024 67.7077);
+  --sidebar-foreground: oklch(0.8074 0.0142 93.0137);
+  --sidebar-primary: oklch(0.325 0 0);
+  --sidebar-primary-foreground: oklch(0.9881 0 0);
+  --sidebar-accent: oklch(0.168 0.002 106.6177);
+  --sidebar-accent-foreground: oklch(0.8074 0.0142 93.0137);
+  --sidebar-border: oklch(0.3618 0.0101 106.8928);
+  --sidebar-ring: oklch(0.6 0.155 38.7559);
+  --footer-bg: oklch(0.2101 0.0032 106.6427);
+  --footer-foreground: oklch(0.9576 0.0027 106.4494);
+}
 
-  /* -------------------------------------------------------------------------
-     Sage Green — calm, earthy green (OKLCH)
-     ------------------------------------------------------------------------- */
-  .sage-light {
-    --background: oklch(0.994 0 0);
-    --foreground: oklch(0.2 0 0);
-    --card: oklch(0.994 0 0);
-    --card-foreground: oklch(0.2 0 0);
-    --popover: oklch(0.9911 0 0);
-    --popover-foreground: oklch(0.2 0 0);
-    --primary: oklch(0.5486 0.0866 132.737);
-    --primary-foreground: oklch(1 0 0);
-    --secondary: oklch(0.954 0.0063 255.4755);
-    --secondary-foreground: oklch(0.1344 0 0);
-    --muted: oklch(0.9702 0 0);
-    --muted-foreground: oklch(0.5 0 0);
-    --accent: oklch(0.4429 0.0444 134.5073);
-    --accent-foreground: oklch(1 0 0);
-    --destructive: oklch(0.4926 0.1864 26.2192);
-    --destructive-foreground: oklch(1 0 0);
-    --border: oklch(0.93 0.0094 286.2156);
-    --input: oklch(0.9401 0 0);
-    --ring: oklch(0.5486 0.0866 132.737);
-    --chart-1: oklch(0.7459 0.1483 156.4499);
-    --chart-2: oklch(0.5393 0.2713 286.7462);
-    --chart-3: oklch(0.7336 0.1758 50.5517);
-    --chart-4: oklch(0.5828 0.1809 259.7276);
-    --chart-5: oklch(0.559 0 0);
-    --radius: 0.75rem;
-    --sidebar: oklch(0.9777 0.0051 247.8763);
-    --sidebar-foreground: oklch(0.2 0 0);
-    --sidebar-primary: oklch(0.5486 0.0866 132.737);
-    --sidebar-primary-foreground: oklch(1 0 0);
-    --sidebar-accent: oklch(0.93 0.0136 134.8996);
-    --sidebar-accent-foreground: oklch(0.2 0 0);
-    --sidebar-border: oklch(0.9401 0 0);
-    --sidebar-ring: oklch(0.5486 0.0866 132.737);
-    --footer-bg: oklch(0.1173 0.009 73.4751);
-    --footer-foreground: oklch(0.9796 0.0017 67.8026);
-  }
+/* -------------------------------------------------------------------------
+   Sage Green — calm, earthy green (OKLCH)
+   ------------------------------------------------------------------------- */
+.sage-light {
+  --background: oklch(0.994 0 0);
+  --foreground: oklch(0.2 0 0);
+  --card: oklch(0.994 0 0);
+  --card-foreground: oklch(0.2 0 0);
+  --popover: oklch(0.9911 0 0);
+  --popover-foreground: oklch(0.2 0 0);
+  --primary: oklch(0.5486 0.0866 132.737);
+  --primary-foreground: oklch(1 0 0);
+  --secondary: oklch(0.954 0.0063 255.4755);
+  --secondary-foreground: oklch(0.1344 0 0);
+  --muted: oklch(0.9702 0 0);
+  --muted-foreground: oklch(0.5 0 0);
+  --accent: oklch(0.4429 0.0444 134.5073);
+  --accent-foreground: oklch(1 0 0);
+  --destructive: oklch(0.4926 0.1864 26.2192);
+  --destructive-foreground: oklch(1 0 0);
+  --border: oklch(0.93 0.0094 286.2156);
+  --input: oklch(0.9401 0 0);
+  --ring: oklch(0.5486 0.0866 132.737);
+  --chart-1: oklch(0.7459 0.1483 156.4499);
+  --chart-2: oklch(0.5393 0.2713 286.7462);
+  --chart-3: oklch(0.7336 0.1758 50.5517);
+  --chart-4: oklch(0.5828 0.1809 259.7276);
+  --chart-5: oklch(0.559 0 0);
+  --radius: 0.75rem;
+  --sidebar: oklch(0.9777 0.0051 247.8763);
+  --sidebar-foreground: oklch(0.2 0 0);
+  --sidebar-primary: oklch(0.5486 0.0866 132.737);
+  --sidebar-primary-foreground: oklch(1 0 0);
+  --sidebar-accent: oklch(0.93 0.0136 134.8996);
+  --sidebar-accent-foreground: oklch(0.2 0 0);
+  --sidebar-border: oklch(0.9401 0 0);
+  --sidebar-ring: oklch(0.5486 0.0866 132.737);
+  --footer-bg: oklch(0.1173 0.009 73.4751);
+  --footer-foreground: oklch(0.9796 0.0017 67.8026);
+}
 
-  .sage-dark {
-    --background: oklch(0.1173 0.009 73.4751);
-    --foreground: oklch(0.9796 0.0017 67.8026);
-    --card: oklch(0.1609 0.0115 80.9823);
-    --card-foreground: oklch(0.9796 0.0017 67.8026);
-    --popover: oklch(0.1405 0.0109 88.4982);
-    --popover-foreground: oklch(0.9796 0.0017 67.8026);
-    --primary: oklch(0.783 0.0384 132.737);
-    --primary-foreground: oklch(0.0986 0.0063 72.5271);
-    --secondary: oklch(0.251 0.0148 76.2105);
-    --secondary-foreground: oklch(0.9198 0.0075 80.7204);
-    --muted: oklch(0.2203 0.0129 77.9565);
-    --muted-foreground: oklch(0.6511 0.0081 80.7132);
-    --accent: oklch(0.4429 0.0444 134.5073);
-    --accent-foreground: oklch(1 0 0);
-    --destructive: oklch(0.4926 0.1864 26.2192);
-    --destructive-foreground: oklch(0.9796 0.0017 67.8026);
-    --border: oklch(0.2806 0.0246 82.6847);
-    --input: oklch(0.1994 0.0155 75.9533);
-    --ring: oklch(0.783 0.0384 132.737);
-    --chart-1: oklch(0.5636 0.1645 136.9338);
-    --chart-2: oklch(0.6509 0.1756 135.9702);
-    --chart-3: oklch(0.7246 0.1732 135.119);
-    --chart-4: oklch(0.8539 0.1402 133.7838);
-    --chart-5: oklch(0.783 0.0384 132.737);
-    --radius: 0.75rem;
-    --sidebar: oklch(0.0986 0.0063 72.5271);
-    --sidebar-foreground: oklch(0.9498 0.0046 78.2977);
-    --sidebar-primary: oklch(0.783 0.0384 132.737);
-    --sidebar-primary-foreground: oklch(0.0986 0.0063 72.5271);
-    --sidebar-accent: oklch(0.4429 0.0444 134.5073);
-    --sidebar-accent-foreground: oklch(1 0 0);
-    --sidebar-border: oklch(0.2513 0.02 80.2775);
-    --sidebar-ring: oklch(0.783 0.0384 132.737);
-    --footer-bg: oklch(0.0986 0.0063 72.5271);
-    --footer-foreground: oklch(0.9498 0.0046 78.2977);
-  }
+.sage-dark {
+  --background: oklch(0.1173 0.009 73.4751);
+  --foreground: oklch(0.9796 0.0017 67.8026);
+  --card: oklch(0.1609 0.0115 80.9823);
+  --card-foreground: oklch(0.9796 0.0017 67.8026);
+  --popover: oklch(0.1405 0.0109 88.4982);
+  --popover-foreground: oklch(0.9796 0.0017 67.8026);
+  --primary: oklch(0.783 0.0384 132.737);
+  --primary-foreground: oklch(0.0986 0.0063 72.5271);
+  --secondary: oklch(0.251 0.0148 76.2105);
+  --secondary-foreground: oklch(0.9198 0.0075 80.7204);
+  --muted: oklch(0.2203 0.0129 77.9565);
+  --muted-foreground: oklch(0.6511 0.0081 80.7132);
+  --accent: oklch(0.4429 0.0444 134.5073);
+  --accent-foreground: oklch(1 0 0);
+  --destructive: oklch(0.4926 0.1864 26.2192);
+  --destructive-foreground: oklch(0.9796 0.0017 67.8026);
+  --border: oklch(0.2806 0.0246 82.6847);
+  --input: oklch(0.1994 0.0155 75.9533);
+  --ring: oklch(0.783 0.0384 132.737);
+  --chart-1: oklch(0.5636 0.1645 136.9338);
+  --chart-2: oklch(0.6509 0.1756 135.9702);
+  --chart-3: oklch(0.7246 0.1732 135.119);
+  --chart-4: oklch(0.8539 0.1402 133.7838);
+  --chart-5: oklch(0.783 0.0384 132.737);
+  --radius: 0.75rem;
+  --sidebar: oklch(0.0986 0.0063 72.5271);
+  --sidebar-foreground: oklch(0.9498 0.0046 78.2977);
+  --sidebar-primary: oklch(0.783 0.0384 132.737);
+  --sidebar-primary-foreground: oklch(0.0986 0.0063 72.5271);
+  --sidebar-accent: oklch(0.4429 0.0444 134.5073);
+  --sidebar-accent-foreground: oklch(1 0 0);
+  --sidebar-border: oklch(0.2513 0.02 80.2775);
+  --sidebar-ring: oklch(0.783 0.0384 132.737);
+  --footer-bg: oklch(0.0986 0.0063 72.5271);
+  --footer-foreground: oklch(0.9498 0.0046 78.2977);
 }
 
 @layer base {


### PR DESCRIPTION
## What & why

Marketing standardization, PR2 of 3. Wiring a **configurable, decoupled theme
for the marketing surface** surfaced a **pre-existing, shipped bug in the #250
multi-theme system**, so this PR does both (per maintainer decision to combine).

### Fix — custom palettes were app-wide no-ops (`fix(theme)`)
The Modern SaaS / Warm Sand / Sage Green theme groups rendered **identically to
the default** everywhere in the app. Two root causes in `global.css`:
1. The six custom theme classes lived inside `@layer base`, which loses the
   cascade to the **unlayered** `:root` / `.dark` (both match `<html>`), so the
   custom declarations were always overridden.
2. `@theme { --color-background: var(--background) }` (non-inline) resolves the
   token **once at `:root`**; a class overriding `--background` lower in the tree
   never reached `bg-*` utilities. (This also silently broke `[data-admin]`
   subtree scoping — now fixed as a side effect.)

**Fix:** switch to `@theme inline` (utilities emit `var(--raw-token)` at the
use-site) and **un-layer** the custom theme classes so they win by source order.
`SignupsChart` + the chart tooltip swatch are repointed off the now-absent
`--color-*` aliases. **Default light/dark appearance is unchanged** (token values
untouched).

### Feature — marketing theme scoping (`feat(marketing)`)
Adds `SITE_CONFIG.marketingTheme` (default `light`). The marketing layout applies
it as a **subtree CSS class**, so a fork can give the landing site its own brand
palette, **independent of the signed-in user's theme**, with **no visitor toggle**
and **no FOUC** (server-rendered from static config). Portalled overlays (auth
dialog) are covered via a `document.body` class mirror (`MarketingThemeScope`),
mirroring the admin-panel pattern.

## Verification
- Computed-style probe (before → after): `modern-light` primary `#0f172a` → `#3b82f6`;
  `warm-dark` bg `#020817` → `lab(15% …)` (warm brown, no longer clobbered by the
  `.dark` bridge). `bg-background` now tracks the theme.
- Subtree scoping proven: with `marketingTheme='warm-dark'`, `<html>` stays
  `light` while the marketing shell computes a warm-dark background — decoupled.
- Legal pages no longer invert for OS-dark visitors: with a simulated
  `<html class="dark">` + default light marketing theme, `/terms` article
  computes dark-on-light (readable), no `prose-invert`.
- Admin theme-independence holds under `@theme inline`: `[data-admin]` resolves
  to default light/dark under `warm-light`/`warm-dark` — follows light/dark,
  never the consumer hue.
- Default light landing pixel-identical before/after.
- `lint` 0 errors · `check-types` clean · **182 tests pass** · production build green.

## Code review
High-effort multi-agent review returned 3 confirmed findings — all fixed in
`cfd4593` (legal-page `dark:` decoupling, portal body-mirror, dead admin
`--color-*` re-alias) plus a chart-swatch border fix. See PR comment for details.

## Follow-up (PR3)
Non-default (esp. dark) marketing themes reveal **hardcoded-color** sections
(Features section bg, CTA gradient, feature-icon squares) that don't follow the
theme. PR3 tokenizes those so any marketing theme looks right out of the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
