### PR TITLE
ci(claude-review): grant plugin tool permissions so findings actually post

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -68,6 +68,30 @@ jobs:
             actions: read
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: code-review@claude-code-plugins
+          # Grant the code-review plugin the tools it needs to READ the diff and
+          # POST findings. Without these, the SDK runs non-interactively (no human
+          # to approve a permission prompt) so every `gh`/`git` call the plugin
+          # makes to post inline comments is DENIED — the run stays green, posts
+          # nothing, and the only trace is `permission_denials_count` in the raw
+          # JSON result summary. Fix per anthropics/claude-code#32459.
+          # NB: do NOT add `show_full_output: true` here — the denial count is in
+          # the always-printed result summary, and full-transcript streaming would
+          # log every message + tool result (may contain secrets) into Actions logs.
+          settings: |
+            {
+              "permissions": {
+                "allow": [
+                  "Bash(gh:*)",
+                  "Bash(git diff:*)",
+                  "Bash(git log:*)",
+                  "Bash(git show:*)",
+                  "Read",
+                  "Glob",
+                  "Grep",
+                  "mcp__github_inline_comment__create_inline_comment"
+                ]
+              }
+            }
           # `--comment` posts line-level findings live during the session. The
           # plugin's final *summary* rides the session's last result, which the
           # action intermittently drops when the session ends on a TodoWrite tool


### PR DESCRIPTION
## Why

Ports the fix validated in ContentFlow ([thevarun/ContentFlow#470](https://github.com/thevarun/ContentFlow/pull/470)). The `Claude Code Review` job runs green but posts **zero** findings: the code-review plugin runs non-interactively in CI, so the permission prompts for the `gh`/`git` calls it uses to post inline comments are auto-**denied**. The run stays green; the only trace is `permission_denials_count` (18–42/run) in the result summary. Matches [anthropics/claude-code#32459](https://github.com/anthropics/claude-code/issues/32459).

## Change

Adds a `settings:` tool allow-list (`Bash(gh:*)`, `git diff/log/show`, `Read`, `Glob`, `Grep`, inline-comment MCP) so the plugin can read the diff and post.

Deliberately **omits** `show_full_output` — the denial count is in the always-printed result summary, and streaming the full transcript would log messages + tool results (may contain secrets) into Actions logs on every PR run.

## Validation (in ContentFlow)

On a throwaway PR with a planted empty-array/NaN bug: `permission_denials_count` dropped **18–42 → 1** and `claude[bot]` posted an inline finding at the exact line. Note: verifiable only after it lands on the default branch — `claude-code-action` self-skips any PR that modifies its own workflow file.

## Not included (separate issue)

Recent review runs here also **fail** on Dependabot PRs (`non-human actor: dependabot… Add bot to allowed_bots`). Distinct problem; happy to follow up with an `allowed_bots` change if you want Dependabot PRs reviewed.