### PR TITLE
fix(ci): repair docs-sync and rework changelog-sync (headless CLI + Releases API)

### DIFF
--- a/.claude/commands/init-downstream.md
+++ b/.claude/commands/init-downstream.md
@@ -103,8 +103,16 @@ Set up a freshly forked/templated project as an independent downstream project.
    - author       → ASK or leave as-is.
 
 3. Reset the changelog:
-   - Truncate docs/CHANGELOG.md to a single heading (semantic-release regenerates it
-     from your commits): "# Changelog\n"
+   - Overwrite docs/changelog.json with an empty seed: {"versions": []}
+     (this is the humanized, user-facing changelog rendered at /changelog). The
+     Changelog Sync workflow reads the GitHub Releases API and humanizes every
+     release NEWER than the newest entry here — an empty seed means it starts
+     from your product's very first release. Do NOT carry over the template's
+     high-water marker entry (e.g. 3.28.0); left in place it sits ABOVE all your
+     0.x releases and changelog-sync would skip them forever.
+   - Note: semantic-release is tag-only and does NOT write a docs/CHANGELOG.md
+     file — release notes live on the GitHub Release page. There is no CHANGELOG.md
+     to reset.
 
 4. OUTPUT: "Project identity reset — package '<package_name>' @ 0.1.0."
 ```

--- a/.github/prompts/changelog-humanize.md
+++ b/.github/prompts/changelog-humanize.md
@@ -8,15 +8,17 @@ branch, commit, or PR commands, and do NOT modify any other file.
 
 ## Steps
 
-1. Read `docs/CHANGELOG.md` — the developer source of truth (NEVER modify it). It
-   lists versions newest-first with commits grouped under Features / Bug Fixes /
-   Performance. Read `docs/changelog.json` if it exists (shape
-   `{ "versions": [ ... ] }`, newest-first).
+1. Read the **pending-releases JSON file** — the developer source of truth (NEVER
+   modify it). Its absolute path is given at the very end of these instructions.
+   It is a newest-first array of `{ version, date, notes }`, one entry per
+   published GitHub Release; `notes` is the release body with commits grouped
+   under Features / Bug Fixes / Performance. Read `docs/changelog.json` if it
+   exists (shape `{ "versions": [ ... ] }`, newest-first).
 
-2. Find every version present in `CHANGELOG.md` but NOT yet in `changelog.json`.
-   Process ALL of them, newest-first (not just the topmost — a rolling branch may
-   have several pending). If every `CHANGELOG.md` version is already present, make
-   NO changes and stop (idempotent — produce no edits).
+2. Find every `version` in the pending-releases file but NOT yet in
+   `changelog.json`. Process ALL of them, newest-first (not just the topmost — a
+   rolling branch may have several pending). If every release version is already
+   present, make NO changes and stop (idempotent — produce no edits).
 
 3. Learn the product and audience from `CLAUDE.md` (Project Overview) and the
    writing voice from `docs/voice.md` (fall back to the voice guidance in
@@ -59,8 +61,8 @@ branch, commit, or PR commands, and do NOT modify any other file.
    }
    ```
 
-   Field rules: `version` and `date` (`YYYY-MM-DD`) come from the `CHANGELOG.md`
-   header. `summary` is one short sentence. `tag` is exactly one of `new` (a new
+   Field rules: `version` and `date` (`YYYY-MM-DD`) come from the pending-releases
+   entry (`version`, `date`). `summary` is one short sentence. `tag` is exactly one of `new` (a new
    capability), `improved` (an improvement or performance win), or `fixed` (a bug
    fix). `highlights` and `underTheHood` may each be empty, but do not emit an
    entry where both are empty (that version should have been skipped per step 4).

--- a/.github/workflows/changelog-sync.yml
+++ b/.github/workflows/changelog-sync.yml
@@ -9,9 +9,11 @@ name: Changelog Sync
 #     suppresses workflow triggers from token-created events — so `on: release`
 #     would never fire. `workflow_run` is the same chaining release.yml uses off
 #     CI, and fires reliably.
-#   - A cheap pre-check compares the newest version in docs/CHANGELOG.md against
-#     docs/changelog.json, so Claude only runs when there's a new release to
-#     humanize (the Release workflow completes on every main CI success).
+#   - A cheap pre-check reads the GitHub Releases API and compares published
+#     versions against docs/changelog.json, so Claude only runs when there's a new
+#     release to humanize (the Release workflow completes on every main CI
+#     success). Releases are the source of truth: semantic-release is configured
+#     tag-only (no @semantic-release/git), so there is no docs/CHANGELOG.md.
 #   - Concurrency-grouped + queued: bursts of releases process in order.
 #   - One rolling PR on `changelog/auto` accumulates entries — max one open PR.
 #   - Each run rebases the rolling branch onto main BEFORE appending, so entries
@@ -22,19 +24,19 @@ name: Changelog Sync
 #   - Claude only edits docs/changelog.json; the workflow owns git / PR / merge.
 #
 # Known minor inefficiency: a release whose only change is a non-user-facing
-# `fix(deps)` (e.g. moving a CLI to devDependencies) lands in CHANGELOG.md but
-# the humanizer correctly produces no entry — so the pre-check keeps seeing it as
-# "not present" and re-runs Claude (a no-op) on each Release completion until the
-# next user-facing release. Bounded and cheap; not worth a version high-water mark.
+# `fix(deps)` (e.g. moving a CLI to devDependencies) still publishes a GitHub
+# Release, but the humanizer correctly produces no entry — so the pre-check keeps
+# seeing it as "not present" and re-runs Claude (a no-op) on each Release
+# completion until the next user-facing release. Bounded and cheap; not worth a
+# version high-water mark.
 #
-# Prerequisites (see docs/changelog/README.md):
-#   - A release-maintained source file at docs/CHANGELOG.md. The template's
-#     semantic-release config does NOT generate this by default — add
-#     @semantic-release/changelog (changelogFile: docs/CHANGELOG.md) to the
-#     release config first. Until then this workflow's pre-check finds no version
-#     and skips safely (dormant-but-correct).
+# Prerequisites:
 #   - The CLAUDE_CODE_OAUTH_TOKEN repo secret (shared with the Claude Code action).
 #   - "Allow auto-merge" enabled in repo settings.
+#   - A seed docs/changelog.json (shape `{ "versions": [ ... ] }`, newest-first)
+#     so the pre-check has a high-water mark. With an empty/absent file the first
+#     run would try to humanize the ENTIRE release history in one job — seed it
+#     with the latest release (or a `1.0.0` placeholder) to bound the first run.
 #   - Activates only once this file is on the default branch (workflow_run reads
 #     the workflow definition from main). Use the Run workflow button to test.
 
@@ -69,36 +71,45 @@ jobs:
           fetch-depth: 0
           ref: main
 
-      - name: Detect un-humanized release
+      - name: Detect un-humanized releases
         id: precheck
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASES_FILE: ${{ runner.temp }}/pending-releases.json
         run: |
           set -euo pipefail
-          if [ ! -f docs/CHANGELOG.md ]; then
-            echo "docs/CHANGELOG.md does not exist — nothing to do (see docs/changelog/README.md)."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          # semantic-release headers look like "## [1.29.1](url) (2026-06-13)" or
-          # "# [1.29.0](url) ..." — grab the version from the topmost one.
-          NEWEST=$(grep -oE '^#+[[:space:]]+\[?[0-9]+\.[0-9]+\.[0-9]+' docs/CHANGELOG.md \
-            | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || true)
-          if [ -z "$NEWEST" ]; then
-            echo "No parseable version in docs/CHANGELOG.md — nothing to do."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "Newest version in CHANGELOG.md: $NEWEST"
-          PRESENT=no
-          if [ -f docs/changelog.json ]; then
-            PRESENT=$(node -e "const d=require('./docs/changelog.json'); process.stdout.write(d.versions.some(v=>v.version==='$NEWEST')?'yes':'no')")
-          fi
-          if [ "$PRESENT" = "yes" ]; then
-            echo "$NEWEST already in changelog.json — skipping."
+          # GitHub Releases are the source of truth: semantic-release is tag-only
+          # (no @semantic-release/git), so there is no docs/CHANGELOG.md to parse.
+          # The Releases API returns the FULL history; humanize only releases
+          # STRICTLY NEWER than the newest already in docs/changelog.json — we move
+          # the changelog forward, never backfill the entire history (that overruns
+          # the job timeout). Write the bounded to-humanize list (newest-first) to
+          # RELEASES_FILE, outside the repo tree so it never becomes a stray file in
+          # the changelog/auto working tree the commit step guards against.
+          ALL="${{ runner.temp }}/all-releases.json"
+          gh api "repos/${{ github.repository }}/releases" --paginate \
+            --jq 'map(select(.draft | not) | {version: (.tag_name | ltrimstr("v")), date: (.published_at[0:10]), notes: .body})' \
+            > "$ALL"
+          echo "releases_file=$RELEASES_FILE" >> "$GITHUB_OUTPUT"
+          TODO=$(ALL="$ALL" OUT="$RELEASES_FILE" node -e '
+            const fs=require("fs");
+            const all=JSON.parse(fs.readFileSync(process.env.ALL,"utf8"));
+            let have=[]; try { have=require("./docs/changelog.json").versions.map(v=>v.version); } catch {}
+            const haveSet=new Set(have);
+            const newest=have[0]; // changelog.json is newest-first
+            const cmp=(a,b)=>{const x=a.split(".").map(Number),y=b.split(".").map(Number);for(let i=0;i<3;i++){const d=(x[i]||0)-(y[i]||0);if(d)return d;}return 0;};
+            const todo=all.filter(r=>!haveSet.has(r.version) && (!newest || cmp(r.version,newest)>0));
+            fs.writeFileSync(process.env.OUT, JSON.stringify(todo,null,2));
+            process.stdout.write(todo.map(r=>r.version).join(","));
+          ')
+          if [ -z "$TODO" ]; then
+            echo "Nothing newer than the latest humanized release — skipping."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
-            echo "$NEWEST not yet humanized — proceeding."
+            echo "To humanize (newer than latest in changelog.json): $TODO"
             echo "skip=false" >> "$GITHUB_OUTPUT"
-            echo "newest=$NEWEST" >> "$GITHUB_OUTPUT"
+            # newest-first list → first element is the high-water version for the commit msg
+            echo "newest=${TODO%%,*}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Check for existing rolling PR
@@ -148,12 +159,19 @@ jobs:
           {
             echo 'CHANGELOG_PROMPT<<PROMPT_EOF'
             cat .github/prompts/changelog-humanize.md
+            echo ''
+            echo 'The pending-releases JSON (newest-first array of { version, date, notes }) is at:'
+            echo '${{ steps.precheck.outputs.releases_file }}'
             echo 'PROMPT_EOF'
           } >> "$GITHUB_ENV"
 
       - name: Run Claude changelog humanizer
         if: steps.precheck.outputs.skip != 'true'
-        uses: anthropics/claude-code-action@v1
+        # This workflow is `workflow_run`-triggered, which the action DOES accept
+        # (unlike docs-sync's `push`, which the action rejects → that one uses the
+        # CLI). Pinned to v1.0.140 — earlier versions threw a tsconfig "directory
+        # mismatch" on the runner. Dependabot bumps the pin as releases ship.
+        uses: anthropics/claude-code-action@fbda2eb1bdc90d319b8d853f5deb53bca199a7c1 # v1.0.140
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: --model claude-sonnet-4-6

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -61,16 +61,39 @@ jobs:
       - name: Skip if commit is cosmetic (Conventional Commits filter)
         id: filter
         if: github.event_name == 'push'
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          SUBJECT=$(git log -1 --format=%s)
-          echo "Commit subject: $SUBJECT"
-          # Skip prefixes that are unlikely to need doc updates.
-          # Matches both bare (chore:) and scoped (chore(deps):) forms.
-          if echo "$SUBJECT" | grep -qE '^(chore|test|style|ci|build|refactor|docs|perf)(\([^)]+\))?!?:'; then
-            echo "Cosmetic / non-feature commit — skipping docs sync."
+          # Inspect exactly the commits THIS push introduced — not `git log -1`,
+          # which reads main's tip at checkout time. With back-to-back merges the
+          # checkout (ref: main) lands on an *advanced* HEAD, so `git log -1`
+          # would judge a later commit than the one that triggered this run. A
+          # cosmetic tip (e.g. a chore release commit) then masked an earlier
+          # feat/fix in the same burst, silently skipping its doc updates.
+          #
+          # Resolve the push range from the event payload instead. Fall back to
+          # the single triggering commit for a new branch (before == zeros) or an
+          # unreachable base (e.g. force-push).
+          ZERO="0000000000000000000000000000000000000000"
+          if [ -n "${BEFORE_SHA:-}" ] && [ "$BEFORE_SHA" != "$ZERO" ] && git cat-file -e "${BEFORE_SHA}^{commit}" 2>/dev/null; then
+            RANGE="${BEFORE_SHA}..${HEAD_SHA}"
+          else
+            RANGE="${HEAD_SHA}~1..${HEAD_SHA}"
+          fi
+          echo "Inspecting pushed commits in range: $RANGE"
+          SUBJECTS=$(git log --format=%s "$RANGE")
+          echo "$SUBJECTS"
+          # Skip ONLY if every commit in the push is cosmetic. Any feat/fix/etc.
+          # in the burst keeps the run alive. Matches bare (chore:) and scoped
+          # (chore(deps):) forms.
+          NON_COSMETIC=$(echo "$SUBJECTS" | grep -vE '^(chore|test|style|ci|build|refactor|docs|perf)(\([^)]+\))?!?:' || true)
+          if [ -z "$NON_COSMETIC" ]; then
+            echo "All pushed commits are cosmetic / non-feature — skipping docs sync."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
+            echo "Non-cosmetic commit(s) present — running docs sync."
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
@@ -97,16 +120,21 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          if [ "${{ steps.existing.outputs.exists }}" = "true" ]; then
-            git fetch origin docs-sync/auto
-            git checkout docs-sync/auto
+          # Reuse the rolling branch whenever it exists on the remote — not just
+          # when an open PR points at it. The branch can outlive its PR (closed
+          # without deletion, or a squash/rebase merge that leaves it behind), and
+          # blindly recreating it makes the later push a non-fast-forward that
+          # fails the job. Probe the remote branch directly, independent of PR state.
+          if git ls-remote --exit-code --heads origin docs-sync/auto >/dev/null 2>&1; then
+            git fetch origin docs-sync/auto:refs/remotes/origin/docs-sync/auto
+            git checkout -B docs-sync/auto origin/docs-sync/auto
             if ! git rebase origin/main; then
               git rebase --abort
               echo "::error::Rebase of docs-sync/auto onto main failed. Resolve manually on the PR, then re-run."
               exit 1
             fi
           else
-            git checkout -b docs-sync/auto
+            git checkout -b docs-sync/auto origin/main
           fi
 
       - name: Load command prompt
@@ -122,14 +150,37 @@ jobs:
             echo 'PROMPT_EOF'
           } >> "$GITHUB_ENV"
 
+      - name: Set up Node
+        if: steps.filter.outputs.skip != 'true'
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+
+      - name: Install Claude Code CLI
+        if: steps.filter.outputs.skip != 'true'
+        run: npm install -g @anthropic-ai/claude-code
+
       - name: Run Claude docs-quick-update --ci
         if: steps.filter.outputs.skip != 'true'
-        # Pinned to v1.0.133. Dependabot will bump as new releases ship.
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: --model claude-sonnet-4-6
-          prompt: ${{ env.DOCS_PROMPT }}
+        # Headless Claude Code CLI — NOT anthropics/claude-code-action.
+        # The action rejects `push` events ("Unsupported event type: push"),
+        # but this workflow is push-triggered, so the action can never run here.
+        # `claude -p` (print mode) has no event-type restriction. Auth reuses the
+        # existing CLAUDE_CODE_OAUTH_TOKEN secret via env var (no interactive login).
+        # --dangerously-skip-permissions: the prompt is first-party (committed in
+        # .github/prompts/) and the runner is ephemeral — same trust level the
+        # action operated at. Do not swap back to the action; it cannot accept push.
+        #
+        # The prompt is piped via stdin, NOT passed as a positional arg: it begins
+        # with the prompt file's `---` YAML frontmatter, which the CLI's option
+        # parser would reject as `unknown option '---'`. stdin sidesteps option
+        # parsing entirely (the documented headless pattern for large prompts).
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          printf '%s' "$DOCS_PROMPT" | claude -p \
+            --model claude-sonnet-4-6 \
+            --dangerously-skip-permissions
 
       - name: Commit and push doc updates
         if: steps.filter.outputs.skip != 'true'
@@ -144,7 +195,11 @@ jobs:
 
           git add -A
           git commit -m "docs: sync with code changes through ${GITHUB_SHA:0:7}"
-          git push origin docs-sync/auto
+          # Rebasing onto main rewrites the branch's commit SHAs, so the push is a
+          # non-fast-forward by design. --force-with-lease lands it while still
+          # refusing to clobber any commit pushed to the branch since our fetch
+          # (e.g. a human editing the rolling PR), failing safely instead.
+          git push --force-with-lease origin docs-sync/auto
           echo "changed=true" >> "$GITHUB_OUTPUT"
 
       - name: Open rolling PR if new

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,17 @@
 name: Release
 
 # Triggered directly on push to main (was chained off the CI workflow via
-# `workflow_run`). CI no longer needs to gate the release: branch protection is
-# `strict` (branches must be up to date before merge), so the PR already
-# validated the exact merge result — re-running CI just to gate the release was
-# redundant. semantic-release no-ops when a push has no releasable commits, so
-# firing on every main push is safe. Releases are tag-only (no commit back to
-# main), so this never re-triggers itself.
+# `workflow_run`). CI does not gate the release, and it doesn't need to:
+# semantic-release only tags + publishes a GitHub Release — it never deploys and
+# never commits back to main, so a release built on an un-tested commit has no
+# runtime blast radius (Vercel runs its own build on merge; the required `CI Gate`
+# check already passed on the PR head). NOTE: branch protection is currently
+# `strict: false`, so a PR can merge without being up to date with main — CI
+# validated the PR head, not necessarily the exact merge result. Enable strict
+# mode if you want that guarantee; the release path itself stays safe either way.
+# semantic-release no-ops when a push has no releasable commits, so firing on
+# every main push is safe. Releases are tag-only (no commit back to main), so
+# this never re-triggers itself.
 on:
   push:
     branches:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,7 @@ Layer boundary and rationale: [docs/testing-strategy.md](docs/testing-strategy.m
 ## Commits & CI
 
 - **Remote `main` is protected** — always branch, then PR. Run `pnpm lint && pnpm check-types && pnpm test && pnpm build` locally before pushing (faster feedback than CI).
-- **Conventional Commits**, one-line, no "Co-Authored-By". semantic-release bumps version from commit type (`feat:`→minor, `fix:`→patch, `feat!:`→major) and writes `docs/CHANGELOG.md`.
+- **Conventional Commits**, one-line, no "Co-Authored-By". semantic-release bumps version from commit type (`feat:`→minor, `fix:`→patch, `feat!:`→major), tags, and publishes the release notes to the **GitHub Release page** (config: `commit-analyzer` + `release-notes-generator` + `@semantic-release/github`). It does **not** write a `docs/CHANGELOG.md` file — there's no `@semantic-release/changelog`/`git` plugin (releases are tag-only, no commit-back to main).
 - Quality gates: ESLint · TypeScript · Vitest · Build · Playwright E2E. Preview deploy on PRs, production on merge. Required secrets + details: [docs/ci-cd-pipeline.md](docs/ci-cd-pipeline.md).
 
 ## Deployment & QA skills

--- a/docs/changelog.json
+++ b/docs/changelog.json
@@ -1,6 +1,13 @@
 {
   "versions": [
     {
+      "version": "3.28.0",
+      "date": "2026-07-02",
+      "summary": "Automated changelog starts here — releases before this point predate the humanizer and are intentionally not backfilled. This entry is the high-water mark that keeps changelog-sync dormant until the next release; downstream forks reset it via /init-downstream.",
+      "highlights": [],
+      "underTheHood": []
+    },
+    {
       "version": "1.0.0",
       "date": "2026-01-01",
       "summary": "The first release of your product.",

--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -7,14 +7,17 @@ and the automation that keeps the JSON up to date.
 ## Data flow
 
 ```
-release-generated changelog source  →  AI humanizer  →  docs/changelog.json  →  /changelog page
-        (docs/CHANGELOG.md)            (claude-code-action)                       (server component)
+GitHub Releases API  →  AI humanizer  →  docs/changelog.json  →  /changelog page
+  (release notes)       (claude-code-action)                      (server component)
 ```
 
-1. semantic-release produces a developer-facing `docs/CHANGELOG.md` (commits
-   grouped under Features / Bug Fixes / Performance) — see the prerequisite below.
-2. The `Changelog Sync` workflow runs the humanizer prompt against that file and
-   writes user-facing entries to `docs/changelog.json`.
+1. semantic-release publishes a **GitHub Release** per version (release notes with
+   commits grouped under Features / Bug Fixes / Performance). Releases are the
+   source of truth — the config is tag-only (no `@semantic-release/git`), so there
+   is **no** `docs/CHANGELOG.md` file.
+2. The `Changelog Sync` workflow reads the Releases API, selects every version
+   newer than the newest already in `docs/changelog.json`, and runs the humanizer
+   prompt against those release notes to write user-facing entries.
 3. The `/changelog` page (`src/app/[locale]/(unauth)/(marketing)/changelog/page.tsx`)
    `fs`-reads `docs/changelog.json` at build/request time and renders one card per
    version with tag badges, highlights, and a collapsible "Under the hood" list.
@@ -69,25 +72,24 @@ operation.
 
 ### Prerequisites
 
-The automation is **not turn-key** in a fresh template. Before it does anything:
+The automation reads the GitHub Releases API directly, so it is **turn-key** once
+these are in place (no `@semantic-release/changelog` plugin needed):
 
-1. **A release-maintained source file at `docs/CHANGELOG.md`.** Both the
-   workflow's pre-check (a `grep` for the newest version) and the humanizer prompt
-   read `docs/CHANGELOG.md` as the release source of truth. The template's current
-   `semantic-release` config (`package.json` → `release.plugins`) only creates
-   GitHub Releases — it does **not** generate `docs/CHANGELOG.md`. You must add
-   `@semantic-release/changelog` (with `changelogFile: docs/CHANGELOG.md`) and
-   `@semantic-release/git` to the release config first. **Until that lands, this
-   workflow is dormant-but-correct:** its pre-check finds no `docs/CHANGELOG.md`
-   (or no version in it) and skips, so nothing breaks.
-2. **The `CLAUDE_CODE_OAUTH_TOKEN` repo secret** (the same secret `claude.yml`
+1. **The `CLAUDE_CODE_OAUTH_TOKEN` repo secret** (the same secret `claude.yml`
    already requires).
-3. **"Allow auto-merge" enabled** in repo settings (Settings → General → Pull
+2. **"Allow auto-merge" enabled** in repo settings (Settings → General → Pull
    Requests).
-4. **The workflow must be on the default branch.** `workflow_run` reads the
+3. **The workflow must be on the default branch.** `workflow_run` reads the
    workflow definition from `main`, so `changelog-sync.yml` only activates once
    it is merged to `main`. Use the **Run workflow** dispatch button to test it
    before then.
+4. **A bounded high-water seed in `docs/changelog.json`.** The pre-check humanizes
+   every release *newer* than the newest entry here. With an empty/absent file the
+   first run would humanize the **entire** release history in one job (timeout
+   risk) — so the template seeds a marker entry at its current version to stay
+   dormant until the next release. A fresh fork resets this to `{"versions": []}`
+   via `/init-downstream`, so its changelog-sync starts from the fork's first
+   release.
 
 ### Alternative: a cloud routine
 


### PR DESCRIPTION
Repairs both AI-automation workflows (docs-sync, changelog-sync) by porting the battle-tested patterns **up** from ContentFlow, plus the doc/config corrections needed to make them correct on the template and on forks.

## 1. Docs Sync — was 100% broken (0 PRs ever)

Real `feat`/`fix` commits died at the Claude step with `Unsupported event type: push`; cosmetic commits skipped. Three fixes, all from ContentFlow's production copy:

| Fix | Why |
|---|---|
| Cosmetic filter inspects the real push range (`before..sha`), not `git log -1` | a cosmetic tip commit masked a `feat`/`fix` in the same burst |
| Rolling branch probed via `git ls-remote` + `checkout -B`; push via `--force-with-lease` | branch can outlive its PR; rebase rewrites SHAs → plain push is a guaranteed non-fast-forward |
| **Claude via headless CLI (`claude -p`, prompt over stdin), not `claude-code-action`** | the action rejects `push` events, so the real step could never run |

## 2. Changelog Sync — reworked to read the GitHub Releases API

It depended on `docs/CHANGELOG.md`, which is never written (config is tag-only, no `@semantic-release/changelog`), so it no-op'd forever and `changelog.json` was frozen at the seed. Reworked (ContentFlow's pattern) to:

- Read the **GitHub Releases API** (`gh api .../releases --paginate`) as the source of truth — `{version, date, notes}` per release.
- Humanize only releases **newer** than the newest entry in `docs/changelog.json` (high-water mark) — never backfill the whole history.
- Keeps `claude-code-action` here (this workflow is `workflow_run`-triggered, which the action *does* accept), pinned to `v1.0.140`.
- Prompt (`changelog-humanize.md`) updated to read the pending-releases JSON instead of `CHANGELOG.md`.

### Backfill safety (template + forks)
The template has 66 releases but the seed was `1.0.0` → first run would have tried to humanize ~65 releases in one job (timeout). Fixes:
- **Template:** seed `docs/changelog.json` with a **high-water marker at `3.28.0`** → changelog-sync stays dormant until the next release (verified: `todo=[]`).
- **Forks:** `/init-downstream` now resets `docs/changelog.json` to `{"versions": []}` (it previously reset the phantom `docs/CHANGELOG.md` and left `changelog.json` untouched — which would have pinned forks *above* their own `0.x` releases and skipped them forever).
- `docs/changelog/README.md` updated: data flow, schema, prerequisites (now turn-key, no plugin needed).

## Minor corrections (from the review)
- `release.yml`: comment claimed branch protection is `strict` — it's `strict: false`. Rewritten accurately.
- `CLAUDE.md`: corrected the "semantic-release writes `docs/CHANGELOG.md`" claim (it doesn't).

## Why these diverged
`upstream-sync` flows **template → product**, never product → template. ContentFlow (downstream) discovered/fixed these; they only reach the template via a deliberate contribute-back — this PR. The template's docs-sync was hand-seeded once (06-17) from a partial snapshot and never re-harvested.

## Validation
YAML tab-free + structurally sound; changelog.json valid + matches `ChangelogVersion`; the version-diff node logic unit-checked locally (`todo`/`newest` correct). Runtime behavior of both workflows can only be confirmed by a real push/release to `main` post-merge.