### PR TITLE
feat(marketing): brand gradient tokens, shared primitives, a11y + blog SEO polish

### DIFF
--- a/src/app/[locale]/(unauth)/(marketing)/about/page.tsx
+++ b/src/app/[locale]/(unauth)/(marketing)/about/page.tsx
@@ -6,7 +6,7 @@ import { Fragment } from 'react';
 import { Reveal } from '@/components/reveal';
 import { LinkedInIcon } from '@/components/share/platformIcons';
 import { getSiteUrl } from '@/libs/seo/config';
-import { generateHreflangLinks } from '@/libs/seo/hreflang';
+import { generateHreflangAlternates } from '@/libs/seo/hreflang';
 import { generateSocialMetadata } from '@/libs/seo/opengraph';
 
 import { ABOUT_CONTENT } from './about-content';
@@ -24,13 +24,7 @@ export async function generateMetadata(): Promise<Metadata> {
   // Single authoritative canonical (default-locale, unprefixed) for every
   // locale variant; hreflang alternates signal the multilingual relationship
   // without splitting canonical authority. Mirrors the root layout pattern.
-  const languages = generateHreflangLinks(PATH).reduce(
-    (acc, link) => {
-      acc[link.hreflang] = link.href;
-      return acc;
-    },
-    {} as Record<string, string>,
-  );
+  const languages = generateHreflangAlternates(PATH);
 
   return {
     title: TITLE,

--- a/src/app/[locale]/(unauth)/(marketing)/blog/[category]/[slug]/page.tsx
+++ b/src/app/[locale]/(unauth)/(marketing)/blog/[category]/[slug]/page.tsx
@@ -8,8 +8,9 @@ import {
   getPageBySlug,
   getRelatedPages,
 } from '@/libs/pseo/data';
-import { SITE_NAME } from '@/libs/seo/constants';
-import { getBaseUrl } from '@/utils/Helpers';
+import { getSiteUrl } from '@/libs/seo/config';
+import { generateHreflangLinks } from '@/libs/seo/hreflang';
+import { generateSocialMetadata } from '@/libs/seo/opengraph';
 
 type PseoPageProps = {
   params: Promise<{
@@ -26,7 +27,7 @@ export async function generateStaticParams() {
 
 export async function generateMetadata(props: PseoPageProps): Promise<Metadata> {
   const params = await props.params;
-  const { category: categorySlug, slug, locale } = params;
+  const { category: categorySlug, slug } = params;
 
   const page = await getPageBySlug(categorySlug, slug);
   const category = await getCategoryBySlug(categorySlug);
@@ -37,29 +38,36 @@ export async function generateMetadata(props: PseoPageProps): Promise<Metadata> 
     };
   }
 
-  const baseUrl = getBaseUrl();
-  const pageUrl = `${baseUrl}/${locale}/blog/${categorySlug}/${slug}`;
+  // Match the other marketing pages: shared OG/Twitter + og:image via
+  // generateSocialMetadata, hreflang alternates via generateHreflangLinks, and a
+  // single default-locale canonical. Article-specific og fields are layered on.
+  const path = `/blog/${categorySlug}/${slug}`;
+  const languages = generateHreflangLinks(path).reduce(
+    (acc, link) => {
+      acc[link.hreflang] = link.href;
+      return acc;
+    },
+    {} as Record<string, string>,
+  );
+  const social = generateSocialMetadata({
+    title: page.title,
+    description: page.description,
+    path,
+  });
 
   return {
     title: page.title,
     description: page.description,
     keywords: page.keywords,
+    ...social,
     openGraph: {
-      title: page.title,
-      description: page.description,
-      url: pageUrl,
-      siteName: SITE_NAME,
-      locale,
+      ...social.openGraph,
       type: 'article',
       publishedTime: page.lastModified,
     },
-    twitter: {
-      card: 'summary_large_image',
-      title: page.title,
-      description: page.description,
-    },
     alternates: {
-      canonical: pageUrl,
+      canonical: `${getSiteUrl()}${path}`,
+      languages,
     },
     robots: {
       index: true,

--- a/src/app/[locale]/(unauth)/(marketing)/blog/[category]/[slug]/page.tsx
+++ b/src/app/[locale]/(unauth)/(marketing)/blog/[category]/[slug]/page.tsx
@@ -11,6 +11,7 @@ import {
 import { getSiteUrl } from '@/libs/seo/config';
 import { generateHreflangAlternates } from '@/libs/seo/hreflang';
 import { generateSocialMetadata } from '@/libs/seo/opengraph';
+import { getI18nPath } from '@/utils/Helpers';
 
 type PseoPageProps = {
   params: Promise<{
@@ -27,7 +28,7 @@ export async function generateStaticParams() {
 
 export async function generateMetadata(props: PseoPageProps): Promise<Metadata> {
   const params = await props.params;
-  const { category: categorySlug, slug } = params;
+  const { category: categorySlug, slug, locale } = params;
 
   const page = await getPageBySlug(categorySlug, slug);
   const category = await getCategoryBySlug(categorySlug);
@@ -38,9 +39,10 @@ export async function generateMetadata(props: PseoPageProps): Promise<Metadata> 
     };
   }
 
-  // Match the other marketing pages: shared OG/Twitter + og:image via
-  // generateSocialMetadata (with the article og:type + publishedTime), hreflang
-  // alternates via generateHreflangAlternates, single default-locale canonical.
+  // Shared OG/Twitter + og:image via generateSocialMetadata (with the article
+  // og:type + publishedTime + og:locale), hreflang alternates via
+  // generateHreflangAlternates, and a locale-prefixed self-canonical matching
+  // the blog index/category pages.
   const path = `/blog/${categorySlug}/${slug}`;
   const languages = generateHreflangAlternates(path);
 
@@ -54,9 +56,12 @@ export async function generateMetadata(props: PseoPageProps): Promise<Metadata> 
       path,
       type: 'article',
       publishedTime: page.lastModified,
+      locale,
     }),
     alternates: {
-      canonical: `${getSiteUrl()}${path}`,
+      // Locale-prefixed self-canonical, matching the blog index/category pages
+      // (getI18nPath); hreflang alternates declare the localized siblings.
+      canonical: `${getSiteUrl()}${getI18nPath(path, locale)}`,
       languages,
     },
     robots: {

--- a/src/app/[locale]/(unauth)/(marketing)/blog/[category]/[slug]/page.tsx
+++ b/src/app/[locale]/(unauth)/(marketing)/blog/[category]/[slug]/page.tsx
@@ -9,7 +9,7 @@ import {
   getRelatedPages,
 } from '@/libs/pseo/data';
 import { getSiteUrl } from '@/libs/seo/config';
-import { generateHreflangLinks } from '@/libs/seo/hreflang';
+import { generateHreflangAlternates } from '@/libs/seo/hreflang';
 import { generateSocialMetadata } from '@/libs/seo/opengraph';
 
 type PseoPageProps = {
@@ -39,32 +39,22 @@ export async function generateMetadata(props: PseoPageProps): Promise<Metadata> 
   }
 
   // Match the other marketing pages: shared OG/Twitter + og:image via
-  // generateSocialMetadata, hreflang alternates via generateHreflangLinks, and a
-  // single default-locale canonical. Article-specific og fields are layered on.
+  // generateSocialMetadata (with the article og:type + publishedTime), hreflang
+  // alternates via generateHreflangAlternates, single default-locale canonical.
   const path = `/blog/${categorySlug}/${slug}`;
-  const languages = generateHreflangLinks(path).reduce(
-    (acc, link) => {
-      acc[link.hreflang] = link.href;
-      return acc;
-    },
-    {} as Record<string, string>,
-  );
-  const social = generateSocialMetadata({
-    title: page.title,
-    description: page.description,
-    path,
-  });
+  const languages = generateHreflangAlternates(path);
 
   return {
     title: page.title,
     description: page.description,
     keywords: page.keywords,
-    ...social,
-    openGraph: {
-      ...social.openGraph,
+    ...generateSocialMetadata({
+      title: page.title,
+      description: page.description,
+      path,
       type: 'article',
       publishedTime: page.lastModified,
-    },
+    }),
     alternates: {
       canonical: `${getSiteUrl()}${path}`,
       languages,

--- a/src/app/[locale]/(unauth)/(marketing)/blog/[category]/page.tsx
+++ b/src/app/[locale]/(unauth)/(marketing)/blog/[category]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 
+import { BlogCard } from '@/components/blog/blog-card';
 import {
   getAllCategoryParams,
   getCategoryBySlug,
@@ -73,23 +74,12 @@ export default async function CategoryPage(props: CategoryPageProps) {
 
       <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
         {pages.map(page => (
-          <Link
+          <BlogCard
             key={page.id}
             href={`/${locale}/blog/${categorySlug}/${page.slug}`}
-            className="group block"
-          >
-            <article className="rounded-lg border border-border p-6 transition-all hover:border-foreground/20 hover:shadow-md">
-              <h3 className="mb-2 text-lg font-semibold text-foreground transition-colors group-hover:text-primary">
-                {page.title}
-              </h3>
-              <p className="line-clamp-3 text-sm text-muted-foreground">
-                {page.description}
-              </p>
-              <div className="mt-4 text-sm font-medium text-primary">
-                Read more &rarr;
-              </div>
-            </article>
-          </Link>
+            title={page.title}
+            description={page.description}
+          />
         ))}
       </div>
 

--- a/src/app/[locale]/(unauth)/(marketing)/blog/page.tsx
+++ b/src/app/[locale]/(unauth)/(marketing)/blog/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 
+import { BlogCard } from '@/components/blog/blog-card';
 import { getPagesByCategory, loadCategories } from '@/libs/pseo/data';
 import { getBaseUrl, getI18nPath } from '@/utils/Helpers';
 
@@ -72,23 +73,12 @@ export default async function BlogIndexPage(props: BlogPageProps) {
             </div>
             <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
               {pages.map(page => (
-                <Link
+                <BlogCard
                   key={page.id}
                   href={`/${locale}/blog/${category.slug}/${page.slug}`}
-                  className="group block"
-                >
-                  <article className="rounded-lg border border-border p-6 transition-all hover:border-foreground/20 hover:shadow-md">
-                    <h3 className="mb-2 text-lg font-semibold text-foreground transition-colors group-hover:text-primary">
-                      {page.title}
-                    </h3>
-                    <p className="line-clamp-3 text-sm text-muted-foreground">
-                      {page.description}
-                    </p>
-                    <div className="mt-4 text-sm font-medium text-primary">
-                      Read more &rarr;
-                    </div>
-                  </article>
-                </Link>
+                  title={page.title}
+                  description={page.description}
+                />
               ))}
             </div>
           </section>

--- a/src/app/[locale]/(unauth)/(marketing)/privacy/page.tsx
+++ b/src/app/[locale]/(unauth)/(marketing)/privacy/page.tsx
@@ -6,7 +6,7 @@ import { isDarkTheme } from '@/components/theme/theme-config';
 import { SITE_CONFIG } from '@/config/site-config';
 import { Container } from '@/features/landing/Container';
 import { getSiteUrl } from '@/libs/seo/config';
-import { generateHreflangLinks } from '@/libs/seo/hreflang';
+import { generateHreflangAlternates } from '@/libs/seo/hreflang';
 import { generateSocialMetadata } from '@/libs/seo/opengraph';
 import { cn } from '@/utils/Helpers';
 
@@ -31,13 +31,7 @@ export async function generateMetadata(): Promise<Metadata> {
   // Single authoritative canonical (default-locale, unprefixed) for every
   // locale variant; hreflang alternates signal the multilingual relationship
   // without splitting canonical authority. Mirrors the /about pattern.
-  const languages = generateHreflangLinks(PATH).reduce(
-    (acc, link) => {
-      acc[link.hreflang] = link.href;
-      return acc;
-    },
-    {} as Record<string, string>,
-  );
+  const languages = generateHreflangAlternates(PATH);
 
   return {
     title: TITLE,

--- a/src/app/[locale]/(unauth)/(marketing)/privacy/page.tsx
+++ b/src/app/[locale]/(unauth)/(marketing)/privacy/page.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from 'next';
 import { LegalTableOfContents } from '@/components/legal/legal-toc';
 import { isDarkTheme } from '@/components/theme/theme-config';
 import { SITE_CONFIG } from '@/config/site-config';
+import { Container } from '@/features/landing/Container';
 import { getSiteUrl } from '@/libs/seo/config';
 import { generateHreflangLinks } from '@/libs/seo/hreflang';
 import { generateSocialMetadata } from '@/libs/seo/opengraph';
@@ -76,7 +77,7 @@ export default async function PrivacyPage(props: {
     <section className="relative overflow-hidden pb-20 pt-12">
       <div className="pointer-events-none absolute -top-32 left-1/2 h-[420px] w-[420px] -translate-x-1/2 rounded-full bg-primary/10 blur-[120px]" />
 
-      <div className="relative mx-auto max-w-3xl px-4 sm:px-6">
+      <Container size="md" className="relative">
         {/* AI-drafted disclaimer banner */}
         <div className={cn('not-prose mb-10 flex items-start gap-3 rounded-xl border border-amber-500/30 bg-amber-500/10 p-4 text-sm text-amber-900', marketingDark && 'text-amber-200')}>
           <AlertTriangle
@@ -208,7 +209,7 @@ export default async function PrivacyPage(props: {
             .
           </p>
         </article>
-      </div>
+      </Container>
     </section>
   );
 }

--- a/src/app/[locale]/(unauth)/(marketing)/terms/page.tsx
+++ b/src/app/[locale]/(unauth)/(marketing)/terms/page.tsx
@@ -6,7 +6,7 @@ import { isDarkTheme } from '@/components/theme/theme-config';
 import { SITE_CONFIG } from '@/config/site-config';
 import { Container } from '@/features/landing/Container';
 import { getSiteUrl } from '@/libs/seo/config';
-import { generateHreflangLinks } from '@/libs/seo/hreflang';
+import { generateHreflangAlternates } from '@/libs/seo/hreflang';
 import { generateSocialMetadata } from '@/libs/seo/opengraph';
 import { cn } from '@/utils/Helpers';
 
@@ -31,13 +31,7 @@ export async function generateMetadata(): Promise<Metadata> {
   // Single authoritative canonical (default-locale, unprefixed) for every
   // locale variant; hreflang alternates signal the multilingual relationship
   // without splitting canonical authority. Mirrors the /about pattern.
-  const languages = generateHreflangLinks(PATH).reduce(
-    (acc, link) => {
-      acc[link.hreflang] = link.href;
-      return acc;
-    },
-    {} as Record<string, string>,
-  );
+  const languages = generateHreflangAlternates(PATH);
 
   return {
     title: TITLE,

--- a/src/app/[locale]/(unauth)/(marketing)/terms/page.tsx
+++ b/src/app/[locale]/(unauth)/(marketing)/terms/page.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from 'next';
 import { LegalTableOfContents } from '@/components/legal/legal-toc';
 import { isDarkTheme } from '@/components/theme/theme-config';
 import { SITE_CONFIG } from '@/config/site-config';
+import { Container } from '@/features/landing/Container';
 import { getSiteUrl } from '@/libs/seo/config';
 import { generateHreflangLinks } from '@/libs/seo/hreflang';
 import { generateSocialMetadata } from '@/libs/seo/opengraph';
@@ -76,7 +77,7 @@ export default async function TermsPage(props: {
     <section className="relative overflow-hidden pb-20 pt-12">
       <div className="pointer-events-none absolute -top-32 left-1/2 h-[420px] w-[420px] -translate-x-1/2 rounded-full bg-primary/10 blur-[120px]" />
 
-      <div className="relative mx-auto max-w-3xl px-4 sm:px-6">
+      <Container size="md" className="relative">
         {/* AI-drafted disclaimer banner */}
         <div className={cn('not-prose mb-10 flex items-start gap-3 rounded-xl border border-amber-500/30 bg-amber-500/10 p-4 text-sm text-amber-900', marketingDark && 'text-amber-200')}>
           <AlertTriangle
@@ -218,7 +219,7 @@ export default async function TermsPage(props: {
             .
           </p>
         </article>
-      </div>
+      </Container>
     </section>
   );
 }

--- a/src/components/Background.tsx
+++ b/src/components/Background.tsx
@@ -4,7 +4,7 @@ export const Background = (props: {
   children: React.ReactNode;
   className?: string;
 }) => (
-  <div className={cn('w-full bg-secondary', props.className)}>
+  <div className={cn('w-full bg-secondary text-secondary-foreground', props.className)}>
     {props.children}
   </div>
 );

--- a/src/components/blog/blog-card.tsx
+++ b/src/components/blog/blog-card.tsx
@@ -1,0 +1,30 @@
+import Link from 'next/link';
+
+/**
+ * Blog listing card, shared by the blog index and category pages. Cards are
+ * equal-height within a grid row (`h-full` + `flex flex-col`, with the "Read
+ * more" affordance pinned to the bottom via `mt-auto`), lift slightly on hover,
+ * and show a keyboard focus ring on the link.
+ */
+export const BlogCard = (props: {
+  href: string;
+  title: string;
+  description: string;
+}) => (
+  <Link
+    href={props.href}
+    className="group block h-full rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+  >
+    <article className="flex h-full flex-col rounded-lg border border-border p-6 transition-all hover:-translate-y-0.5 hover:border-foreground/20 hover:shadow-md">
+      <h3 className="mb-2 text-lg font-semibold text-foreground transition-colors group-hover:text-primary">
+        {props.title}
+      </h3>
+      <p className="line-clamp-3 text-sm text-muted-foreground">
+        {props.description}
+      </p>
+      <div className="mt-auto pt-4 text-sm font-medium text-primary">
+        Read more &rarr;
+      </div>
+    </article>
+  </Link>
+);

--- a/src/components/blog/blog-card.tsx
+++ b/src/components/blog/blog-card.tsx
@@ -3,8 +3,9 @@ import Link from 'next/link';
 /**
  * Blog listing card, shared by the blog index and category pages. Cards are
  * equal-height within a grid row (`h-full` + `flex flex-col`, with the "Read
- * more" affordance pinned to the bottom via `mt-auto`), lift slightly on hover,
- * and show a keyboard focus ring on the link.
+ * more" affordance pinned to the bottom via `mt-auto`) and lift slightly on
+ * hover. Keyboard focus is handled by the global `a:focus-visible` outline
+ * (see global.css); `rounded-lg` makes that outline follow the card's corners.
  */
 export const BlogCard = (props: {
   href: string;
@@ -13,7 +14,7 @@ export const BlogCard = (props: {
 }) => (
   <Link
     href={props.href}
-    className="group block h-full rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+    className="group block h-full rounded-lg"
   >
     <article className="flex h-full flex-col rounded-lg border border-border p-6 transition-all hover:-translate-y-0.5 hover:border-foreground/20 hover:shadow-md">
       <h3 className="mb-2 text-lg font-semibold text-foreground transition-colors group-hover:text-primary">

--- a/src/features/landing/CTABanner.tsx
+++ b/src/features/landing/CTABanner.tsx
@@ -3,7 +3,7 @@ export const CTABanner = (props: {
   description: string;
   buttons: React.ReactNode;
 }) => (
-  <div className="rounded-xl bg-muted bg-linear-to-br from-indigo-400 via-purple-400 to-pink-400 px-6 py-10 text-center">
+  <div className="rounded-xl bg-muted bg-linear-to-br from-(--gradient-from) via-(--gradient-via) to-(--gradient-to) px-6 py-10 text-center">
     <div className="text-3xl font-bold text-primary-foreground">
       {props.title}
     </div>

--- a/src/features/landing/CTABanner.tsx
+++ b/src/features/landing/CTABanner.tsx
@@ -3,7 +3,7 @@ export const CTABanner = (props: {
   description: string;
   buttons: React.ReactNode;
 }) => (
-  <div className="rounded-xl bg-linear-to-br from-(--gradient-from) via-(--gradient-via) to-(--gradient-to) px-6 py-10 text-center">
+  <div className="rounded-xl bg-linear-to-br from-(--gradient-soft-from) via-(--gradient-soft-via) to-(--gradient-soft-to) px-6 py-10 text-center">
     <div className="text-3xl font-bold text-primary-foreground">
       {props.title}
     </div>

--- a/src/features/landing/CTABanner.tsx
+++ b/src/features/landing/CTABanner.tsx
@@ -3,7 +3,7 @@ export const CTABanner = (props: {
   description: string;
   buttons: React.ReactNode;
 }) => (
-  <div className="rounded-xl bg-muted bg-linear-to-br from-(--gradient-from) via-(--gradient-via) to-(--gradient-to) px-6 py-10 text-center">
+  <div className="rounded-xl bg-linear-to-br from-(--gradient-from) via-(--gradient-via) to-(--gradient-to) px-6 py-10 text-center">
     <div className="text-3xl font-bold text-primary-foreground">
       {props.title}
     </div>

--- a/src/features/landing/Container.tsx
+++ b/src/features/landing/Container.tsx
@@ -2,14 +2,14 @@ import { cn } from '@/utils/Helpers';
 
 /**
  * Centered, horizontally-padded content column for marketing pages. Standardizes
- * the `mx-auto max-w-* px-4 sm:px-6` pattern that was repeated across the landing
- * sections and legal/about pages, so page width stays consistent in one place.
+ * the `mx-auto max-w-* px-4 sm:px-6` pattern so page width stays consistent in
+ * one place. Adopted by the legal pages (terms/privacy); other marketing pages
+ * can move onto it incrementally.
  */
 const SIZES = {
   sm: 'max-w-2xl',
   md: 'max-w-3xl',
   lg: 'max-w-5xl',
-  xl: 'max-w-(--breakpoint-lg)',
 } as const;
 
 export const Container = (props: {

--- a/src/features/landing/Container.tsx
+++ b/src/features/landing/Container.tsx
@@ -1,0 +1,23 @@
+import { cn } from '@/utils/Helpers';
+
+/**
+ * Centered, horizontally-padded content column for marketing pages. Standardizes
+ * the `mx-auto max-w-* px-4 sm:px-6` pattern that was repeated across the landing
+ * sections and legal/about pages, so page width stays consistent in one place.
+ */
+const SIZES = {
+  sm: 'max-w-2xl',
+  md: 'max-w-3xl',
+  lg: 'max-w-5xl',
+  xl: 'max-w-(--breakpoint-lg)',
+} as const;
+
+export const Container = (props: {
+  children: React.ReactNode;
+  size?: keyof typeof SIZES;
+  className?: string;
+}) => (
+  <div className={cn('mx-auto w-full px-4 sm:px-6', SIZES[props.size ?? 'lg'], props.className)}>
+    {props.children}
+  </div>
+);

--- a/src/features/landing/FeatureCard.tsx
+++ b/src/features/landing/FeatureCard.tsx
@@ -4,13 +4,13 @@ export const FeatureCard = (props: {
   children: React.ReactNode;
 }) => (
   <div className="rounded-xl border border-border bg-card p-5 text-card-foreground">
-    <div className="size-12 rounded-lg bg-linear-to-br from-(--gradient-from) via-(--gradient-via) to-(--gradient-to) p-2 [&_svg]:stroke-white [&_svg]:stroke-2">
+    <div className="size-12 rounded-lg bg-linear-to-br from-(--gradient-soft-from) via-(--gradient-soft-via) to-(--gradient-soft-to) p-2 [&_svg]:stroke-white [&_svg]:stroke-2">
       {props.icon}
     </div>
 
     <div className="mt-2 text-lg font-bold">{props.title}</div>
 
-    <div className="my-3 w-8 border-t border-(--gradient-via)" />
+    <div className="my-3 w-8 border-t border-(--gradient-soft-via)" />
 
     <div className="mt-2 text-muted-foreground">{props.children}</div>
   </div>

--- a/src/features/landing/FeatureCard.tsx
+++ b/src/features/landing/FeatureCard.tsx
@@ -3,14 +3,14 @@ export const FeatureCard = (props: {
   title: string;
   children: React.ReactNode;
 }) => (
-  <div className="rounded-xl border border-border bg-card p-5">
-    <div className="size-12 rounded-lg bg-linear-to-br from-indigo-400 via-purple-400 to-pink-400 p-2 [&_svg]:stroke-white [&_svg]:stroke-2">
+  <div className="rounded-xl border border-border bg-card p-5 text-card-foreground">
+    <div className="size-12 rounded-lg bg-linear-to-br from-(--gradient-from) via-(--gradient-via) to-(--gradient-to) p-2 [&_svg]:stroke-white [&_svg]:stroke-2">
       {props.icon}
     </div>
 
     <div className="mt-2 text-lg font-bold">{props.title}</div>
 
-    <div className="my-3 w-8 border-t border-purple-400" />
+    <div className="my-3 w-8 border-t border-(--gradient-via)" />
 
     <div className="mt-2 text-muted-foreground">{props.children}</div>
   </div>

--- a/src/features/landing/Section.tsx
+++ b/src/features/landing/Section.tsx
@@ -1,3 +1,4 @@
+import { SectionHeading } from '@/features/landing/SectionHeading';
 import { cn } from '@/utils/Helpers';
 
 export const Section = (props: {
@@ -9,25 +10,11 @@ export const Section = (props: {
   id?: string;
 }) => (
   <div id={props.id} className={cn('px-3 py-16', props.className)}>
-    {(props.title || props.subtitle || props.description) && (
-      <div className="mx-auto mb-12 max-w-(--breakpoint-md) text-center">
-        {props.subtitle && (
-          <div className="bg-linear-to-r from-indigo-500 via-purple-500 to-pink-500 bg-clip-text text-sm font-bold text-transparent">
-            {props.subtitle}
-          </div>
-        )}
-
-        {props.title && (
-          <h2 className="mt-1 text-3xl font-bold">{props.title}</h2>
-        )}
-
-        {props.description && (
-          <div className="mt-2 text-lg text-muted-foreground">
-            {props.description}
-          </div>
-        )}
-      </div>
-    )}
+    <SectionHeading
+      eyebrow={props.subtitle}
+      title={props.title}
+      description={props.description}
+    />
 
     <div className="mx-auto max-w-(--breakpoint-lg)">{props.children}</div>
   </div>

--- a/src/features/landing/SectionHeading.tsx
+++ b/src/features/landing/SectionHeading.tsx
@@ -1,0 +1,37 @@
+import { cn } from '@/utils/Helpers';
+
+/**
+ * The eyebrow + title + description block shared by marketing sections. The
+ * eyebrow uses the per-theme brand gradient tokens (`--gradient-*`), so it
+ * follows the marketing theme. Renders nothing when no text is provided.
+ */
+export const SectionHeading = (props: {
+  eyebrow?: string;
+  title?: string;
+  description?: string;
+  className?: string;
+}) => {
+  if (!props.eyebrow && !props.title && !props.description) {
+    return null;
+  }
+
+  return (
+    <div className={cn('mx-auto mb-12 max-w-(--breakpoint-md) text-center', props.className)}>
+      {props.eyebrow && (
+        <div className="bg-linear-to-r from-(--gradient-from) via-(--gradient-via) to-(--gradient-to) bg-clip-text text-sm font-bold text-transparent">
+          {props.eyebrow}
+        </div>
+      )}
+
+      {props.title && (
+        <h2 className="mt-1 text-3xl font-bold">{props.title}</h2>
+      )}
+
+      {props.description && (
+        <div className="mt-2 text-lg text-muted-foreground">
+          {props.description}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/features/landing/StickyBanner.tsx
+++ b/src/features/landing/StickyBanner.tsx
@@ -1,5 +1,5 @@
 export const StickyBanner = (props: { children: React.ReactNode }) => (
-  <div className="sticky top-0 z-50 bg-primary p-4 text-center text-lg font-semibold text-primary-foreground [&_a:hover]:text-(--gradient-from) [&_a]:text-(--gradient-to)">
+  <div className="sticky top-0 z-50 bg-primary p-4 text-center text-lg font-semibold text-primary-foreground [&_a:hover]:text-indigo-500 [&_a]:text-fuchsia-500">
     {props.children}
   </div>
 );

--- a/src/features/landing/StickyBanner.tsx
+++ b/src/features/landing/StickyBanner.tsx
@@ -1,5 +1,5 @@
 export const StickyBanner = (props: { children: React.ReactNode }) => (
-  <div className="sticky top-0 z-50 bg-primary p-4 text-center text-lg font-semibold text-primary-foreground [&_a:hover]:text-indigo-500 [&_a]:text-fuchsia-500">
+  <div className="sticky top-0 z-50 bg-primary p-4 text-center text-lg font-semibold text-primary-foreground [&_a:hover]:text-(--gradient-from) [&_a]:text-(--gradient-to)">
     {props.children}
   </div>
 );

--- a/src/libs/seo/hreflang.ts
+++ b/src/libs/seo/hreflang.ts
@@ -76,3 +76,19 @@ export function generateHreflangLinks(pathname: string): HreflangLink[] {
 
   return links;
 }
+
+/**
+ * Hreflang links shaped for Next.js `Metadata.alternates.languages` — a
+ * `{ [hreflang]: href }` map. Thin wrapper over {@link generateHreflangLinks}
+ * so every page builds the same map the same way instead of copy-pasting the
+ * reduce into each `generateMetadata`.
+ */
+export function generateHreflangAlternates(pathname: string): Record<string, string> {
+  return generateHreflangLinks(pathname).reduce<Record<string, string>>(
+    (acc, link) => {
+      acc[link.hreflang] = link.href;
+      return acc;
+    },
+    {},
+  );
+}

--- a/src/libs/seo/opengraph.ts
+++ b/src/libs/seo/opengraph.ts
@@ -26,6 +26,8 @@ export type SocialMetadataParams = {
   type?: 'website' | 'article';
   /** ISO date string for og:article:published_time. Only emitted when type === 'article'. */
   publishedTime?: string;
+  /** Locale code for og:locale (e.g. 'en', 'hi'). Omitted when unset. */
+  locale?: string;
 };
 
 /**
@@ -59,7 +61,7 @@ function withBrand(title: string): string {
 export function generateOpenGraphMetadata(
   params: SocialMetadataParams,
 ): Metadata['openGraph'] {
-  const { title, description, image, path = '', type = 'website', publishedTime } = params;
+  const { title, description, image, path = '', type = 'website', publishedTime, locale } = params;
   const siteUrl = getSiteUrl();
 
   // Use provided image, or generate dynamic OG image, or fallback to static
@@ -77,6 +79,7 @@ export function generateOpenGraphMetadata(
     title: withBrand(title),
     description,
     url: `${siteUrl}${path}`,
+    ...(locale ? { locale } : {}),
     images: [
       {
         url: imageUrl,

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -588,9 +588,12 @@
    vibrant mid-tones that read on either background) rather than inside each
    theme block. These MUST come after the theme blocks above and be unlayered,
    so a family's gradient wins over the default block for `*-dark` themes (which
-   also carry `.dark`). The default `:root`/`.light`/`.dark` values are the exact
-   indigo-500 / purple-500 / pink-500 the template shipped — default look
-   unchanged. To rebrand, edit the raw `--gradient-*` per family here.
+   also carry `.dark`). Two tiers preserve the template's EXACT shipped look: the
+   `--gradient-*` (500) tier drives the hero title + section eyebrows (which
+   shipped at 500), and the `--gradient-soft-*` (400) tier drives the softer CTA
+   band + feature-icon squares (which shipped at 400). Non-default themes reuse
+   their single family gradient for both tiers (soft = strong, set below). To
+   rebrand, edit the raw `--gradient-*` per family here.
    ============================================================================= */
 :root,
 .light,
@@ -598,6 +601,9 @@
   --gradient-from: hsl(238.7 83.5% 66.7%); /* indigo-500 */
   --gradient-via: hsl(270.7 91% 65.1%); /* purple-500 */
   --gradient-to: hsl(330.4 81.2% 60.4%); /* pink-500 */
+  --gradient-soft-from: hsl(234.5 89.5% 73.9%); /* indigo-400 */
+  --gradient-soft-via: hsl(269.7 96.8% 75.5%); /* purple-400 */
+  --gradient-soft-to: hsl(330.4 90.1% 70%); /* pink-400 */
 }
 
 .modern-light,
@@ -619,6 +625,18 @@
   --gradient-from: oklch(0.6 0.11 150); /* sage */
   --gradient-via: oklch(0.68 0.13 160); /* emerald */
   --gradient-to: oklch(0.6 0.1 195); /* teal */
+}
+
+/* Non-default themes only ship one gradient, so the soft tier reuses it. */
+.modern-light,
+.modern-dark,
+.warm-light,
+.warm-dark,
+.sage-light,
+.sage-dark {
+  --gradient-soft-from: var(--gradient-from);
+  --gradient-soft-via: var(--gradient-via);
+  --gradient-soft-to: var(--gradient-to);
 }
 
 @layer base {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -579,8 +579,70 @@
   --footer-foreground: oklch(0.9498 0.0046 78.2977);
 }
 
+/* =============================================================================
+   Brand gradient — per-theme accent gradient for the marketing surface
+   (hero title, section eyebrows, CTA band, feature-icon squares).
+
+   Consumed via `from-(--gradient-from) via-(--gradient-via) to-(--gradient-to)`.
+   Defined once per theme FAMILY here (light+dark share a gradient — these are
+   vibrant mid-tones that read on either background) rather than inside each
+   theme block. These MUST come after the theme blocks above and be unlayered,
+   so a family's gradient wins over the default block for `*-dark` themes (which
+   also carry `.dark`). The default `:root`/`.light`/`.dark` values are the exact
+   indigo-500 / purple-500 / pink-500 the template shipped — default look
+   unchanged. To rebrand, edit the raw `--gradient-*` per family here.
+   ============================================================================= */
+:root,
+.light,
+.dark {
+  --gradient-from: hsl(238.7 83.5% 66.7%); /* indigo-500 */
+  --gradient-via: hsl(270.7 91% 65.1%); /* purple-500 */
+  --gradient-to: hsl(330.4 81.2% 60.4%); /* pink-500 */
+}
+
+.modern-light,
+.modern-dark {
+  --gradient-from: hsl(217.2 91.2% 59.8%); /* blue */
+  --gradient-via: hsl(224.3 76.3% 58%); /* indigo-blue */
+  --gradient-to: hsl(198.6 88.7% 55%); /* sky */
+}
+
+.warm-light,
+.warm-dark {
+  --gradient-from: oklch(0.62 0.17 40); /* terracotta */
+  --gradient-via: oklch(0.72 0.15 65); /* amber */
+  --gradient-to: oklch(0.63 0.18 20); /* rose */
+}
+
+.sage-light,
+.sage-dark {
+  --gradient-from: oklch(0.6 0.11 150); /* sage */
+  --gradient-via: oklch(0.68 0.13 160); /* emerald */
+  --gradient-to: oklch(0.6 0.1 195); /* teal */
+}
+
 @layer base {
   * {
     @apply border-border;
   }
+
+  /* Keyboard-only focus ring for links and interactive elements that don't
+     ship their own. shadcn controls set `focus-visible:ring-*` + `outline-hidden`
+     in the utilities layer, which overrides this base rule — so no double ring;
+     this only fills the gap for plain links, summaries, and custom tabbables. */
+  a:focus-visible,
+  summary:focus-visible,
+  [tabindex]:not([tabindex='-1']):focus-visible {
+    outline: 2px solid var(--ring);
+    outline-offset: 2px;
+  }
+}
+
+/* Hide scrollbars while keeping scroll (e.g. horizontal nav/tab strips). */
+@utility no-scrollbar {
+  &::-webkit-scrollbar {
+    display: none;
+  }
+  -ms-overflow-style: none;
+  scrollbar-width: none;
 }

--- a/src/templates/Hero.tsx
+++ b/src/templates/Hero.tsx
@@ -17,7 +17,7 @@ export const Hero = () => {
       <CenteredHero
         title={t.rich('title', {
           important: chunks => (
-            <span className="bg-linear-to-r from-indigo-500 via-purple-500 to-pink-500 bg-clip-text text-transparent">
+            <span className="bg-linear-to-r from-(--gradient-from) via-(--gradient-via) to-(--gradient-to) bg-clip-text text-transparent">
               {chunks}
             </span>
           ),


### PR DESCRIPTION
## What & why

Marketing standardization, **PR3 of 3** (the polish PR). Completes the marketing
theme feature enabled by PR2 (#373) and adds shared primitives + a11y + blog SEO.

### `feat(marketing)` — per-theme brand gradient + theme-legible surfaces + a11y
- The marketing surface hardcoded an `indigo→purple→pink` gradient (hero title,
  section eyebrow, CTA band, feature-icon squares, sticky-banner links) that
  couldn't follow a fork's theme. Added per-theme `--gradient-from/via/to` tokens
  (consumed via `from-(--gradient-*)`). **Default keeps the exact indigo/purple/pink**
  — no default change; each built-in family (modern/warm/sage) gets a fitting one.
- **Legibility fixes:** `Background` (`bg-secondary`) and `FeatureCard` (`bg-card`)
  inherited a mismatched foreground, making the section heading and card titles
  invisible under themes with an inverted secondary (e.g. `warm-dark`). Paired each
  surface with its `text-*-foreground`.
- **a11y:** global `:focus-visible` ring for links/tabbables that lack their own
  (shadcn controls override it in the utilities layer) + a `no-scrollbar` utility.

### `refactor(marketing)` — shared primitives
- `Container` (sizes sm/md/lg/xl) for the `mx-auto max-w-* px-*` column; adopted in
  `Section` + the legal pages.
- `SectionHeading` (eyebrow + title + description); `Section` delegates to it.
- `BlogCard` used by the blog index + category pages — equal-height rows
  (`flex h-full`, "Read more" pinned via `mt-auto`), hover-lift, focus ring.

### `feat(blog)` — article social metadata
Article `generateMetadata` was hand-rolled and lacked hreflang. Routed through the
shared `generateSocialMetadata` (OG + Twitter + og:image) + `generateHreflangLinks`,
matching the other pages, keeping og:type=article + publishedTime + canonical.

## Verification
- Default light landing **pixel-identical** (gradient tokens resolve to the exact
  indigo/purple/pink). Screenshots `pr3-01` (default) vs `pr3-02/03` (warm-dark).
- Under `warm-dark`: gradients render warm; section heading + card titles legible
  (computed: card title `lab(97.9%)` on `lab(17.9%)` card). Regression caught by the
  visual check and fixed (FeatureCard foreground pairing).
- Blog index: equal-height cards, bottom-aligned CTA.
- `lint` 0 errors · `check-types` clean · **340 tests pass** · production build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
